### PR TITLE
Fix typo in pipefail (eou to euo)

### DIFF
--- a/derivatives/pytorch/derivatives/fooocus/Dockerfile
+++ b/derivatives/pytorch/derivatives/fooocus/Dockerfile
@@ -14,7 +14,7 @@ COPY ./ROOT /
 ARG FOOOCUS_REF
 
 RUN \
-    set -eou pipefail && \
+    set -euo pipefail && \
     [[ -n "${FOOOCUS_REF}" ]] || { echo "Must specify FOOOCUS_REF" && exit 1; } && \
     . /venv/main/bin/activate && \
     # We have PyTorch pre-installed so we will check at the end of the install that it has not been clobbered

--- a/derivatives/pytorch/provisioning_scripts/dia_1.6b.sh
+++ b/derivatives/pytorch/provisioning_scripts/dia_1.6b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Provisioning should not complete if there is an error. Retry on reboot if it failed
-set -eou pipefail
+set -euo pipefail
 
 # Ensure downloaded models are in the workspace
 export HF_HOME="${DATA_DIRECTORY}/huggingface"

--- a/derivatives/pytorch/provisioning_scripts/fluxgym.sh
+++ b/derivatives/pytorch/provisioning_scripts/fluxgym.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Provisioning should not complete if there is an error. Retry on reboot if it failed
-set -eou pipefail
+set -euo pipefail
 
 # Allow user to fetch alternative repo, branch, tag, commit
 export APP_REPO_URL=${APP_REPO_URL:-https://github.com/cocktailpeanut/fluxgym}

--- a/derivatives/pytorch/provisioning_scripts/open_sora2.0.sh
+++ b/derivatives/pytorch/provisioning_scripts/open_sora2.0.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-set -eou pipefail
+set -euo pipefail
 
 apt-get install -y libaio-dev
 

--- a/provisioning_scripts/ACE-step.sh
+++ b/provisioning_scripts/ACE-step.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 
 . /venv/main/bin/activate
 

--- a/provisioning_scripts/invokeai.sh
+++ b/provisioning_scripts/invokeai.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 
 . /venv/main/bin/activate
 

--- a/provisioning_scripts/ollama.sh
+++ b/provisioning_scripts/ollama.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 
 # Install Ollama if not present
 which ollama > /dev/null 2>&1 || curl -fsSL https://ollama.com/install.sh | sh

--- a/provisioning_scripts/ostris-ai-toolkit.sh
+++ b/provisioning_scripts/ostris-ai-toolkit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 
 . /venv/main/bin/activate
 

--- a/provisioning_scripts/wan2gp.sh
+++ b/provisioning_scripts/wan2gp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 
 . /venv/main/bin/activate
 


### PR DESCRIPTION
eou pipefail is incorrect and will not work as intended.  Use correct order euo pipefail in provisioning scripts