### PR TITLE
Missing "/" in custom_nodes path in ComfyUI provisioning script

### DIFF
--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/default.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/default.sh
@@ -86,7 +86,7 @@ function provisioning_get_pip_packages() {
 function provisioning_get_nodes() {
     for repo in "${NODES[@]}"; do
         dir="${repo##*/}"
-        path="${COMFYUI_DIR}custom_nodes/${dir}"
+        path="${COMFYUI_DIR}/custom_nodes/${dir}"
         requirements="${path}/requirements.txt"
         if [[ -d $path ]]; then
             if [[ ${AUTO_UPDATE,,} != "false" ]]; then


### PR DESCRIPTION
Fixed missing slash in custom_nodes path. Custom nodes now install correctly