### PR TITLE
Comfyui serverless init

### DIFF
--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
@@ -18,6 +18,8 @@ if [[ "$available_space" -lt 512 ]]; then
         cutoff=$(awk "BEGIN {printf \"%.0f\", ${oldest}+86400}")
         # Only delete files
         find "${output_dir}" -mindepth 1 -type f ! -newermt "@${cutoff}" -delete
+        # Delete broken symlinks
+        find "${output_dir}" -mindepth 1 -xtype l -delete
         # Now delete *empty* directories separately
         find "${output_dir}" -mindepth 1 -type d -empty -delete
     fi

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eou pipefail
+set -euo pipefail
 
 main() {
     set_cleanup_job

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
@@ -11,8 +11,9 @@ set_cleanup_job() {
         cat > /opt/instance-tools/bin/clean-output.sh << 'CLEAN_OUTPUT'
 #!/bin/bash
 output_dir="${WORKSPACE:-/workspace}/ComfyUI/output/"
+min_free_mb=512
 available_space=$(df -m "${output_dir}" | awk 'NR==2 {print $4}')
-if [[ "$available_space" -lt 512 ]]; then
+if [[ "$available_space" -lt "$min_free_mb" ]]; then
     oldest=$(find "${output_dir}" -mindepth 1 -type f -printf "%T@\n" 2>/dev/null | sort -n | head -1 | awk '{printf "%.0f", $1}')
     if [[ -n "$oldest" ]]; then
         cutoff=$(awk "BEGIN {printf \"%.0f\", ${oldest}+86400}")

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eou pipefail
+
+main() {
+    set_cleanup_job
+}
+
+# Add a cron job to remove older (oldest +24 hours) output files if disk space is low
+set_cleanup_job() {
+    if [[ ! -f /opt/instance-tools/bin/clean-output.sh ]]; then
+        cat > /opt/instance-tools/bin/clean-output.sh << 'CLEAN_OUTPUT'
+#!/bin/bash
+output_dir="${WORKSPACE:-/workspace}/ComfyUI/output/"
+available_space=$(df -m "${output_dir}" | awk 'NR==2 {print $4}')
+if [[ "$available_space" -lt 512 ]]; then
+    oldest=$(find "${output_dir}" -mindepth 1 -type f -printf "%T@\n" 2>/dev/null | sort -n | head -1 | awk '{printf "%.0f", $1}')
+    if [[ -n "$oldest" ]]; then
+        cutoff=$(awk "BEGIN {printf \"%.0f\", ${oldest}+86400}")
+        # Only delete files
+        find "${output_dir}" -mindepth 1 -type f ! -newermt "@${cutoff}" -delete
+        # Now delete *empty* directories separately
+        find "${output_dir}" -mindepth 1 -type d -empty -delete
+    fi
+fi
+CLEAN_OUTPUT
+        chmod +x /opt/instance-tools/bin/clean-output.sh
+    fi
+
+    if ! crontab -l 2>/dev/null | grep -qF 'clean-output.sh'; then
+        (crontab -l 2>/dev/null; echo '*/10 * * * * /opt/instance-tools/bin/clean-output.sh') | crontab -
+    fi
+}
+
+main


### PR DESCRIPTION
Adds cron job to delete files from the ComfyUI output directory if storage space is <512MB

This will identify the oldest file and then delete that file along with all other files created within 24 hours of the oldest

We will always delete old files first, cleaning up broken symlinks and empty directories.

This is necessary to avoid filling the disk and will only happen in low storage scenarios