### PR TITLE
user provisioned custom nodes downloaded into the correct target folder

### DIFF
--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/default.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/default.sh
@@ -86,7 +86,7 @@ function provisioning_get_pip_packages() {
 function provisioning_get_nodes() {
     for repo in "${NODES[@]}"; do
         dir="${repo##*/}"
-        path="${COMFYUI_DIR}custom_nodes/${dir}"
+        path="${COMFYUI_DIR}/custom_nodes/${dir}"
         requirements="${path}/requirements.txt"
         if [[ -d $path ]]; then
             if [[ ${AUTO_UPDATE,,} != "false" ]]; then


### PR DESCRIPTION
in the default provisioning script, the user-configured, custom nodes were getting downloaded into the parent folder, and not getting activated