### PR TITLE
Fix conditions of http/https choice

### DIFF
--- a/portal-aio/caddy_manager/caddy_config_manager.py
+++ b/portal-aio/caddy_manager/caddy_config_manager.py
@@ -73,7 +73,7 @@ def is_port_auth_excluded(external_port):
     return external_port in excluded_ports
 
 def generate_caddyfile(config):
-    if os.environ.get('ENABLE_HTTPS', 'false').lower() != 'true' and wait_for_valid_certs():
+    if os.environ.get('ENABLE_HTTPS', 'false').lower() != 'true' or not wait_for_valid_certs():
         enable_https = False
     else:
         enable_https = True


### PR DESCRIPTION
The HTTPS protocol should be enabled if `ENABLE_HTTPS == "true" AND wait_for_valid_certs() == True`; otherwise, the HTTP protocol should be enabled.

That means the HTTP protocol is enabled if `ENABLE_HTTPS != "true" OR wait_for_valid_certs() != True`.