### PR TITLE
Set vglrun -nodl when launching pinokio.  Prevents dlopen library errors

### DIFF
--- a/derivatives/linux-desktop/provisioning_scripts/pinokio.sh
+++ b/derivatives/linux-desktop/provisioning_scripts/pinokio.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 mkdir -p "${USER_HOME}/Desktop"
 cd /tmp
 [[ -n ${PINOKIO_VERSION:-} ]] || PINOKIO_VERSION=$(curl -s https://api.github.com/repos/pinokiocomputer/pinokio/releases/latest |jq -r .tag_name)
-VERSION_NUMBER=${PINOKIO_VERSION}
+VERSION_NUMBER=${PINOKIO_VERSION:-3.8.0}
 FILE_NAME="pinokio_${VERSION_NUMBER}_amd64.AppImage"
 wget -O "${FILE_NAME}" "https://github.com/pinokiocomputer/pinokio/releases/download/${VERSION_NUMBER}/Pinokio-${VERSION_NUMBER}.AppImage"
 chmod +x "${FILE_NAME}"
@@ -28,7 +28,7 @@ Version=1.0
 Type=Application
 Name=Pinokio
 Comment=Pinokio Application
-Exec=env HOME=${WORKSPACE} APPDIR=/opt/pinokio /opt/pinokio/AppRun --no-sandbox %U
+Exec=env HOME=${WORKSPACE} APPDIR=/opt/pinokio vglrun -nodl /opt/pinokio/AppRun --no-sandbox %U
 Icon=/opt/pinokio/pinokio.png
 Terminal=false
 Categories=Utility;


### PR DESCRIPTION
The desktop as a whole runs via vglrun.  This can cause problems for CUDA applications whereby they are unable to locate shared libraries.

This breaks some important video generation applications when launched by Pinokio.  We can avoid this by launching Pinokio with `vglrun -nodl`.  PR adds this to the desktop icon.  User can override by either modifying the desktop icon or by launching from a terminal