### PR TITLE
Ensure startup script has the global HF_HOME variable 

### DIFF
--- a/derivatives/pytorch/provisioning_scripts/dia_1.6b.sh
+++ b/derivatives/pytorch/provisioning_scripts/dia_1.6b.sh
@@ -74,6 +74,7 @@ while [ -f "/.provisioning" ]; do
 done
 
 cd ${DATA_DIRECTORY}/dia
+export HF_HOME="${DATA_DIRECTORY}/huggingface"
 export GRADIO_SERVER_NAME=${GRADIO_SERVER_NAME:-127.0.0.1}
 export GRADIO_SERVER_PORT=${GRADIO_SERVER_PORT:-17860}
 


### PR DESCRIPTION
Prevents downloading model twice and delaying startup