### PR TITLE
Pin libnccl2 to lowest CUDA version in runtime image

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -9,7 +9,6 @@ ARG CUDA_VERSIONS="12-9"
 
 RUN \
     set -euo pipefail && \
-    set -f && \
     [ -n "${CUDA_VERSIONS// }" ] || { echo "CUDA_VERSIONS must not be empty" >&2; exit 1; } && \
     apt-get update && \
     PACKAGES="" && \
@@ -23,6 +22,7 @@ RUN \
         fi; \
     done && \
     PACKAGES="$PACKAGES libnccl2=*+cuda${lowest_dotver}" && \
+    set -f && \
     apt-get install -y --no-install-recommends $PACKAGES && \
     set +f && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -24,6 +24,7 @@ RUN \
     done && \
     PACKAGES="$PACKAGES libnccl2=*+cuda${lowest_dotver}" && \
     apt-get install -y --no-install-recommends $PACKAGES && \
+    set +f && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Defend against environment clashes when syncing to volume

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -9,6 +9,8 @@ ARG CUDA_VERSIONS="12-9"
 
 RUN \
     set -euo pipefail && \
+    set -f && \
+    [ -n "${CUDA_VERSIONS// }" ] || { echo "CUDA_VERSIONS must not be empty" >&2; exit 1; } && \
     apt-get update && \
     PACKAGES="" && \
     lowest_dotver="" && \

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -4,17 +4,24 @@ FROM ${BASE_IMAGE}
 
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Space-separated list of CUDA version suffixes (e.g., "12-9 13-2")
+# Space-separated list of CUDA versions (e.g., "12-9 13-2" or "12.9 13.2")
 ARG CUDA_VERSIONS="12-9"
 
 RUN \
     set -euo pipefail && \
     apt-get update && \
     PACKAGES="" && \
+    lowest_dotver="" && \
     for ver in ${CUDA_VERSIONS}; do \
-        PACKAGES="$PACKAGES cuda-compat-${ver} cuda-nvcc-${ver} cuda-cccl-${ver} cuda-nvrtc-${ver} libnpp-${ver} libnvjpeg-${ver} libcufft-${ver}"; \
+        dashver="${ver//./-}" && \
+        dotver="${ver//-/.}" && \
+        PACKAGES="$PACKAGES cuda-compat-${dashver} cuda-nvcc-${dashver} cuda-cccl-${dashver} cuda-nvrtc-${dashver} libnpp-${dashver} libnvjpeg-${dashver} libcufft-${dashver}" && \
+        if [ -z "$lowest_dotver" ] || [ "$(printf '%s\n%s\n' "$dotver" "$lowest_dotver" | sort -V | head -n1)" = "$dotver" ]; then \
+            lowest_dotver="$dotver"; \
+        fi; \
     done && \
-    apt-get install -y --no-install-recommends $PACKAGES libnccl2 && \
+    PACKAGES="$PACKAGES libnccl2=*+cuda${lowest_dotver}" && \
+    apt-get install -y --no-install-recommends $PACKAGES && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Defend against environment clashes when syncing to volume


### PR DESCRIPTION
## Summary
- libnccl2 was installed unpinned in Dockerfile.runtime, so apt could pull a build tagged against a CUDA release not present in the image.
- Pin it to `libnccl2=*+cuda<ver>`, selecting the lowest CUDA version from `CUDA_VERSIONS` so the single `libnccl2` slot is compatible with every installed toolkit.
- Normalize `CUDA_VERSIONS` entries so either `12-9` or `12.9` input works, via `dashver`/`dotver` locals in the loop.

## Test plan
- [ ] Build with default `CUDA_VERSIONS=12-9` and confirm `libnccl2` resolves to `*+cuda12.9`.
- [ ] Build with `CUDA_VERSIONS="12-9 13-2"` and confirm the pin uses `cuda12.9` (the lowest).
- [ ] Build with dot-form input `CUDA_VERSIONS="12.9"` and confirm apt package names still resolve.