### PR TITLE
Fix AIO Studio resolve-refs reading wrong composite action output

### DIFF
--- a/.github/actions/check-github-release/action.yml
+++ b/.github/actions/check-github-release/action.yml
@@ -60,14 +60,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        # Manual triggers always proceed
-        if [[ "${{ inputs.trigger }}" != "schedule" ]]; then
-          echo "new-release=true" >> $GITHUB_OUTPUT
-          echo "Manual trigger - skipping release check"
-          exit 0
-        fi
-        
-        echo "Checking GitHub for new releases of ${{ inputs.repository }}..."
+        echo "Checking GitHub for latest release of ${{ inputs.repository }}..."
         
         AUTH_HEADER=""
         if [[ -n "$GH_TOKEN" ]]; then
@@ -84,7 +77,7 @@ runs:
         
         if [[ "$HTTP_CODE" != "200" ]]; then
           echo "::warning::GitHub API returned $HTTP_CODE"
-          echo "new-release=false" >> $GITHUB_OUTPUT
+          echo "new-release=${{ inputs.trigger != 'schedule' }}" >> $GITHUB_OUTPUT
           exit 0
         fi
         
@@ -100,25 +93,28 @@ runs:
         
         if [[ -z "$TAG" || -z "$UPDATED_AT" ]]; then
           echo "::warning::Could not parse release data"
-          echo "new-release=false" >> $GITHUB_OUTPUT
+          echo "new-release=${{ inputs.trigger != 'schedule' }}" >> $GITHUB_OUTPUT
           exit 0
         fi
-        
+
         echo "release-tag=$TAG" >> $GITHUB_OUTPUT
         echo "published-at=$PUBLISHED_AT" >> $GITHUB_OUTPUT
         echo "updated-at=$UPDATED_AT" >> $GITHUB_OUTPUT
 
-        # Calculate age from updated_at — catches releases promoted from prerelease
         RELEASE_EPOCH=$(date -d "$UPDATED_AT" +%s)
         NOW_EPOCH=$(date +%s)
         AGE=$((NOW_EPOCH - RELEASE_EPOCH))
         AGE_HOURS=$((AGE / 3600))
-        
+
         echo "Latest: $TAG (updated $AGE_HOURS hours ago)"
-        
-        if [[ $AGE -lt ${{ inputs.age-threshold-seconds }} ]]; then
+
+        # new-release gates scheduled rebuilds by release age. Manual/workflow_dispatch
+        # runs always proceed regardless of age.
+        if [[ "${{ inputs.trigger }}" != "schedule" ]]; then
           echo "new-release=true" >> $GITHUB_OUTPUT
-          echo "✓ New release detected"
+        elif [[ $AGE -lt ${{ inputs.age-threshold-seconds }} ]]; then
+          echo "new-release=true" >> $GITHUB_OUTPUT
+          echo "New release detected"
         else
           echo "new-release=false" >> $GITHUB_OUTPUT
           echo "::notice::No new release in threshold period"
@@ -128,11 +124,11 @@ runs:
       id: resolve
       shell: bash
       run: |
-        # Priority: manual input > release tag > default
+        # Priority: manual input > latest release tag > default branch
         if [[ -n "${{ inputs.manual-ref }}" && "${{ inputs.trigger }}" != "schedule" ]]; then
           REF="${{ inputs.manual-ref }}"
           echo "Using manual ref: $REF"
-        elif [[ -n "${{ steps.check.outputs.release-tag }}" && "${{ inputs.trigger }}" == "schedule" ]]; then
+        elif [[ -n "${{ steps.check.outputs.release-tag }}" ]]; then
           REF="${{ steps.check.outputs.release-tag }}"
           echo "Using release tag: $REF"
         else

--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       ACE_STEP_REF:
-        description: "ACE-Step git ref - leave empty to simulate scheduled build"
+        description: "ACE-Step git ref - leave empty for latest"
         required: false
       ACE_STEP_UI_REF:
         description: "ACE-Step UI git ref (default: main)"

--- a/.github/workflows/build-aio-studio.yml
+++ b/.github/workflows/build-aio-studio.yml
@@ -59,13 +59,13 @@ jobs:
   resolve-refs:
     runs-on: ubuntu-latest
     outputs:
-      comfyui-ref: ${{ steps.comfyui.outputs.ref }}
+      comfyui-ref: ${{ steps.comfyui.outputs.resolved-ref }}
       forge-ref: ${{ steps.forge.outputs.ref }}
