### PR TITLE
Feat volume support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -241,9 +241,7 @@ RUN \
     git clone https://github.com/nvm-sh/nvm.git /opt/nvm && \
     (cd /opt/nvm/ && git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`) && \
     source /opt/nvm/nvm.sh && \
-    nvm install --lts && \
-    echo "source /opt/nvm/nvm.sh" >> /root/.bashrc && \
-    echo "source /opt/nvm/nvm.sh" >> /home/user/.bashrc
+    nvm install --lts
 
 # Add the 'service portal' web app into this container to avoid needing to specify in onstart.  
 # We will launch each component with supervisor - Not the standalone launch script.
@@ -286,7 +284,9 @@ RUN \
     set -euo pipefail && \
     SYNCTHING_VERSION="$(curl -fsSL "https://api.github.com/repos/syncthing/syncthing/releases/latest" | jq -r '.tag_name' | sed 's/[^0-9\.\-]*//g')" && \
     SYNCTHING_URL="https://github.com/syncthing/syncthing/releases/download/v${SYNCTHING_VERSION}/syncthing-linux-${TARGETARCH}-v${SYNCTHING_VERSION}.tar.gz" && \
-    mkdir /opt/syncthing/ && \
+    mkdir -p /opt/syncthing/config && \
+    chown -R root.user /opt/syncthing && \
+    chmod -R ug+rwX /opt/syncthing && \
     wget -O /opt/syncthing.tar.gz $SYNCTHING_URL && (cd /opt && tar -zxf syncthing.tar.gz -C /opt/syncthing/ --strip-components=1) && rm -f /opt/syncthing.tar.gz
 
 ARG PYTHON_VERSION=3.10
@@ -301,6 +301,11 @@ RUN \
         python${PYTHON_VERSION}-venv \
         python${PYTHON_VERSION}-tk && \
     mkdir -p /venv && \
+    chown 0:1001 /venv && \
+    chmod g+rwxs /venv && \
+    setfacl -R -d -m g:1001:rwX /venv && \
+    setfacl -R -d -m u::rwX /venv && \
+    setfacl -R -d -m o::r-X /venv && \
     # Create a virtual env - This gives us portability without sacrificing any functionality
     python${PYTHON_VERSION} -m venv /venv/main && \
     /venv/main/bin/pip install --no-cache-dir \
@@ -321,6 +326,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/opt/instance-tools/bin:${PATH}
+ENV IMAGE_ID=vastai-base-image
 
 ENTRYPOINT ["/opt/instance-tools/bin/entrypoint.sh"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -285,9 +285,10 @@ RUN \
     SYNCTHING_VERSION="$(curl -fsSL "https://api.github.com/repos/syncthing/syncthing/releases/latest" | jq -r '.tag_name' | sed 's/[^0-9\.\-]*//g')" && \
     SYNCTHING_URL="https://github.com/syncthing/syncthing/releases/download/v${SYNCTHING_VERSION}/syncthing-linux-${TARGETARCH}-v${SYNCTHING_VERSION}.tar.gz" && \
     mkdir -p /opt/syncthing/config && \
+    mkdir -p /opt/syncthing/data && \
+    wget -O /opt/syncthing.tar.gz $SYNCTHING_URL && (cd /opt && tar -zxf syncthing.tar.gz -C /opt/syncthing/ --strip-components=1) && rm -f /opt/syncthing.tar.gz && \
     chown -R root:user /opt/syncthing && \
-    chmod -R ug+rwX /opt/syncthing && \
-    wget -O /opt/syncthing.tar.gz $SYNCTHING_URL && (cd /opt && tar -zxf syncthing.tar.gz -C /opt/syncthing/ --strip-components=1) && rm -f /opt/syncthing.tar.gz
+    chmod -R ug+rwX /opt/syncthing
 
 ARG PYTHON_VERSION=3.10
 ENV PYTHON_VERSION=${PYTHON_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -285,7 +285,7 @@ RUN \
     SYNCTHING_VERSION="$(curl -fsSL "https://api.github.com/repos/syncthing/syncthing/releases/latest" | jq -r '.tag_name' | sed 's/[^0-9\.\-]*//g')" && \
     SYNCTHING_URL="https://github.com/syncthing/syncthing/releases/download/v${SYNCTHING_VERSION}/syncthing-linux-${TARGETARCH}-v${SYNCTHING_VERSION}.tar.gz" && \
     mkdir -p /opt/syncthing/config && \
-    chown -R root.user /opt/syncthing && \
+    chown -R root:user /opt/syncthing && \
     chmod -R ug+rwX /opt/syncthing && \
     wget -O /opt/syncthing.tar.gz $SYNCTHING_URL && (cd /opt && tar -zxf syncthing.tar.gz -C /opt/syncthing/ --strip-components=1) && rm -f /opt/syncthing.tar.gz
 

--- a/ROOT/opt/supervisor-scripts/syncthing.sh
+++ b/ROOT/opt/supervisor-scripts/syncthing.sh
@@ -19,7 +19,7 @@ fi
 
 # Keep the per-machine settings out of /home/user in case of volume syncing /home
 export STCONFDIR=${STCONFDIR:-/opt/syncthing/config}
-export STDATADIR=${STCONFDIR:-/opt/syncthing/config}
+export STDATADIR=${STDATADIR:-/opt/syncthing/data}
 
 # We run this as user (uid 1001) because Syncthing displays security warnings if run as root
 run_syncthing() {

--- a/ROOT/opt/supervisor-scripts/syncthing.sh
+++ b/ROOT/opt/supervisor-scripts/syncthing.sh
@@ -17,6 +17,10 @@ if ! grep -qiE "^[^#].*${search_pattern}" /etc/portal.yaml; then
     exit 0
 fi
 
+# Keep the per-machine settings out of /home/user in case of volume syncing /home
+export STCONFDIR=${STCONFDIR:-/opt/syncthing/config}
+export STDATADIR=${STCONFDIR:-/opt/syncthing/config}
+
 # We run this as user (uid 1001) because Syncthing displays security warnings if run as root
 run_syncthing() {
     API_KEY=${OPEN_BUTTON_TOKEN:-$(openssl rand -hex 16)}


### PR DESCRIPTION
With QA

Introduces ability to move python venv (generally /venv/main) to a volume if mounted on $WORKSPACE

opt in/out

`--no-sync-pyenv`
`--force-sync-pyenv`

When enabled, the original venv will be moved and replaced with a symlink.  Paths will be updated.  PS1 will show `(vol->main)`

Useful where user wants to easily maintain the state of multiple instances with a single source of truth for both application files and python modules.

This change is only effective when the volume is on the workspace directory.  Original behaviour will be maintained if using volumes at any other mountpoint.

Allow syncing /home to `$WORKSPACE/home` if user passes `--sync-home` to the `entrypoint.sh`

opt-in to move /home directory to $WORKSPACE - most useful when using the desktop variants to save/share files between instances. 

Small fixes applied to ensure that the user sources the correct files on terminal login and that the correct env is made available to SSH, Jupyter Terminal, supervisord)