### PR TITLE
Update CUDA version in llama-cpp.sh script

### DIFF
--- a/provisioning_scripts/llama-cpp.sh
+++ b/provisioning_scripts/llama-cpp.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-cuda_ver="${CUDA_VERSION%.*}"
+cuda_ver="12.8"
 
 llama_dir="${WORKSPACE}/llama.cpp"
 llama_ver_dir="${WORKSPACE}/llama.cpp/cuda-${cuda_ver}"


### PR DESCRIPTION
upstream builder is fixed, but now only building for CU128