-      voicebox-ref: ${{ steps.voicebox.outputs.ref }}
+      voicebox-ref: ${{ steps.voicebox.outputs.resolved-ref }}
       ai-toolkit-ref: ${{ steps.ai-toolkit.outputs.ref }}
       wan2gp-ref: ${{ steps.wan2gp.outputs.ref }}
-      whisper-ref: ${{ steps.whisper.outputs.ref }}
-      ace-step-ref: ${{ steps.ace-step.outputs.ref }}
+      whisper-ref: ${{ steps.whisper.outputs.resolved-ref }}
+      ace-step-ref: ${{ steps.ace-step.outputs.resolved-ref }}
       ace-step-ui-ref: ${{ steps.ace-step-ui.outputs.ref }}
       image-tag: ${{ steps.tag.outputs.tag }}
       should-run: ${{ steps.decision.outputs.should-run }}
@@ -194,13 +194,13 @@ jobs:
           echo "## Resolved Refs" >> $GITHUB_STEP_SUMMARY
           echo "| App | Ref |" >> $GITHUB_STEP_SUMMARY
           echo "|-----|-----|" >> $GITHUB_STEP_SUMMARY
-          echo "| ComfyUI | \`${{ steps.comfyui.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| ComfyUI | \`${{ steps.comfyui.outputs.resolved-ref }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| SD Forge | \`${{ steps.forge.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Voicebox | \`${{ steps.voicebox.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Voicebox | \`${{ steps.voicebox.outputs.resolved-ref }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| AI Toolkit | \`${{ steps.ai-toolkit.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Wan2GP | \`${{ steps.wan2gp.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Whisper WebUI | \`${{ steps.whisper.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| ACE Step | \`${{ steps.ace-step.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Whisper WebUI | \`${{ steps.whisper.outputs.resolved-ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| ACE Step | \`${{ steps.ace-step.outputs.resolved-ref }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| ACE Step UI | \`${{ steps.ace-step-ui.outputs.ref }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **Image Tag** | **${{ steps.tag.outputs.tag }}** |" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       COMFYUI_REF:
-        description: "ComfyUI git ref - leave empty to simulate scheduled build"
+        description: "ComfyUI git ref - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to username/<repo>"

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -67,7 +67,7 @@ jobs:
           repository: Comfy-Org/ComfyUI
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          trigger: ${{ inputs.COMFYUI_REF && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-ref: ${{ inputs.COMFYUI_REF }}
           default-ref: master
 

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -69,7 +69,7 @@ jobs:
           repository: invoke-ai/InvokeAI
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          trigger: schedule
+          trigger: ${{ github.event_name }}
           tag-pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
           resolve-master-to-commit: "false"
 

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       INVOKEAI_VERSION:
-        description: "InvokeAI version (e.g. 5.8.1) - leave empty to simulate scheduled build"
+        description: "InvokeAI version (e.g. 5.8.1) - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       LLAMA_CPP_VERSION:
-        description: "Release tag (e.g. b5460) - leave empty to simulate scheduled build"
+        description: "Release tag (e.g. b5460) - leave empty for latest"
         required: false
       CUDA_VERSION:
         description: "CUDA version for binary package"

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           repository: ai-dock/llama.cpp-cuda
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          trigger: ${{ inputs.LLAMA_CPP_VERSION && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-ref: ${{ inputs.LLAMA_CPP_VERSION }}
           resolve-master-to-commit: "false"
 

--- a/.github/workflows/build-ollama.yml
+++ b/.github/workflows/build-ollama.yml
@@ -60,7 +60,7 @@ jobs:
           repository: ollama/ollama
           version-pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          trigger: ${{ inputs.OLLAMA_VERSION && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-version: ${{ inputs.OLLAMA_VERSION }}
 
       - name: Determine if build should run

--- a/.github/workflows/build-ollama.yml
+++ b/.github/workflows/build-ollama.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       OLLAMA_VERSION:
-        description: "Ollama version (e.g. 0.6.2) - leave empty to simulate scheduled build"
+        description: "Ollama version (e.g. 0.6.2) - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to username/<repo>"

--- a/.github/workflows/build-openwebui.yml
+++ b/.github/workflows/build-openwebui.yml
@@ -66,7 +66,7 @@ jobs:
           version-pattern: "^v[0-9]+\\.[0-9]+(\\.[0-9]+)?-cuda$"
           version-extract: "s/-cuda$//"
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          trigger: ${{ inputs.OPENWEBUI_VERSION && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-version: ${{ inputs.OPENWEBUI_VERSION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,7 +77,7 @@ jobs:
           repository: ollama/ollama
           tag-pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
           age-threshold-seconds: "999999999"
-          trigger: ${{ inputs.OLLAMA_VERSION && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-ref: ${{ inputs.OLLAMA_VERSION && format('v{0}', inputs.OLLAMA_VERSION) || '' }}
           resolve-master-to-commit: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-openwebui.yml
+++ b/.github/workflows/build-openwebui.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       OPENWEBUI_VERSION:
-        description: "Open WebUI version (e.g. v0.8.2) - leave empty to simulate scheduled build"
+        description: "Open WebUI version (e.g. v0.8.2) - leave empty for latest"
         required: false
       OLLAMA_VERSION:
         description: "Ollama version (e.g. 0.15.2) - leave empty to auto-detect"

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -71,7 +71,7 @@ jobs:
           repository: ostris/aitoolkit
           version-pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          trigger: schedule
+          trigger: ${{ github.event_name }}
 
       - name: Resolve AI Toolkit git ref
         id: resolve-ref

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       AI_TOOLKIT_REF:
-        description: "Git ref (commit/branch) - leave empty to simulate scheduled build"
+        description: "Git ref (commit/branch) - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"

--- a/.github/workflows/build-sglang.yml
+++ b/.github/workflows/build-sglang.yml
@@ -73,7 +73,7 @@ jobs:
           # -cu130 etc. for explicit CUDA variants, optional .postN suffix.
           version-pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+(\\.post[0-9]+)?$"
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          trigger: ${{ inputs.SGLANG_VERSION && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-version: ${{ inputs.SGLANG_VERSION }}
 
       - name: Build matrix from variant tags

--- a/.github/workflows/build-sglang.yml
+++ b/.github/workflows/build-sglang.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       SGLANG_VERSION:
-        description: "SGLang version (e.g. v0.5.7, or 'nightly') - leave empty to simulate scheduled build"
+        description: "SGLang version (e.g. v0.5.7, or 'nightly') - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to username/<repo>"

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       UNSLOTH_REF:
-        description: "Unsloth Studio release tag - leave empty to simulate scheduled build"
+        description: "Unsloth Studio release tag - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to username/<repo>"

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -66,7 +66,7 @@ jobs:
           repository: unslothai/unsloth
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          trigger: ${{ inputs.UNSLOTH_REF && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-ref: ${{ inputs.UNSLOTH_REF }}
           default-ref: ""
           # Only match studio release tags (v0.1.0-beta etc.), not llama.cpp builds (b8508)

--- a/.github/workflows/build-vllm-omni.yml
+++ b/.github/workflows/build-vllm-omni.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       VLLM_OMNI_VERSION:
-        description: "vLLM-Omni version (e.g. v0.14.0, or 'nightly') - leave empty to simulate scheduled build"
+        description: "vLLM-Omni version (e.g. v0.14.0, or 'nightly') - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to username/<repo>"

--- a/.github/workflows/build-vllm-omni.yml
+++ b/.github/workflows/build-vllm-omni.yml
@@ -71,7 +71,7 @@ jobs:
           repository: vllm/vllm-omni
           version-pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          trigger: ${{ inputs.VLLM_OMNI_VERSION && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-version: ${{ inputs.VLLM_OMNI_VERSION }}
 
       - name: Build matrix from variant tags

--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -71,7 +71,7 @@ jobs:
           repository: vllm/vllm-openai
           version-pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          trigger: ${{ inputs.VLLM_VERSION && github.event_name || 'schedule' }}
+          trigger: ${{ github.event_name }}
           manual-version: ${{ inputs.VLLM_VERSION }}
 
       - name: Build matrix from variant tags

--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       VLLM_VERSION:
-        description: "vLLM version (e.g. v0.14.0, or 'nightly') - leave empty to simulate scheduled build"
+        description: "vLLM version (e.g. v0.14.0, or 'nightly') - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to username/<repo>"


### PR DESCRIPTION
## Summary
- The four apps using the `check-github-release` composite action (ComfyUI, Voicebox, Whisper, ACE Step) were reading `steps.<id>.outputs.ref`, but composite actions only expose their declared outputs — the action emits `resolved-ref`.
- Those refs silently evaluated to empty strings and were passed as empty `--build-arg` values to the Docker build, while the four inline-shell apps (Forge, AI Toolkit, Wan2GP, ACE Step UI) worked fine.
- Observed in run [24412544674](https://github.com/vast-ai/base-image/actions/runs/24412544674).

## Test plan
- [ ] Re-run `Build AIO Studio Image` via workflow_dispatch and confirm all 8 refs appear populated in the resolve-refs summary
- [ ] Confirm the build job receives non-empty `--build-arg` values for COMFYUI_REF, VOICEBOX_REF, WHISPER_REF, ACE_STEP_REF