### PR TITLE
Harden extend/promote workflows and wire in multi-torch

### DIFF
--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -162,7 +162,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-03-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-04-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-aio-studio-base.yml
+++ b/.github/workflows/build-aio-studio-base.yml
@@ -15,7 +15,7 @@ on:
       PYTORCH_BASE:
         description: "Multi-torch base image"
         required: true
-        default: "vastai/pytorch:multi-210-291-271-cu128"
+        default: "vastai/pytorch:multi-210-291-271-2026-04-15"
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
         required: true

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -94,8 +94,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-03-26
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-03-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-04-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-03-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-linux-desktop.yml
+++ b/.github/workflows/build-linux-desktop.yml
@@ -71,8 +71,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-03-26
-          - vastai/base-image:cuda-12.9-mini-py312-2026-03-26
+          - vastai/base-image:cuda-13.2-mini-py312-2026-04-15
+          - vastai/base-image:cuda-12.9-mini-py312-2026-04-15
           - vastai/base-image:stock-ubuntu24.04-py312-2026-03-26
 
     steps:

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-12.9-mini-py312-2026-03-26
+          - vastai/base-image:cuda-12.9-mini-py312-2026-04-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-03-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-pytorch.yml
+++ b/.github/workflows/build-pytorch.yml
@@ -173,6 +173,20 @@ jobs:
             done
           done
 
+          # Pre-pass: collect the (torch_ver, torch_backend) pairs
+          # required by any in-scope multi config. build-multi layers
+          # over a freshly-built mini, so the primary mini MUST be in
+          # the mini matrices even if FILTER wouldn't normally match
+          # it (e.g. FILTER=multi excludes every mini by substring).
+          REQUIRED_MINI_PAIRS="|"
+          for multi_config in "${ALL_MULTI_CONFIGS[@]}"; do
+            IFS='|' read -r mkey primary_torch primary_backend mcuda_minor marches mpython_versions <<< "$multi_config"
+            if [[ -n "$FILTER" && "$mkey" != *"$FILTER"* && "$primary_torch" != *"$FILTER"* && "multi" != *"$FILTER"* && "mini" != *"$FILTER"* ]]; then
+              continue
+            fi
+            REQUIRED_MINI_PAIRS="${REQUIRED_MINI_PAIRS}${primary_torch}:${primary_backend}|"
+          done
+
           # Mini configs
           MINI_BUILD_MATRIX="[]"
           MINI_MERGE_MATRIX="[]"
@@ -180,7 +194,15 @@ jobs:
           for mini_config in "${ALL_MINI_CONFIGS[@]}"; do
             IFS='|' read -r torch_ver key mini_base_tag torch_backend arches python_versions <<< "$mini_config"
 
+            filter_match=true
             if [[ -n "$FILTER" && "$torch_ver" != *"$FILTER"* && "$key" != *"$FILTER"* && "mini" != *"$FILTER"* ]]; then
+              filter_match=false
+            fi
+            required_match=false
+            if [[ "$REQUIRED_MINI_PAIRS" == *"|${torch_ver}:${torch_backend}|"* ]]; then
+              required_match=true
+            fi
+            if [[ "$filter_match" == "false" && "$required_match" == "false" ]]; then
               continue
             fi
 

--- a/.github/workflows/build-pytorch.yml
+++ b/.github/workflows/build-pytorch.yml
@@ -63,6 +63,9 @@ jobs:
       mini-build-matrix: ${{ steps.matrix.outputs.mini-build-matrix }}
       mini-merge-matrix: ${{ steps.matrix.outputs.mini-merge-matrix }}
       has-mini: ${{ steps.matrix.outputs.has-mini }}
+      multi-build-matrix: ${{ steps.matrix.outputs.multi-build-matrix }}
+      multi-merge-matrix: ${{ steps.matrix.outputs.multi-merge-matrix }}
+      has-multi: ${{ steps.matrix.outputs.has-multi }}
       build-date: ${{ steps.matrix.outputs.build-date }}
     steps:
       - name: Generate matrices
@@ -99,6 +102,15 @@ jobs:
             "2.11.0|cu126|12.6.3-cudnn-devel|cu126|linux/amd64|310 311 312"
             "2.11.0|cu128|12.8.1-cudnn-devel|cu128|linux/amd64,linux/arm64|310 311 312 313 314"
             "2.11.0|cu130|13.0.2-cudnn-devel|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
+          )
+
+          # Multi-torch configs: a primary mini pytorch image with
+          # additional torch venvs layered in. Each produces
+          #   ${NS}/pytorch:${key}-py${py}-${date}-${arch}
+          # and is later merged into a multi-arch manifest.
+          # Format: key|primary_torch|primary_backend|cuda_minor|arches|python_versions
+          ALL_MULTI_CONFIGS=(
+            "multi-210-291-271|2.10.0|cu128|12.9|linux/amd64,linux/arm64|312"
           )
 
           # Mini format: torch_ver|key|mini_base_tag|torch_backend|arches|python_versions
@@ -207,6 +219,48 @@ jobs:
             echo "has-mini=false" >> $GITHUB_OUTPUT
           fi
 
+          # Multi-torch configs
+          MULTI_BUILD_MATRIX="[]"
+          MULTI_MERGE_MATRIX="[]"
+
+          for multi_config in "${ALL_MULTI_CONFIGS[@]}"; do
+            IFS='|' read -r key primary_torch primary_backend cuda_minor arches python_versions <<< "$multi_config"
+
+            # FILTER=mini also includes multi since multi layers on mini.
+            if [[ -n "$FILTER" && "$key" != *"$FILTER"* && "$primary_torch" != *"$FILTER"* && "multi" != *"$FILTER"* && "mini" != *"$FILTER"* ]]; then
+              continue
+            fi
+
+            MULTI_MERGE_MATRIX=$(echo "$MULTI_MERGE_MATRIX" | jq -c \
+              --arg key "$key" \
+              --arg primary_torch "$primary_torch" \
+              --arg primary_backend "$primary_backend" \
+              --arg cuda_minor "$cuda_minor" \
+              --arg arches "$arches" \
+              --arg python_versions "$python_versions" \
+              '. + [{"config_key": $key, "primary_torch": $primary_torch, "primary_backend": $primary_backend, "cuda_minor": $cuda_minor, "arches": $arches, "python_versions": $python_versions}]')
+
+            IFS=',' read -ra ARCH_LIST <<< "$arches"
+            for arch in "${ARCH_LIST[@]}"; do
+              arch_suffix="${arch#linux/}"
+              MULTI_BUILD_MATRIX=$(echo "$MULTI_BUILD_MATRIX" | jq -c \
+                --arg key "$key" \
+                --arg primary_torch "$primary_torch" \
+                --arg primary_backend "$primary_backend" \
+                --arg cuda_minor "$cuda_minor" \
+                --arg arch "$arch" \
+                --arg arch_suffix "$arch_suffix" \
+                --arg python_versions "$python_versions" \
+                '. + [{"config_key": $key, "primary_torch": $primary_torch, "primary_backend": $primary_backend, "cuda_minor": $cuda_minor, "arch": $arch, "arch_suffix": $arch_suffix, "python_versions": $python_versions}]')
+            done
+          done
+
+          if [[ $(echo "$MULTI_BUILD_MATRIX" | jq length) -gt 0 ]]; then
+            echo "has-multi=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-multi=false" >> $GITHUB_OUTPUT
+          fi
+
           # Output matrices
           {
             echo "build-matrix<<BUILD_MATRIX_EOF"
@@ -227,6 +281,16 @@ jobs:
             echo "mini-merge-matrix<<MINI_MERGE_MATRIX_EOF"
             echo "{\"include\":${MINI_MERGE_MATRIX}}"
             echo "MINI_MERGE_MATRIX_EOF"
+          } >> $GITHUB_OUTPUT
+          {
+            echo "multi-build-matrix<<MULTI_BUILD_MATRIX_EOF"
+            echo "{\"include\":${MULTI_BUILD_MATRIX}}"
+            echo "MULTI_BUILD_MATRIX_EOF"
+          } >> $GITHUB_OUTPUT
+          {
+            echo "multi-merge-matrix<<MULTI_MERGE_MATRIX_EOF"
+            echo "{\"include\":${MULTI_MERGE_MATRIX}}"
+            echo "MULTI_MERGE_MATRIX_EOF"
           } >> $GITHUB_OUTPUT
 
           echo "Build matrix entries: $(echo "$BUILD_MATRIX" | jq length)"
@@ -513,8 +577,132 @@ jobs:
           path: built-tags/
           retention-days: 1
 
+  build-multi:
+    needs: [generate-matrix, merge-mini-manifests]
+    if: ${{ needs.generate-matrix.outputs.has-multi == 'true' && !inputs.DRY_RUN }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.multi-build-matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: ./.github/actions/maximize-build-space
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build multi-torch variants
+        env:
+          NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          CONFIG_KEY: ${{ matrix.config_key }}
+          PRIMARY_TORCH: ${{ matrix.primary_torch }}
+          PRIMARY_BACKEND: ${{ matrix.primary_backend }}
+          CUDA_MINOR: ${{ matrix.cuda_minor }}
+          ARCH: ${{ matrix.arch }}
+          ARCH_SUFFIX: ${{ matrix.arch_suffix }}
+          PYTHON_VERSIONS: ${{ matrix.python_versions }}
+          BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/built-tags"
+          cd derivatives/pytorch
+
+          for py_tag in ${PYTHON_VERSIONS}; do
+            # Layer on top of the freshly-built mini from this run
+            BASE="${NAMESPACE}/pytorch:${PRIMARY_TORCH}-${PRIMARY_BACKEND}-cuda-${CUDA_MINOR}-mini-py${py_tag}-${BUILD_DATE}"
+            TAG="${NAMESPACE}/pytorch:${CONFIG_KEY}-py${py_tag}-${BUILD_DATE}-${ARCH_SUFFIX}"
+
+            echo "=== Building multi-torch: ${CONFIG_KEY} py${py_tag} for ${ARCH} ==="
+            echo "    Base: ${BASE}"
+            docker buildx build \
+              --progress=plain \
+              --platform "${ARCH}" \
+              -f Dockerfile.multi-torch \
+              --build-arg PYTORCH_BASE="${BASE}" \
+              --build-arg PYTORCH_BACKEND="${PRIMARY_BACKEND}" \
+              --tag "${TAG}" \
+              --push .
+
+            echo "$TAG" >> "$GITHUB_WORKSPACE/built-tags/tags.txt"
+          done
+
+      - name: Upload multi tags
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-tags-${{ matrix.config_key }}-${{ matrix.arch_suffix }}
+          path: built-tags/
+          retention-days: 1
+
+  merge-multi-manifests:
+    needs: [generate-matrix, build-multi]
+    if: ${{ needs.generate-matrix.outputs.has-multi == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.multi-merge-matrix) }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Merge multi-torch manifests
+        env:
+          NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          CONFIG_KEY: ${{ matrix.config_key }}
+          ARCHES: ${{ matrix.arches }}
+          PYTHON_VERSIONS: ${{ matrix.python_versions }}
+          BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
+        run: |
+          mkdir -p built-tags
+
+          IFS=',' read -ra ARCH_LIST <<< "$ARCHES"
+
+          for py_tag in ${PYTHON_VERSIONS}; do
+            FINAL_TAG="${NAMESPACE}/pytorch:${CONFIG_KEY}-py${py_tag}-${BUILD_DATE}"
+            AMD64_TAG="${FINAL_TAG}-amd64"
+
+            echo "=== Merging multi manifest: ${FINAL_TAG} ==="
+            if [[ ${#ARCH_LIST[@]} -gt 1 ]]; then
+              ARM64_TAG="${FINAL_TAG}-arm64"
+              docker buildx imagetools create \
+                -t "${FINAL_TAG}" \
+                "${AMD64_TAG}" "${ARM64_TAG}"
+            else
+              docker buildx imagetools create \
+                -t "${FINAL_TAG}" \
+                "${AMD64_TAG}"
+            fi
+
+            echo "$FINAL_TAG" >> built-tags/tags.txt
+          done
+
+      - name: Upload multi manifest tags
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-manifest-tags-${{ matrix.config_key }}
+          path: built-tags/
+          retention-days: 1
+
   collect-tags:
-    needs: [generate-matrix, build, merge-manifests, build-mini, merge-mini-manifests]
+    needs: [generate-matrix, build, merge-manifests, build-mini, merge-mini-manifests, build-multi, merge-multi-manifests]
     if: always() && !inputs.DRY_RUN
     runs-on: ubuntu-latest
     outputs:
@@ -523,7 +711,7 @@ jobs:
       - name: Download all tag artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "{built-tags-*,manifest-tags-*,mini-tags-*,mini-manifest-tags-*}"
+          pattern: "{built-tags-*,manifest-tags-*,mini-tags-*,mini-manifest-tags-*,multi-tags-*,multi-manifest-tags-*}"
           path: all-tags/
 
       - name: Aggregate tags
@@ -553,6 +741,8 @@ jobs:
           MERGE_MATRIX: ${{ needs.generate-matrix.outputs.merge-matrix }}
           MINI_BUILD_MATRIX: ${{ needs.generate-matrix.outputs.mini-build-matrix }}
           HAS_MINI: ${{ needs.generate-matrix.outputs.has-mini }}
+          MULTI_BUILD_MATRIX: ${{ needs.generate-matrix.outputs.multi-build-matrix }}
+          HAS_MULTI: ${{ needs.generate-matrix.outputs.has-multi }}
           BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
           BASE_DATE: ${{ inputs.BASE_DATE }}
           NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
@@ -622,8 +812,31 @@ jobs:
             done
           fi
 
+          if [[ "$HAS_MULTI" == "true" ]]; then
+            echo ""
+            MULTI_COUNT=$(echo "$MULTI_BUILD_MATRIX" | jq '[.include[] | select(.arch_suffix == "amd64")] | length')
+            echo "=== Multi-torch Builds (${MULTI_COUNT} configs) ==="
+            for ((i=0; i<$(echo "$MULTI_BUILD_MATRIX" | jq '.include | length'); i++)); do
+              arch_suffix=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].arch_suffix")
+              [[ "$arch_suffix" != "amd64" ]] && continue
+
+              key=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].config_key")
+              primary_torch=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].primary_torch")
+              primary_backend=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].primary_backend")
+              cuda_minor=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].cuda_minor")
+              python_versions=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].python_versions")
+
+              echo ""
+              echo "--- ${key} (torch ${primary_torch} ${primary_backend}) ---"
+              for py_tag in ${python_versions}; do
+                echo "  base: ${NAMESPACE_STAGING}/pytorch:${primary_torch}-${primary_backend}-cuda-${cuda_minor}-mini-py${py_tag}-${BUILD_DATE}"
+                echo "    -> ${NAMESPACE_STAGING}/pytorch:${key}-py${py_tag}-${BUILD_DATE}"
+              done
+            done
+          fi
+
   notify:
-    needs: [generate-matrix, build, merge-manifests, collect-tags]
+    needs: [generate-matrix, build, merge-manifests, build-mini, merge-mini-manifests, build-multi, merge-multi-manifests, collect-tags]
     if: always() && !inputs.DRY_RUN
     uses: ./.github/workflows/notify-slack.yml
     with:

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -41,7 +41,7 @@ on:
 env:
   DEFAULT_DOCKERHUB_REPO: "sd-forge"
   DEFAULT_MULTI_ARCH: "false"
-  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-03-26"
+  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-04-15"
   # 7 days in seconds
   COMMIT_AGE_THRESHOLD: 604800
 

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-03-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/extend-base-image.yml
+++ b/.github/workflows/extend-base-image.yml
@@ -284,7 +284,7 @@ jobs:
           retention-days: 1
 
   extend-mini:
-    needs: [generate-matrix, merge-manifests]
+    needs: [generate-matrix]
     if: ${{ !inputs.DRY_RUN }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/extend-pytorch.yml
+++ b/.github/workflows/extend-pytorch.yml
@@ -222,7 +222,8 @@ jobs:
           BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
         run: |
           DEFAULT_PYTHON="312"
-          mkdir -p built-tags
+          mkdir -p "$GITHUB_WORKSPACE/built-tags"
+          cd derivatives/pytorch
 
           for py_tag in ${PYTHON_VERSIONS}; do
             SOURCE="${PROD_NAMESPACE}/pytorch:${PYTORCH_VERSION}-cuda-${CUDA_SHORT}-py${py_tag}-24.04-${SOURCE_DATE}"
@@ -233,7 +234,7 @@ jobs:
             if [[ "$py_tag" == "$DEFAULT_PYTHON" ]]; then
               ALIAS_TAG="${NAMESPACE}/pytorch:${PYTORCH_VERSION}-cuda-${CUDA_SHORT}-24.04-${BUILD_DATE}-${ARCH_SUFFIX}"
               TAGS+=" --tag ${ALIAS_TAG}"
-              echo "$ALIAS_TAG" >> built-tags/tags.txt
+              echo "$ALIAS_TAG" >> "$GITHUB_WORKSPACE/built-tags/tags.txt"
             fi
 
             echo "=== Extending pytorch ${PYTORCH_VERSION} cuda-${CUDA_SHORT} py${py_tag} for ${ARCH} ==="
@@ -246,7 +247,7 @@ jobs:
               ${TAGS} \
               --push .
 
-            echo "$PRIMARY_TAG" >> built-tags/tags.txt
+            echo "$PRIMARY_TAG" >> "$GITHUB_WORKSPACE/built-tags/tags.txt"
           done
 
       - name: Upload built tags
@@ -322,7 +323,7 @@ jobs:
           retention-days: 1
 
   extend-mini:
-    needs: [generate-matrix, merge-manifests]
+    needs: [generate-matrix]
     if: ${{ needs.generate-matrix.outputs.has-mini == 'true' && !inputs.DRY_RUN }}
     runs-on: ubuntu-latest
     permissions:
@@ -359,7 +360,8 @@ jobs:
           SOURCE_DATE: ${{ inputs.SOURCE_DATE }}
           BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
         run: |
-          mkdir -p built-tags
+          mkdir -p "$GITHUB_WORKSPACE/built-tags"
+          cd derivatives/pytorch
 
           for py_tag in ${PYTHON_VERSIONS}; do
             SOURCE="${PROD_NAMESPACE}/pytorch:${PYTORCH_VERSION}-${TORCH_BACKEND}-cuda-${CUDA_MINOR}-mini-py${py_tag}-${SOURCE_DATE}"
@@ -375,7 +377,7 @@ jobs:
               --tag "${TAG}" \
               --push .
 
-            echo "$TAG" >> built-tags/tags.txt
+            echo "$TAG" >> "$GITHUB_WORKSPACE/built-tags/tags.txt"
           done
 
       - name: Upload mini tags

--- a/.github/workflows/promote-base-image.yml
+++ b/.github/workflows/promote-base-image.yml
@@ -347,7 +347,13 @@ jobs:
 
             AUTO_TAG_REF="${NAMESPACE_PROD}/base-image:cuda-${cuda_ver}-auto"
             if [[ -z "$anchor_ref" ]]; then
-              echo "WARN: no distinct anchor for ${AUTO_TAG_REF}; skipping dance (tag order will not advance)"
+              # No distinct anchor (e.g. fresh namespace, only one
+              # auto tag resolvable). Fall back to a direct update so
+              # correctness does not depend on the dance being
+              # possible — only the tag-order optimisation is lost.
+              echo "WARN: no distinct anchor for ${AUTO_TAG_REF}; falling back to direct update (tag order will not advance)"
+              docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${TARGET_REF}"
+              echo "$AUTO_TAG_REF" >> built-tags/tags.txt
               continue
             fi
 

--- a/.github/workflows/promote-base-image.yml
+++ b/.github/workflows/promote-base-image.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       configs: ${{ steps.configs.outputs.configs }}
+      all-configs: ${{ steps.configs.outputs.all-configs }}
       mini-tags: ${{ steps.configs.outputs.mini-tags }}
     steps:
       - name: Generate filtered config list
@@ -60,19 +61,24 @@ jobs:
           )
 
           CONFIGS_JSON="[]"
+          ALL_CONFIGS_JSON="[]"
 
           for config in "${ALL_CONFIGS[@]}"; do
             IFS='|' read -r key tag_template default_python <<< "$config"
+
+            ENTRY_JSON=$(jq -nc \
+              --arg key "$key" \
+              --arg tag_template "$tag_template" \
+              --arg default_python "$default_python" \
+              '{key: $key, tag_template: $tag_template, default_python: $default_python}')
+
+            ALL_CONFIGS_JSON=$(echo "$ALL_CONFIGS_JSON" | jq -c ". + [${ENTRY_JSON}]")
 
             if [[ -n "$FILTER" && "$key" != *"$FILTER"* ]]; then
               continue
             fi
 
-            CONFIGS_JSON=$(echo "$CONFIGS_JSON" | jq -c \
-              --arg key "$key" \
-              --arg tag_template "$tag_template" \
-              --arg default_python "$default_python" \
-              '. + [{"key": $key, "tag_template": $tag_template, "default_python": $default_python}]')
+            CONFIGS_JSON=$(echo "$CONFIGS_JSON" | jq -c ". + [${ENTRY_JSON}]")
           done
 
           # Mini configs: key|mini_tag
@@ -97,6 +103,11 @@ jobs:
             echo "configs<<CONFIGS_EOF"
             echo "${CONFIGS_JSON}"
             echo "CONFIGS_EOF"
+          } >> $GITHUB_OUTPUT
+          {
+            echo "all-configs<<ALL_CONFIGS_EOF"
+            echo "${ALL_CONFIGS_JSON}"
+            echo "ALL_CONFIGS_EOF"
           } >> $GITHUB_OUTPUT
           {
             echo "mini-tags<<MINI_TAGS_EOF"
@@ -127,11 +138,74 @@ jobs:
           NAMESPACE_PROD: ${{ secrets.DOCKERHUB_NAMESPACE }}
           STAGING_DATE: ${{ inputs.STAGING_DATE }}
           CONFIGS: ${{ needs.generate-configs.outputs.configs }}
+          ALL_CONFIGS: ${{ needs.generate-configs.outputs.all-configs }}
           MINI_TAGS: ${{ needs.generate-configs.outputs.mini-tags }}
         run: |
           set -euo pipefail
           PYTHON_VERSIONS=("3.10" "3.11" "3.12" "3.13" "3.14")
+          MINI_PYTHON_VERSIONS=("3.10" "3.11" "3.12" "3.13" "3.14")
           mkdir -p built-tags
+
+          # Pre-flight: every staging source we plan to promote must
+          # exist. Fail fast with a full list of missing refs rather
+          # than clobbering prod tags and then dying half way through.
+          echo "=== Pre-flight: verifying staging sources ==="
+          MISSING=()
+          CONFIG_COUNT=$(echo "$CONFIGS" | jq length)
+          for ((i=0; i<CONFIG_COUNT; i++)); do
+            tag_template=$(echo "$CONFIGS" | jq -r ".[$i].tag_template")
+            for py_version in "${PYTHON_VERSIONS[@]}"; do
+              py_tag="${py_version//.}"
+              SOURCE="${NAMESPACE_STAGING}/base-image:${tag_template}-py${py_tag}-${STAGING_DATE}"
+              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                echo "  ok: $SOURCE"
+              else
+                echo "  MISSING: $SOURCE"
+                MISSING+=("$SOURCE")
+              fi
+            done
+          done
+          MINI_COUNT=$(echo "$MINI_TAGS" | jq length)
+          for ((i=0; i<MINI_COUNT; i++)); do
+            mini_tag=$(echo "$MINI_TAGS" | jq -r ".[$i].mini_tag")
+            for py_version in "${MINI_PYTHON_VERSIONS[@]}"; do
+              py_tag="${py_version//.}"
+              SOURCE="${NAMESPACE_STAGING}/base-image:${mini_tag}-py${py_tag}-${STAGING_DATE}"
+              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                echo "  ok: $SOURCE"
+              else
+                echo "  MISSING: $SOURCE"
+                MISSING+=("$SOURCE")
+              fi
+            done
+          done
+          if [[ "${#MISSING[@]}" -gt 0 ]]; then
+            echo ""
+            echo "ERROR: ${#MISSING[@]} staging source(s) missing; aborting before any prod writes:"
+            printf '  %s\n' "${MISSING[@]}"
+            exit 1
+          fi
+          echo "Pre-flight passed: all staging sources resolved."
+
+          # Capture the current target of every auto tag BEFORE we promote.
+          # We need this so the post-promotion auto-tag dance can restore
+          # auto tags for configs NOT being promoted in this run (keeping
+          # them pinned to their existing content while still re-pushing
+          # them so they appear at the top of the tag list).
+          declare -A AUTO_TARGET_PRE
+          ALL_COUNT=$(echo "$ALL_CONFIGS" | jq length)
+          for ((i=0; i<ALL_COUNT; i++)); do
+            at_template=$(echo "$ALL_CONFIGS" | jq -r ".[$i].tag_template")
+            at_cuda_ver=$(echo "$at_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
+            [[ -z "$at_cuda_ver" ]] && continue
+            AUTO_TAG_REF="${NAMESPACE_PROD}/base-image:cuda-${at_cuda_ver}-auto"
+            if digest=$(docker buildx imagetools inspect "$AUTO_TAG_REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+              AUTO_TARGET_PRE[$at_cuda_ver]="${NAMESPACE_PROD}/base-image@${digest}"
+              echo "Captured existing auto tag: cuda-${at_cuda_ver}-auto @ ${digest}"
+            else
+              echo "No existing auto tag for cuda-${at_cuda_ver} (will be created if promoted)"
+            fi
+          done
 
           # Promote all base images (per-config, per-python)
           echo "=== Promoting base images ==="
@@ -192,30 +266,96 @@ jobs:
             done
           done
 
-          # Auto convenience tags MUST be created last.
+          # Auto convenience tags MUST be the most recently pushed tags.
           # The Vast.ai @vastai-automatic-tag backend resolves to the most
-          # recently pushed image for a given CUDA version. These auto tags
-          # point to the default Python variant (e.g. py312) so they must be
-          # the final push to ensure correct resolution ordering.
-          echo ""
-          echo "=== Creating auto convenience tags (must be last) ==="
+          # recently pushed image for a given CUDA version, so these auto
+          # tags must be the final push to ensure correct ordering.
+          #
+          # We run a two-phase dance over the FULL unfiltered config list
+          # (not just the configs promoted in this run). Phase A points
+          # every auto tag at a per-tag anchor whose digest differs from
+          # the auto tag's current and intended content; Phase B points
+          # each back at its real target. The dance guarantees that every
+          # auto tag receives two fresh pushes — even for configs not
+          # promoted in this run — so their push timestamps always end
+          # up newer than any dated tag. Re-pushing the same digest is
+          # not sufficient: the registry only bumps the tag order when
+          # the underlying manifest actually changes.
+
+          # Build the final-target map. For configs promoted this run,
+          # the real target is the new dated default-python image. For
+          # configs NOT promoted, the real target is the pre-captured
+          # digest ref.
+          declare -A AUTO_TARGET_FINAL
+          for cuda_ver in "${!AUTO_TARGET_PRE[@]}"; do
+            AUTO_TARGET_FINAL[$cuda_ver]="${AUTO_TARGET_PRE[$cuda_ver]}"
+          done
           for ((i=0; i<CONFIG_COUNT; i++)); do
             tag_template=$(echo "$CONFIGS" | jq -r ".[$i].tag_template")
             default_python=$(echo "$CONFIGS" | jq -r ".[$i].default_python")
-
             cuda_ver=$(echo "$tag_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
             [[ -z "$cuda_ver" ]] && continue
-
             dp_tag="${default_python//.}"
-            SOURCE="${NAMESPACE_PROD}/base-image:${tag_template}-py${dp_tag}-${STAGING_DATE}"
-            TARGET="${NAMESPACE_PROD}/base-image:cuda-${cuda_ver}-auto"
+            AUTO_TARGET_FINAL[$cuda_ver]="${NAMESPACE_PROD}/base-image:${tag_template}-py${dp_tag}-${STAGING_DATE}"
+          done
 
-            echo "Auto-tag: ${SOURCE} -> ${TARGET}"
-            docker buildx imagetools create \
-              --tag "${TARGET}" \
-              "${SOURCE}"
+          # Resolve each final target to its digest so we can pick
+          # anchors whose content actually differs.
+          declare -A FINAL_DIGEST
+          for cuda_ver in "${!AUTO_TARGET_FINAL[@]}"; do
+            ref="${AUTO_TARGET_FINAL[$cuda_ver]}"
+            if d=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+              FINAL_DIGEST[$cuda_ver]="$d"
+            else
+              echo "WARN: could not resolve digest for ${ref}; cuda-${cuda_ver}-auto will be skipped in the dance"
+            fi
+          done
 
-            echo "$TARGET" >> built-tags/tags.txt
+          # Iterate auto tags in ALL_CONFIGS order and run the dance.
+          echo ""
+          echo "=== Auto-tag dance ==="
+          for ((i=0; i<ALL_COUNT; i++)); do
+            at_template=$(echo "$ALL_CONFIGS" | jq -r ".[$i].tag_template")
+            cuda_ver=$(echo "$at_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
+            [[ -z "$cuda_ver" ]] && continue
+            TARGET_REF="${AUTO_TARGET_FINAL[$cuda_ver]:-}"
+            [[ -z "$TARGET_REF" ]] && continue
+            target_digest="${FINAL_DIGEST[$cuda_ver]:-}"
+            [[ -z "$target_digest" ]] && continue
+
+            # Pre-capture already stores a digest-qualified ref of the
+            # form <repo>@sha256:... — extract just the digest portion.
+            current_ref="${AUTO_TARGET_PRE[$cuda_ver]:-}"
+            current_digest=""
+            [[ -n "$current_ref" ]] && current_digest="${current_ref##*@}"
+
+            # Pick an anchor: any other config's final target whose
+            # digest differs from both current and intended.
+            anchor_ref=""
+            for ((j=0; j<ALL_COUNT; j++)); do
+              [[ "$j" -eq "$i" ]] && continue
+              cj_template=$(echo "$ALL_CONFIGS" | jq -r ".[$j].tag_template")
+              cj_cuda_ver=$(echo "$cj_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
+              [[ -z "$cj_cuda_ver" ]] && continue
+              cand_digest="${FINAL_DIGEST[$cj_cuda_ver]:-}"
+              [[ -z "$cand_digest" ]] && continue
+              if [[ "$cand_digest" != "$current_digest" && "$cand_digest" != "$target_digest" ]]; then
+                anchor_ref="${AUTO_TARGET_FINAL[$cj_cuda_ver]}"
+                break
+              fi
+            done
+
+            AUTO_TAG_REF="${NAMESPACE_PROD}/base-image:cuda-${cuda_ver}-auto"
+            if [[ -z "$anchor_ref" ]]; then
+              echo "WARN: no distinct anchor for ${AUTO_TAG_REF}; skipping dance (tag order will not advance)"
+              continue
+            fi
+
+            echo "  Phase A: ${AUTO_TAG_REF} -> anchor ${anchor_ref}"
+            docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${anchor_ref}"
+            echo "  Phase B: ${AUTO_TAG_REF} -> ${TARGET_REF}"
+            docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${TARGET_REF}"
+            echo "$AUTO_TAG_REF" >> built-tags/tags.txt
           done
 
           echo ""
@@ -262,12 +402,22 @@ jobs:
     if: ${{ inputs.DRY_RUN }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Print promotion plan
         env:
           STAGING_DATE: ${{ inputs.STAGING_DATE }}
           NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
           NAMESPACE_PROD: ${{ secrets.DOCKERHUB_NAMESPACE }}
           CONFIGS: ${{ needs.generate-configs.outputs.configs }}
+          ALL_CONFIGS: ${{ needs.generate-configs.outputs.all-configs }}
           MINI_TAGS: ${{ needs.generate-configs.outputs.mini-tags }}
         run: |
           echo "=== DRY RUN - Promotion Plan ==="
@@ -275,6 +425,50 @@ jobs:
           echo ""
 
           PYTHON_VERSIONS=("3.10" "3.11" "3.12" "3.13" "3.14")
+          MINI_PYTHON_VERSIONS=("3.10" "3.11" "3.12" "3.13" "3.14")
+
+          # Pre-flight: verify every staging source exists. Dry-run
+          # must flag missing images because promote always runs after
+          # a dry-run — we want problems visible before the real job
+          # begins clobbering prod tags.
+          echo "=== Pre-flight: verifying staging sources ==="
+          MISSING=()
+          CONFIG_COUNT=$(echo "$CONFIGS" | jq length)
+          for ((i=0; i<CONFIG_COUNT; i++)); do
+            tag_template=$(echo "$CONFIGS" | jq -r ".[$i].tag_template")
+            for py_version in "${PYTHON_VERSIONS[@]}"; do
+              py_tag="${py_version//.}"
+              SOURCE="${NAMESPACE_STAGING}/base-image:${tag_template}-py${py_tag}-${STAGING_DATE}"
+              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                echo "  ok: $SOURCE"
+              else
+                echo "  MISSING: $SOURCE"
+                MISSING+=("$SOURCE")
+              fi
+            done
+          done
+          MINI_COUNT=$(echo "$MINI_TAGS" | jq length)
+          for ((i=0; i<MINI_COUNT; i++)); do
+            mini_tag=$(echo "$MINI_TAGS" | jq -r ".[$i].mini_tag")
+            for py_version in "${MINI_PYTHON_VERSIONS[@]}"; do
+              py_tag="${py_version//.}"
+              SOURCE="${NAMESPACE_STAGING}/base-image:${mini_tag}-py${py_tag}-${STAGING_DATE}"
+              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                echo "  ok: $SOURCE"
+              else
+                echo "  MISSING: $SOURCE"
+                MISSING+=("$SOURCE")
+              fi
+            done
+          done
+          if [[ "${#MISSING[@]}" -gt 0 ]]; then
+            echo ""
+            echo "ERROR: ${#MISSING[@]} staging source(s) missing; real promote would abort:"
+            printf '  %s\n' "${MISSING[@]}"
+            exit 1
+          fi
+          echo "Pre-flight passed: all staging sources resolved."
+          echo ""
 
           echo "=== Base Image Promotions (in order) ==="
           CONFIG_COUNT=$(echo "$CONFIGS" | jq length)
@@ -308,16 +502,120 @@ jobs:
           done
 
           echo ""
-          echo "=== Auto Tags (created last for @vastai-automatic-tag resolution) ==="
+          echo "=== Auto-tag dance resolution ==="
+          echo "(Resolves against the live registry so you can verify"
+          echo " each auto tag's current digest, its intended final"
+          echo " digest, and the anchor that would be used in Phase A.)"
+          echo ""
+
+          ALL_COUNT=$(echo "$ALL_CONFIGS" | jq length)
+
+          # Capture current digests of every existing auto tag.
+          declare -A AUTO_TARGET_PRE
+          for ((i=0; i<ALL_COUNT; i++)); do
+            at_template=$(echo "$ALL_CONFIGS" | jq -r ".[$i].tag_template")
+            at_cuda_ver=$(echo "$at_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
+            [[ -z "$at_cuda_ver" ]] && continue
+            AUTO_TAG_REF="${NAMESPACE_PROD}/base-image:cuda-${at_cuda_ver}-auto"
+            if digest=$(docker buildx imagetools inspect "$AUTO_TAG_REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+              AUTO_TARGET_PRE[$at_cuda_ver]="${NAMESPACE_PROD}/base-image@${digest}"
+            fi
+          done
+
+          # Build the final-target map (promoted configs override pre).
+          declare -A AUTO_TARGET_FINAL
+          for cuda_ver in "${!AUTO_TARGET_PRE[@]}"; do
+            AUTO_TARGET_FINAL[$cuda_ver]="${AUTO_TARGET_PRE[$cuda_ver]}"
+          done
           for ((i=0; i<CONFIG_COUNT; i++)); do
             tag_template=$(echo "$CONFIGS" | jq -r ".[$i].tag_template")
             default_python=$(echo "$CONFIGS" | jq -r ".[$i].default_python")
-
             cuda_ver=$(echo "$tag_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
             [[ -z "$cuda_ver" ]] && continue
-
             dp_tag="${default_python//.}"
-            echo "  ${NAMESPACE_PROD}/base-image:${tag_template}-py${dp_tag}-${STAGING_DATE} -> ${NAMESPACE_PROD}/base-image:cuda-${cuda_ver}-auto"
+            AUTO_TARGET_FINAL[$cuda_ver]="${NAMESPACE_PROD}/base-image:${tag_template}-py${dp_tag}-${STAGING_DATE}"
+          done
+
+          # Resolve final target digests. In dry-run the prod-side
+          # dated tags don't exist yet, so resolve promoted configs via
+          # the staging source that would be copied to prod, and fall
+          # back to the pre-captured digest for configs not promoted
+          # in this run.
+          declare -A FINAL_DIGEST
+          for ((i=0; i<CONFIG_COUNT; i++)); do
+            tag_template=$(echo "$CONFIGS" | jq -r ".[$i].tag_template")
+            default_python=$(echo "$CONFIGS" | jq -r ".[$i].default_python")
+            cuda_ver=$(echo "$tag_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
+            [[ -z "$cuda_ver" ]] && continue
+            dp_tag="${default_python//.}"
+            staging_ref="${NAMESPACE_STAGING}/base-image:${tag_template}-py${dp_tag}-${STAGING_DATE}"
+            if d=$(docker buildx imagetools inspect "$staging_ref" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+              FINAL_DIGEST[$cuda_ver]="$d"
+            else
+              echo "WARN: could not resolve staging source ${staging_ref}"
+            fi
+          done
+          for cuda_ver in "${!AUTO_TARGET_PRE[@]}"; do
+            if [[ -z "${FINAL_DIGEST[$cuda_ver]:-}" ]]; then
+              FINAL_DIGEST[$cuda_ver]="${AUTO_TARGET_PRE[$cuda_ver]##*@}"
+            fi
+          done
+
+          for ((i=0; i<ALL_COUNT; i++)); do
+            at_template=$(echo "$ALL_CONFIGS" | jq -r ".[$i].tag_template")
+            cuda_ver=$(echo "$at_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
+            [[ -z "$cuda_ver" ]] && continue
+            TARGET_REF="${AUTO_TARGET_FINAL[$cuda_ver]:-}"
+            AUTO_TAG_REF="${NAMESPACE_PROD}/base-image:cuda-${cuda_ver}-auto"
+
+            echo "--- cuda-${cuda_ver}-auto ---"
+            if [[ -z "$TARGET_REF" ]]; then
+              echo "  (no current auto tag and not in this promotion — skipped)"
+              echo ""
+              continue
+            fi
+
+            current_ref="${AUTO_TARGET_PRE[$cuda_ver]:-}"
+            current_digest=""
+            [[ -n "$current_ref" ]] && current_digest="${current_ref##*@}"
+            target_digest="${FINAL_DIGEST[$cuda_ver]:-}"
+
+            echo "  Current:       ${current_ref:-<none>}"
+            echo "  Current digest: ${current_digest:-<none>}"
+            echo "  Final target:   ${TARGET_REF}"
+            echo "  Final digest:   ${target_digest:-<unresolved>}"
+
+            if [[ -z "$target_digest" ]]; then
+              echo "  Phase A/B:     SKIP (final target digest not resolvable)"
+              echo ""
+              continue
+            fi
+
+            anchor_ref=""
+            anchor_digest=""
+            for ((j=0; j<ALL_COUNT; j++)); do
+              [[ "$j" -eq "$i" ]] && continue
+              cj_template=$(echo "$ALL_CONFIGS" | jq -r ".[$j].tag_template")
+              cj_cuda_ver=$(echo "$cj_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
+              [[ -z "$cj_cuda_ver" ]] && continue
+              cand_digest="${FINAL_DIGEST[$cj_cuda_ver]:-}"
+              [[ -z "$cand_digest" ]] && continue
+              if [[ "$cand_digest" != "$current_digest" && "$cand_digest" != "$target_digest" ]]; then
+                anchor_ref="${AUTO_TARGET_FINAL[$cj_cuda_ver]}"
+                anchor_digest="$cand_digest"
+                break
+              fi
+            done
+
+            if [[ -z "$anchor_ref" ]]; then
+              echo "  Phase A/B:     SKIP (no distinct anchor available)"
+            else
+              echo "  Phase A anchor: ${anchor_ref}"
+              echo "  Phase A digest: ${anchor_digest}"
+              echo "  Phase A:        ${AUTO_TAG_REF} -> ${anchor_ref}"
+              echo "  Phase B:        ${AUTO_TAG_REF} -> ${TARGET_REF}"
+            fi
+            echo ""
           done
 
   notify:

--- a/.github/workflows/promote-pytorch.yml
+++ b/.github/workflows/promote-pytorch.yml
@@ -502,7 +502,13 @@ jobs:
 
             AUTO_TAG_REF="${NAMESPACE_PROD}/pytorch:${auto_tag}"
             if [[ -z "$anchor_ref" ]]; then
-              echo "WARN: no distinct anchor for ${AUTO_TAG_REF}; skipping dance (tag order will not advance)"
+              # No distinct anchor (e.g. fresh namespace, only one
+              # auto tag resolvable). Fall back to a direct update so
+              # correctness does not depend on the dance being
+              # possible — only the tag-order optimisation is lost.
+              echo "WARN: no distinct anchor for ${AUTO_TAG_REF}; falling back to direct update (tag order will not advance)"
+              docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${TARGET_REF}"
+              echo "$AUTO_TAG_REF" >> built-tags/tags.txt
               continue
             fi
 

--- a/.github/workflows/promote-pytorch.yml
+++ b/.github/workflows/promote-pytorch.yml
@@ -37,8 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       configs: ${{ steps.configs.outputs.configs }}
+      all-configs: ${{ steps.configs.outputs.all-configs }}
       mini-configs: ${{ steps.configs.outputs.mini-configs }}
       has-mini: ${{ steps.configs.outputs.has-mini }}
+      multi-configs: ${{ steps.configs.outputs.multi-configs }}
+      has-multi: ${{ steps.configs.outputs.has-multi }}
     steps:
       - name: Generate filtered config list
         id: configs
@@ -85,22 +88,36 @@ jobs:
           )
 
           CONFIGS_JSON="[]"
+          ALL_CONFIGS_JSON="[]"
 
           for config in "${ALL_CONFIGS[@]}"; do
             IFS='|' read -r torch_ver key cuda_short python_versions <<< "$config"
+
+            ENTRY_JSON=$(jq -nc \
+              --arg torch_ver "$torch_ver" \
+              --arg key "$key" \
+              --arg cuda_short "$cuda_short" \
+              --arg python_versions "$python_versions" \
+              '{torch_version: $torch_ver, key: $key, cuda_short: $cuda_short, python_versions: $python_versions}')
+
+            ALL_CONFIGS_JSON=$(echo "$ALL_CONFIGS_JSON" | jq -c ". + [${ENTRY_JSON}]")
 
             # Filter matches version or config key
             if [[ -n "$FILTER" && "$torch_ver" != *"$FILTER"* && "$key" != *"$FILTER"* ]]; then
               continue
             fi
 
-            CONFIGS_JSON=$(echo "$CONFIGS_JSON" | jq -c \
-              --arg torch_ver "$torch_ver" \
-              --arg key "$key" \
-              --arg cuda_short "$cuda_short" \
-              --arg python_versions "$python_versions" \
-              '. + [{"torch_version": $torch_ver, "key": $key, "cuda_short": $cuda_short, "python_versions": $python_versions}]')
+            CONFIGS_JSON=$(echo "$CONFIGS_JSON" | jq -c ". + [${ENTRY_JSON}]")
           done
+
+          # Multi-torch variants: a base pytorch image with additional
+          # torch venvs layered in. Tag format:
+          #   ${NS}/pytorch:${key}-py${py}-${date}
+          # plus a default-python dated alias and a no-date latest alias.
+          # Format: key|primary_torch|primary_backend|cuda_minor|python_versions
+          ALL_MULTI_CONFIGS=(
+            "multi-210-291-271|2.10.0|cu128|12.9|312"
+          )
 
           MINI_CONFIGS_JSON="[]"
 
@@ -126,15 +143,49 @@ jobs:
             echo "has-mini=false" >> $GITHUB_OUTPUT
           fi
 
+          MULTI_CONFIGS_JSON="[]"
+          for multi_config in "${ALL_MULTI_CONFIGS[@]}"; do
+            IFS='|' read -r key primary_torch primary_backend cuda_minor python_versions <<< "$multi_config"
+
+            # FILTER=mini also includes multi since multi layers on mini.
+            if [[ -n "$FILTER" && "$key" != *"$FILTER"* && "$primary_torch" != *"$FILTER"* && "multi" != *"$FILTER"* && "mini" != *"$FILTER"* ]]; then
+              continue
+            fi
+
+            MULTI_CONFIGS_JSON=$(echo "$MULTI_CONFIGS_JSON" | jq -c \
+              --arg key "$key" \
+              --arg primary_torch "$primary_torch" \
+              --arg primary_backend "$primary_backend" \
+              --arg cuda_minor "$cuda_minor" \
+              --arg python_versions "$python_versions" \
+              '. + [{"key": $key, "primary_torch": $primary_torch, "primary_backend": $primary_backend, "cuda_minor": $cuda_minor, "python_versions": $python_versions}]')
+          done
+
+          if [[ $(echo "$MULTI_CONFIGS_JSON" | jq length) -gt 0 ]]; then
+            echo "has-multi=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-multi=false" >> $GITHUB_OUTPUT
+          fi
+
           {
             echo "configs<<CONFIGS_EOF"
             echo "${CONFIGS_JSON}"
             echo "CONFIGS_EOF"
           } >> $GITHUB_OUTPUT
           {
+            echo "all-configs<<ALL_CONFIGS_EOF"
+            echo "${ALL_CONFIGS_JSON}"
+            echo "ALL_CONFIGS_EOF"
+          } >> $GITHUB_OUTPUT
+          {
             echo "mini-configs<<MINI_CONFIGS_EOF"
             echo "${MINI_CONFIGS_JSON}"
             echo "MINI_CONFIGS_EOF"
+          } >> $GITHUB_OUTPUT
+          {
+            echo "multi-configs<<MULTI_CONFIGS_EOF"
+            echo "${MULTI_CONFIGS_JSON}"
+            echo "MULTI_CONFIGS_EOF"
           } >> $GITHUB_OUTPUT
           echo "Configs: $(echo "$CONFIGS_JSON" | jq length)"
           echo "Mini configs: $(echo "$MINI_CONFIGS_JSON" | jq length)"
@@ -160,12 +211,101 @@ jobs:
           NAMESPACE_PROD: ${{ secrets.DOCKERHUB_NAMESPACE }}
           STAGING_DATE: ${{ inputs.STAGING_DATE }}
           CONFIGS: ${{ needs.generate-configs.outputs.configs }}
+          ALL_CONFIGS: ${{ needs.generate-configs.outputs.all-configs }}
           MINI_CONFIGS: ${{ needs.generate-configs.outputs.mini-configs }}
           HAS_MINI: ${{ needs.generate-configs.outputs.has-mini }}
+          MULTI_CONFIGS: ${{ needs.generate-configs.outputs.multi-configs }}
+          HAS_MULTI: ${{ needs.generate-configs.outputs.has-multi }}
         run: |
           set -euo pipefail
           DEFAULT_PYTHON="312"
           mkdir -p built-tags
+
+          AUTO_TAG_MAP=(
+            "cuda-12.1.1-auto|cu126"
+            "cuda-12.4.1-auto|cu126"
+            "cuda-12.6.3-auto|cu126"
+            "cuda-12.8.1-auto|cu128"
+            "cuda-12.9.1-auto|cu128"
+            "cuda-13.0.2-auto|cu130"
+          )
+
+          # Pre-flight: every staging source we plan to promote must
+          # exist. Fail fast before clobbering prod tags.
+          echo "=== Pre-flight: verifying staging sources ==="
+          MISSING=()
+          CONFIG_COUNT=$(echo "$CONFIGS" | jq length)
+          for ((i=0; i<CONFIG_COUNT; i++)); do
+            torch_ver=$(echo "$CONFIGS" | jq -r ".[$i].torch_version")
+            cuda_short=$(echo "$CONFIGS" | jq -r ".[$i].cuda_short")
+            python_versions=$(echo "$CONFIGS" | jq -r ".[$i].python_versions")
+            for py_tag in ${python_versions}; do
+              SOURCE="${NAMESPACE_STAGING}/pytorch:${torch_ver}-cuda-${cuda_short}-py${py_tag}-24.04-${STAGING_DATE}"
+              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                echo "  ok: $SOURCE"
+              else
+                echo "  MISSING: $SOURCE"
+                MISSING+=("$SOURCE")
+              fi
+            done
+          done
+          if [[ "$HAS_MINI" == "true" ]]; then
+            MINI_COUNT=$(echo "$MINI_CONFIGS" | jq length)
+            for ((i=0; i<MINI_COUNT; i++)); do
+              torch_ver=$(echo "$MINI_CONFIGS" | jq -r ".[$i].torch_version")
+              torch_backend=$(echo "$MINI_CONFIGS" | jq -r ".[$i].torch_backend")
+              cuda_minor=$(echo "$MINI_CONFIGS" | jq -r ".[$i].cuda_minor")
+              python_versions=$(echo "$MINI_CONFIGS" | jq -r ".[$i].python_versions")
+              for py_tag in ${python_versions}; do
+                SOURCE="${NAMESPACE_STAGING}/pytorch:${torch_ver}-${torch_backend}-cuda-${cuda_minor}-mini-py${py_tag}-${STAGING_DATE}"
+                if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                  echo "  ok: $SOURCE"
+                else
+                  echo "  MISSING: $SOURCE"
+                  MISSING+=("$SOURCE")
+                fi
+              done
+            done
+          fi
+          if [[ "$HAS_MULTI" == "true" ]]; then
+            MULTI_COUNT=$(echo "$MULTI_CONFIGS" | jq length)
+            for ((i=0; i<MULTI_COUNT; i++)); do
+              key=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].key")
+              python_versions=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].python_versions")
+              for py_tag in ${python_versions}; do
+                SOURCE="${NAMESPACE_STAGING}/pytorch:${key}-py${py_tag}-${STAGING_DATE}"
+                if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                  echo "  ok: $SOURCE"
+                else
+                  echo "  MISSING: $SOURCE"
+                  MISSING+=("$SOURCE")
+                fi
+              done
+            done
+          fi
+          if [[ "${#MISSING[@]}" -gt 0 ]]; then
+            echo ""
+            echo "ERROR: ${#MISSING[@]} staging source(s) missing; aborting before any prod writes:"
+            printf '  %s\n' "${MISSING[@]}"
+            exit 1
+          fi
+          echo "Pre-flight passed: all staging sources resolved."
+
+          # Capture the current target of every auto tag BEFORE we
+          # promote. The dance needs this so auto tags for backends
+          # NOT being promoted this run can still be re-pushed
+          # (pointed at their existing digest) to advance tag order.
+          declare -A AUTO_TARGET_PRE
+          for entry in "${AUTO_TAG_MAP[@]}"; do
+            IFS='|' read -r auto_tag backend <<< "$entry"
+            AUTO_TAG_REF="${NAMESPACE_PROD}/pytorch:${auto_tag}"
+            if digest=$(docker buildx imagetools inspect "$AUTO_TAG_REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+              AUTO_TARGET_PRE[$auto_tag]="${NAMESPACE_PROD}/pytorch@${digest}"
+              echo "Captured existing auto tag: ${auto_tag} @ ${digest}"
+            else
+              echo "No existing auto tag for ${auto_tag}"
+            fi
+          done
 
           # Promote full images
           echo "=== Promoting PyTorch full images ==="
@@ -238,45 +378,139 @@ jobs:
             done
           fi
 
-          # Auto convenience tags MUST be created last.
-          # Each auto-tag points to the LATEST torch version that supports
-          # the corresponding backend. If a future torch drops cu126, the
-          # 12.6.3-auto tag stays on the last torch that supported it.
-          echo ""
-          echo "=== Creating auto convenience tags (must be last) ==="
+          # Promote multi-torch variants (layered pytorch images).
+          # Each config produces a dated prod tag per python, a dated
+          # default-python alias, and a no-date latest alias that the
+          # aio-studio / other consumers reference.
+          if [[ "$HAS_MULTI" == "true" ]]; then
+            echo ""
+            echo "=== Promoting PyTorch multi-torch variants ==="
+            MULTI_COUNT=$(echo "$MULTI_CONFIGS" | jq length)
+            for ((i=0; i<MULTI_COUNT; i++)); do
+              key=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].key")
+              python_versions=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].python_versions")
 
-          # Map: host_cuda_auto_tag | backend_config_key
-          # backend_config_key is used to find the latest torch with that backend
-          AUTO_TAG_MAP=(
-            "cuda-12.1.1-auto|cu126"
-            "cuda-12.4.1-auto|cu126"
-            "cuda-12.6.3-auto|cu126"
-            "cuda-12.8.1-auto|cu128"
-            "cuda-12.9.1-auto|cu128"
-            "cuda-13.0.2-auto|cu130"
-          )
+              echo ""
+              echo "--- ${key} ---"
+
+              DEFAULT_DATED=""
+              for py_tag in ${python_versions}; do
+                SOURCE="${NAMESPACE_STAGING}/pytorch:${key}-py${py_tag}-${STAGING_DATE}"
+                DATED_TAG="${NAMESPACE_PROD}/pytorch:${key}-py${py_tag}-${STAGING_DATE}"
+
+                EXTRA_TAGS=""
+                if [[ "$py_tag" == "$DEFAULT_PYTHON" ]]; then
+                  DATED_ALIAS="${NAMESPACE_PROD}/pytorch:${key}-${STAGING_DATE}"
+                  EXTRA_TAGS="--tag ${DATED_ALIAS}"
+                  DEFAULT_DATED="$DATED_TAG"
+                  echo "$DATED_ALIAS" >> built-tags/tags.txt
+                fi
+
+                echo "Promoting multi: ${SOURCE} -> ${DATED_TAG}"
+                docker buildx imagetools create \
+                  --tag "${DATED_TAG}" \
+                  ${EXTRA_TAGS} \
+                  "${SOURCE}"
+
+                echo "$DATED_TAG" >> built-tags/tags.txt
+              done
+
+              # Repoint the no-date latest alias at the default-python
+              # dated prod image we just pushed. Must come after the
+              # dated tags so the alias sits at the top of the tag list.
+              if [[ -n "$DEFAULT_DATED" ]]; then
+                LATEST_ALIAS="${NAMESPACE_PROD}/pytorch:${key}"
+                echo "Updating latest alias: ${LATEST_ALIAS} -> ${DEFAULT_DATED}"
+                docker buildx imagetools create --tag "${LATEST_ALIAS}" "${DEFAULT_DATED}"
+                echo "$LATEST_ALIAS" >> built-tags/tags.txt
+              fi
+            done
+          fi
+
+          # Auto convenience tags MUST be the most recently pushed tags.
+          # Each auto-tag points to the LATEST torch version that supports
+          # the corresponding backend (determined from the unfiltered
+          # ALL_CONFIGS). Promotions partial by filter must still re-push
+          # every auto tag so ordering stays correct.
+          #
+          # Two-phase dance: Phase A points each auto tag at a per-tag
+          # anchor whose digest differs from the auto tag's current and
+          # intended content; Phase B points it back at its real target.
+          # Both phases carry real manifest changes so every auto tag
+          # receives two fresh pushes, advancing the registry tag order.
+
+          echo ""
+          echo "=== Auto-tag dance ==="
+
+          # Build the final-target map per auto tag. For backends whose
+          # latest torch IS being promoted this run, target = new dated
+          # default-python prod image. For backends not in scope,
+          # target = pre-captured digest ref.
+          declare -A AUTO_TARGET_FINAL
+          for entry in "${AUTO_TAG_MAP[@]}"; do
+            IFS='|' read -r auto_tag backend <<< "$entry"
+            BEST_VER=$(echo "$ALL_CONFIGS" | jq -r --arg k "$backend" \
+              '[.[] | select(.key == $k)] | sort_by(.torch_version | split(".") | map(tonumber)) | last | .torch_version // empty')
+            [[ -z "$BEST_VER" ]] && continue
+            CUDA_SHORT=$(echo "$ALL_CONFIGS" | jq -r --arg k "$backend" --arg v "$BEST_VER" \
+              '.[] | select(.key == $k and .torch_version == $v) | .cuda_short')
+            in_scope=$(echo "$CONFIGS" | jq --arg k "$backend" --arg v "$BEST_VER" \
+              '[.[] | select(.key == $k and .torch_version == $v)] | length')
+            if [[ "$in_scope" -gt 0 ]]; then
+              AUTO_TARGET_FINAL[$auto_tag]="${NAMESPACE_PROD}/pytorch:${BEST_VER}-cuda-${CUDA_SHORT}-py${DEFAULT_PYTHON}-24.04-${STAGING_DATE}"
+            elif [[ -n "${AUTO_TARGET_PRE[$auto_tag]:-}" ]]; then
+              AUTO_TARGET_FINAL[$auto_tag]="${AUTO_TARGET_PRE[$auto_tag]}"
+            fi
+          done
+
+          # Resolve each final target to its digest so we can pick
+          # anchors whose content actually differs.
+          declare -A FINAL_DIGEST
+          for auto_tag in "${!AUTO_TARGET_FINAL[@]}"; do
+            ref="${AUTO_TARGET_FINAL[$auto_tag]}"
+            if d=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+              FINAL_DIGEST[$auto_tag]="$d"
+            else
+              echo "WARN: could not resolve digest for ${ref}; ${auto_tag} will be skipped"
+            fi
+          done
 
           for entry in "${AUTO_TAG_MAP[@]}"; do
             IFS='|' read -r auto_tag backend <<< "$entry"
+            TARGET_REF="${AUTO_TARGET_FINAL[$auto_tag]:-}"
+            [[ -z "$TARGET_REF" ]] && continue
+            target_digest="${FINAL_DIGEST[$auto_tag]:-}"
+            [[ -z "$target_digest" ]] && continue
 
-            # Find the latest torch version that has this backend
-            BEST_VER=$(echo "$CONFIGS" | jq -r --arg k "$backend" \
-              '[.[] | select(.key == $k)] | sort_by(.torch_version | split(".") | map(tonumber)) | last | .torch_version // empty')
-            [[ -z "$BEST_VER" ]] && continue
+            current_ref="${AUTO_TARGET_PRE[$auto_tag]:-}"
+            current_digest=""
+            [[ -n "$current_ref" ]] && current_digest="${current_ref##*@}"
 
-            # Get the cuda_short for this backend+version
-            CUDA_SHORT=$(echo "$CONFIGS" | jq -r --arg k "$backend" --arg v "$BEST_VER" \
-              '.[] | select(.key == $k and .torch_version == $v) | .cuda_short')
+            # Pick an anchor from another AUTO_TAG_MAP entry whose
+            # final-target digest differs from both current and final.
+            anchor_ref=""
+            for other in "${AUTO_TAG_MAP[@]}"; do
+              IFS='|' read -r other_tag _ <<< "$other"
+              [[ "$other_tag" == "$auto_tag" ]] && continue
+              cand_digest="${FINAL_DIGEST[$other_tag]:-}"
+              [[ -z "$cand_digest" ]] && continue
+              if [[ "$cand_digest" != "$current_digest" && "$cand_digest" != "$target_digest" ]]; then
+                anchor_ref="${AUTO_TARGET_FINAL[$other_tag]}"
+                break
+              fi
+            done
 
-            SOURCE="${NAMESPACE_PROD}/pytorch:${BEST_VER}-cuda-${CUDA_SHORT}-py${DEFAULT_PYTHON}-24.04-${STAGING_DATE}"
-            TARGET="${NAMESPACE_PROD}/pytorch:${auto_tag}"
+            AUTO_TAG_REF="${NAMESPACE_PROD}/pytorch:${auto_tag}"
+            if [[ -z "$anchor_ref" ]]; then
+              echo "WARN: no distinct anchor for ${AUTO_TAG_REF}; skipping dance (tag order will not advance)"
+              continue
+            fi
 
-            echo "Auto-tag: ${SOURCE} -> ${TARGET} (latest ${backend} = ${BEST_VER})"
-            docker buildx imagetools create \
-              --tag "${TARGET}" \
-              "${SOURCE}"
-
-            echo "$TARGET" >> built-tags/tags.txt
+            echo "  Phase A: ${AUTO_TAG_REF} -> anchor ${anchor_ref}"
+            docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${anchor_ref}"
+            echo "  Phase B: ${AUTO_TAG_REF} -> ${TARGET_REF}"
+            docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${TARGET_REF}"
+            echo "$AUTO_TAG_REF" >> built-tags/tags.txt
           done
 
           echo ""
@@ -323,19 +557,102 @@ jobs:
     if: ${{ inputs.DRY_RUN }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Print promotion plan
         env:
           STAGING_DATE: ${{ inputs.STAGING_DATE }}
           NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
           NAMESPACE_PROD: ${{ secrets.DOCKERHUB_NAMESPACE }}
           CONFIGS: ${{ needs.generate-configs.outputs.configs }}
+          ALL_CONFIGS: ${{ needs.generate-configs.outputs.all-configs }}
           MINI_CONFIGS: ${{ needs.generate-configs.outputs.mini-configs }}
           HAS_MINI: ${{ needs.generate-configs.outputs.has-mini }}
+          MULTI_CONFIGS: ${{ needs.generate-configs.outputs.multi-configs }}
+          HAS_MULTI: ${{ needs.generate-configs.outputs.has-multi }}
         run: |
           DEFAULT_PYTHON="312"
 
           echo "=== DRY RUN - PyTorch Promotion Plan ==="
           echo "Staging date: $STAGING_DATE"
+          echo ""
+
+          AUTO_TAG_MAP=(
+            "cuda-12.1.1-auto|cu126"
+            "cuda-12.4.1-auto|cu126"
+            "cuda-12.6.3-auto|cu126"
+            "cuda-12.8.1-auto|cu128"
+            "cuda-12.9.1-auto|cu128"
+            "cuda-13.0.2-auto|cu130"
+          )
+
+          # Pre-flight: mirror the real promote so missing images
+          # surface here, before we commit to running live.
+          echo "=== Pre-flight: verifying staging sources ==="
+          MISSING=()
+          CONFIG_COUNT=$(echo "$CONFIGS" | jq length)
+          for ((i=0; i<CONFIG_COUNT; i++)); do
+            torch_ver=$(echo "$CONFIGS" | jq -r ".[$i].torch_version")
+            cuda_short=$(echo "$CONFIGS" | jq -r ".[$i].cuda_short")
+            python_versions=$(echo "$CONFIGS" | jq -r ".[$i].python_versions")
+            for py_tag in ${python_versions}; do
+              SOURCE="${NAMESPACE_STAGING}/pytorch:${torch_ver}-cuda-${cuda_short}-py${py_tag}-24.04-${STAGING_DATE}"
+              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                echo "  ok: $SOURCE"
+              else
+                echo "  MISSING: $SOURCE"
+                MISSING+=("$SOURCE")
+              fi
+            done
+          done
+          if [[ "$HAS_MINI" == "true" ]]; then
+            MINI_COUNT=$(echo "$MINI_CONFIGS" | jq length)
+            for ((i=0; i<MINI_COUNT; i++)); do
+              torch_ver=$(echo "$MINI_CONFIGS" | jq -r ".[$i].torch_version")
+              torch_backend=$(echo "$MINI_CONFIGS" | jq -r ".[$i].torch_backend")
+              cuda_minor=$(echo "$MINI_CONFIGS" | jq -r ".[$i].cuda_minor")
+              python_versions=$(echo "$MINI_CONFIGS" | jq -r ".[$i].python_versions")
+              for py_tag in ${python_versions}; do
+                SOURCE="${NAMESPACE_STAGING}/pytorch:${torch_ver}-${torch_backend}-cuda-${cuda_minor}-mini-py${py_tag}-${STAGING_DATE}"
+                if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                  echo "  ok: $SOURCE"
+                else
+                  echo "  MISSING: $SOURCE"
+                  MISSING+=("$SOURCE")
+                fi
+              done
+            done
+          fi
+          if [[ "$HAS_MULTI" == "true" ]]; then
+            MULTI_COUNT=$(echo "$MULTI_CONFIGS" | jq length)
+            for ((i=0; i<MULTI_COUNT; i++)); do
+              key=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].key")
+              python_versions=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].python_versions")
+              for py_tag in ${python_versions}; do
+                SOURCE="${NAMESPACE_STAGING}/pytorch:${key}-py${py_tag}-${STAGING_DATE}"
+                if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+                  echo "  ok: $SOURCE"
+                else
+                  echo "  MISSING: $SOURCE"
+                  MISSING+=("$SOURCE")
+                fi
+              done
+            done
+          fi
+          if [[ "${#MISSING[@]}" -gt 0 ]]; then
+            echo ""
+            echo "ERROR: ${#MISSING[@]} staging source(s) missing; real promote would abort:"
+            printf '  %s\n' "${MISSING[@]}"
+            exit 1
+          fi
+          echo "Pre-flight passed: all staging sources resolved."
           echo ""
 
           echo "=== Full Image Promotions (in order) ==="
@@ -383,30 +700,142 @@ jobs:
             done
           fi
 
-          echo ""
-          echo "=== Auto Tags (created last for @vastai-automatic-tag resolution) ==="
-          echo "Each auto-tag points to the latest torch with that backend:"
+          if [[ "$HAS_MULTI" == "true" ]]; then
+            echo ""
+            echo "=== Multi-torch Promotions ==="
+            MULTI_COUNT=$(echo "$MULTI_CONFIGS" | jq length)
+            for ((i=0; i<MULTI_COUNT; i++)); do
+              key=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].key")
+              python_versions=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].python_versions")
 
-          AUTO_TAG_MAP=(
-            "cuda-12.1.1-auto|cu126"
-            "cuda-12.4.1-auto|cu126"
-            "cuda-12.6.3-auto|cu126"
-            "cuda-12.8.1-auto|cu128"
-            "cuda-12.9.1-auto|cu128"
-            "cuda-13.0.2-auto|cu130"
-          )
+              echo ""
+              echo "--- ${key} ---"
+              for py_tag in ${python_versions}; do
+                echo "  ${NAMESPACE_STAGING}/pytorch:${key}-py${py_tag}-${STAGING_DATE}"
+                echo "    -> ${NAMESPACE_PROD}/pytorch:${key}-py${py_tag}-${STAGING_DATE}"
+              done
+              echo "  + default python alias:"
+              echo "    -> ${NAMESPACE_PROD}/pytorch:${key}-${STAGING_DATE} (alias for py${DEFAULT_PYTHON})"
+              echo "  + latest alias:"
+              echo "    -> ${NAMESPACE_PROD}/pytorch:${key} -> ${key}-py${DEFAULT_PYTHON}-${STAGING_DATE}"
+            done
+          fi
+
+          echo ""
+          echo "=== Auto-tag dance resolution ==="
+          echo "(Each auto-tag points to the latest torch with its"
+          echo " backend, determined from the unfiltered ALL_CONFIGS.)"
+          echo ""
+
+          # Capture current digests of every existing auto tag.
+          declare -A AUTO_TARGET_PRE
+          for entry in "${AUTO_TAG_MAP[@]}"; do
+            IFS='|' read -r auto_tag backend <<< "$entry"
+            AUTO_TAG_REF="${NAMESPACE_PROD}/pytorch:${auto_tag}"
+            if digest=$(docker buildx imagetools inspect "$AUTO_TAG_REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+              AUTO_TARGET_PRE[$auto_tag]="${NAMESPACE_PROD}/pytorch@${digest}"
+            fi
+          done
+
+          # Build the final-target map (in-scope backends override pre).
+          declare -A AUTO_TARGET_FINAL
+          declare -A BEST_INFO
+          for entry in "${AUTO_TAG_MAP[@]}"; do
+            IFS='|' read -r auto_tag backend <<< "$entry"
+            BEST_VER=$(echo "$ALL_CONFIGS" | jq -r --arg k "$backend" \
+              '[.[] | select(.key == $k)] | sort_by(.torch_version | split(".") | map(tonumber)) | last | .torch_version // empty')
+            [[ -z "$BEST_VER" ]] && continue
+            CUDA_SHORT=$(echo "$ALL_CONFIGS" | jq -r --arg k "$backend" --arg v "$BEST_VER" \
+              '.[] | select(.key == $k and .torch_version == $v) | .cuda_short')
+            BEST_INFO[$auto_tag]="${backend} ${BEST_VER} ${CUDA_SHORT}"
+            in_scope=$(echo "$CONFIGS" | jq --arg k "$backend" --arg v "$BEST_VER" \
+              '[.[] | select(.key == $k and .torch_version == $v)] | length')
+            if [[ "$in_scope" -gt 0 ]]; then
+              AUTO_TARGET_FINAL[$auto_tag]="${NAMESPACE_PROD}/pytorch:${BEST_VER}-cuda-${CUDA_SHORT}-py${DEFAULT_PYTHON}-24.04-${STAGING_DATE}"
+            elif [[ -n "${AUTO_TARGET_PRE[$auto_tag]:-}" ]]; then
+              AUTO_TARGET_FINAL[$auto_tag]="${AUTO_TARGET_PRE[$auto_tag]}"
+            fi
+          done
+
+          # Resolve final target digests. For in-scope backends the
+          # prod-side dated tag does not exist yet, so resolve via the
+          # staging source that would be copied to prod.
+          declare -A FINAL_DIGEST
+          for entry in "${AUTO_TAG_MAP[@]}"; do
+            IFS='|' read -r auto_tag backend <<< "$entry"
+            info="${BEST_INFO[$auto_tag]:-}"
+            [[ -z "$info" ]] && continue
+            read -r bi_backend bi_ver bi_cuda <<< "$info"
+            in_scope=$(echo "$CONFIGS" | jq --arg k "$bi_backend" --arg v "$bi_ver" \
+              '[.[] | select(.key == $k and .torch_version == $v)] | length')
+            if [[ "$in_scope" -gt 0 ]]; then
+              staging_ref="${NAMESPACE_STAGING}/pytorch:${bi_ver}-cuda-${bi_cuda}-py${DEFAULT_PYTHON}-24.04-${STAGING_DATE}"
+              if d=$(docker buildx imagetools inspect "$staging_ref" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+                FINAL_DIGEST[$auto_tag]="$d"
+              else
+                echo "WARN: could not resolve staging source ${staging_ref}"
+              fi
+            elif [[ -n "${AUTO_TARGET_PRE[$auto_tag]:-}" ]]; then
+              FINAL_DIGEST[$auto_tag]="${AUTO_TARGET_PRE[$auto_tag]##*@}"
+            fi
+          done
 
           for entry in "${AUTO_TAG_MAP[@]}"; do
             IFS='|' read -r auto_tag backend <<< "$entry"
+            TARGET_REF="${AUTO_TARGET_FINAL[$auto_tag]:-}"
+            AUTO_TAG_REF="${NAMESPACE_PROD}/pytorch:${auto_tag}"
+            info="${BEST_INFO[$auto_tag]:-}"
 
-            BEST_VER=$(echo "$CONFIGS" | jq -r --arg k "$backend" \
-              '[.[] | select(.key == $k)] | sort_by(.torch_version | split(".") | map(tonumber)) | last | .torch_version // empty')
-            [[ -z "$BEST_VER" ]] && continue
+            echo "--- ${auto_tag} ---"
+            if [[ -n "$info" ]]; then
+              read -r bi_backend bi_ver bi_cuda <<< "$info"
+              echo "  Latest ${bi_backend}: torch ${bi_ver} (cuda-${bi_cuda})"
+            fi
+            if [[ -z "$TARGET_REF" ]]; then
+              echo "  (no current auto tag and backend not in this promotion — skipped)"
+              echo ""
+              continue
+            fi
 
-            CUDA_SHORT=$(echo "$CONFIGS" | jq -r --arg k "$backend" --arg v "$BEST_VER" \
-              '.[] | select(.key == $k and .torch_version == $v) | .cuda_short')
+            current_ref="${AUTO_TARGET_PRE[$auto_tag]:-}"
+            current_digest=""
+            [[ -n "$current_ref" ]] && current_digest="${current_ref##*@}"
+            target_digest="${FINAL_DIGEST[$auto_tag]:-}"
 
-            echo "  ${NAMESPACE_PROD}/pytorch:${BEST_VER}-cuda-${CUDA_SHORT}-py${DEFAULT_PYTHON}-24.04-${STAGING_DATE} -> ${NAMESPACE_PROD}/pytorch:${auto_tag} (latest ${backend} = ${BEST_VER})"
+            echo "  Current:       ${current_ref:-<none>}"
+            echo "  Current digest: ${current_digest:-<none>}"
+            echo "  Final target:   ${TARGET_REF}"
+            echo "  Final digest:   ${target_digest:-<unresolved>}"
+
+            if [[ -z "$target_digest" ]]; then
+              echo "  Phase A/B:     SKIP (final target digest not resolvable)"
+              echo ""
+              continue
+            fi
+
+            anchor_ref=""
+            anchor_digest=""
+            for other in "${AUTO_TAG_MAP[@]}"; do
+              IFS='|' read -r other_tag _ <<< "$other"
+              [[ "$other_tag" == "$auto_tag" ]] && continue
+              cand_digest="${FINAL_DIGEST[$other_tag]:-}"
+              [[ -z "$cand_digest" ]] && continue
+              if [[ "$cand_digest" != "$current_digest" && "$cand_digest" != "$target_digest" ]]; then
+                anchor_ref="${AUTO_TARGET_FINAL[$other_tag]}"
+                anchor_digest="$cand_digest"
+                break
+              fi
+            done
+
+            if [[ -z "$anchor_ref" ]]; then
+              echo "  Phase A/B:     SKIP (no distinct anchor available)"
+            else
+              echo "  Phase A anchor: ${anchor_ref}"
+              echo "  Phase A digest: ${anchor_digest}"
+              echo "  Phase A:        ${AUTO_TAG_REF} -> ${anchor_ref}"
+              echo "  Phase B:        ${AUTO_TAG_REF} -> ${TARGET_REF}"
+            fi
+            echo ""
           done
 
   notify:

--- a/derivatives/pytorch/Dockerfile.extend
+++ b/derivatives/pytorch/Dockerfile.extend
@@ -1,0 +1,13 @@
+# Placeholder extend Dockerfile for PyTorch images.
+#
+# Dockerfile.extend is invoked by the Extend PyTorch workflow to layer
+# last-minute changes over an already-promoted pytorch image without a
+# full rebuild. By default it is a no-op — it simply passes the base
+# image through unchanged.
+#
+# When a hotfix is needed, add the required RUN/COPY steps below,
+# push, and trigger the Extend PyTorch workflow. Revert this file to
+# its no-op form after the hotfix has been promoted.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}

--- a/derivatives/pytorch/Dockerfile.multi-torch
+++ b/derivatives/pytorch/Dockerfile.multi-torch
@@ -1,0 +1,27 @@
+# Extend a PyTorch image with supplementary torch venvs.
+# Each additional version gets its own layer and venv at /venv/torch-X.Y.Z
+# The base image's /venv/main is left untouched.
+#
+# Usage:
+#   docker buildx build -f Dockerfile.multi-torch \
+#     --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15 \
+#     --build-arg PYTORCH_BACKEND=cu128 \
+#     -t my-multi-torch .
+
+ARG PYTORCH_BASE
+FROM ${PYTORCH_BASE}
+
+ARG PYTORCH_BACKEND
+ARG TARGETARCH
+
+COPY ./torch-companions.json /tmp/torch-companions.json
+COPY ./install-torch-venv.sh /tmp/install-torch-venv.sh
+
+# Each version is a separate layer for better caching
+RUN /tmp/install-torch-venv.sh 2.9.1 "${PYTORCH_BACKEND}" "${TARGETARCH}"
+RUN /tmp/install-torch-venv.sh 2.7.1 "${PYTORCH_BACKEND}" "${TARGETARCH}"
+
+RUN rm -f /tmp/install-torch-venv.sh /tmp/torch-companions.json
+
+# Refresh environment hash
+RUN env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/a1111/Dockerfile
+++ b/derivatives/pytorch/derivatives/a1111/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=robatvastai/pytorch:multi-210-291-271-cu128
+ARG PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/aio-studio/README.md
+++ b/derivatives/pytorch/derivatives/aio-studio/README.md
@@ -155,7 +155,7 @@ All build arguments have sensible defaults. Override as needed:
 
 ```bash
 docker buildx build \
-    --build-arg PYTORCH_BASE=robatvastai/pytorch:multi-210-291-271-cu128 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-04-15 \
     --build-arg COMFYUI_REF=v0.18.1 \
     -t yournamespace/aio-studio .
 ```
@@ -164,7 +164,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `robatvastai/pytorch:multi-210-291-271-cu128` | PyTorch base image (multi-torch: 2.10, 2.9.1, 2.7.1) |
+| `PYTORCH_BASE` | `vastai/pytorch:multi-210-291-271-2026-04-15` | PyTorch base image (multi-torch: 2.10, 2.9.1, 2.7.1) |
 | `COMFYUI_REPO` | `https://github.com/Comfy-Org/ComfyUI` | ComfyUI repository |
 | `COMFYUI_REF` | `v0.18.1` | ComfyUI git ref |
 | `FORGE_REPO` | `https://github.com/Haoming02/sd-webui-forge-classic` | SD Forge repository |

--- a/derivatives/pytorch/derivatives/comfyui/Dockerfile
+++ b/derivatives/pytorch/derivatives/comfyui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fooocus/Dockerfile
+++ b/derivatives/pytorch/derivatives/fooocus/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/invokeai/Dockerfile
+++ b/derivatives/pytorch/derivatives/invokeai/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
+++ b/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/Dockerfile
+++ b/derivatives/pytorch/derivatives/oobabooga/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/sd-forge/Dockerfile
+++ b/derivatives/pytorch/derivatives/sd-forge/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/swarmui/Dockerfile
+++ b/derivatives/pytorch/derivatives/swarmui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-03-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15
 FROM ${PYTORCH_BASE}
 
 LABEL org.opencontainers.image.source="https://github.com/vastai/"

--- a/derivatives/pytorch/derivatives/unsloth-studio/README.md
+++ b/derivatives/pytorch/derivatives/unsloth-studio/README.md
@@ -78,7 +78,7 @@ The following patches are applied at build time:
 cd base-image/derivatives/pytorch/derivatives/unsloth-studio
 
 docker buildx build \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-03-19 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15 \
     -t yournamespace/unsloth-studio .
 ```
 
@@ -86,7 +86,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-03-19` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15` | PyTorch mini base image |
 
 ## Licenses
 

--- a/derivatives/pytorch/install-torch-venv.sh
+++ b/derivatives/pytorch/install-torch-venv.sh
@@ -9,8 +9,11 @@ TARGETARCH="$3"
 VENV="/venv/torch-${TORCH_VER}"
 
 echo "=== Creating venv for torch ${TORCH_VER} at ${VENV} ==="
-/opt/miniforge3/bin/conda create -p "${VENV}" \
-    python="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" -y
+# Match the python minor version of /venv/main so the extra torch
+# venv stays aligned with the base image's primary python, not
+# whatever python3 happens to resolve to on PATH.
+PY_MINOR=$(/venv/main/bin/python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+/opt/miniforge3/bin/conda create -p "${VENV}" python="${PY_MINOR}" -y
 
 # Look up pinned companion versions, filtering amd64-only packages on other arches
 COMPANIONS=$(jq -r --arg v "${TORCH_VER}" --arg arch "${TARGETARCH}" \

--- a/derivatives/pytorch/install-torch-venv.sh
+++ b/derivatives/pytorch/install-torch-venv.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Install a pinned torch version into a new conda venv.
+# Usage: install-torch-venv.sh <torch_version> <backend> <targetarch>
+set -euo pipefail
+
+TORCH_VER="$1"
+PYTORCH_BACKEND="$2"
+TARGETARCH="$3"
+VENV="/venv/torch-${TORCH_VER}"
+
+echo "=== Creating venv for torch ${TORCH_VER} at ${VENV} ==="
+/opt/miniforge3/bin/conda create -p "${VENV}" \
+    python="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" -y
+
+# Look up pinned companion versions, filtering amd64-only packages on other arches
+COMPANIONS=$(jq -r --arg v "${TORCH_VER}" --arg arch "${TARGETARCH}" \
+    'if .[$v] == null then error("version not found") else . end |
+     (.[$v].amd64_only // []) as $excl |
+     .[$v].packages | to_entries |
+     if $arch != "amd64" then map(select(.key as $k | $excl | index($k) | not)) else . end |
+     map(.key + "==" + .value) | .[]' \
+    /tmp/torch-companions.json | tr '\n' ' ')
+
+PACKAGES="torch==${TORCH_VER} ${COMPANIONS}"
+echo "Installing: ${PACKAGES}"
+uv pip install --no-cache-dir --python "${VENV}/bin/python" ${PACKAGES} --torch-backend "${PYTORCH_BACKEND}"
+
+# Add activate script matching /venv/main pattern
+sed "s|realpath /venv/main|realpath ${VENV}|" /venv/main/bin/activate > "${VENV}/bin/activate"
+
+# Verify versions
+"${VENV}/bin/python" -c "import torch; assert torch.__version__.startswith('${TORCH_VER}'), f'torch: expected ${TORCH_VER}, got {torch.__version__}'"
+for spec in ${COMPANIONS}; do
+    pkg="${spec%%==*}" && ver="${spec#*==}"
+    actual=$("${VENV}/bin/python" -c "from importlib.metadata import version; print(version('${pkg}'))")
+    [[ "${actual}" == "${ver}"* ]] || { echo "${pkg}: expected ${ver}, got ${actual}" && exit 1; }
+    echo "${pkg}==${actual} OK"
+done
+
+/opt/miniforge3/bin/conda clean -ay
+echo "=== torch ${TORCH_VER} installed at ${VENV} ==="


### PR DESCRIPTION
## Summary
- Harden base-image and PyTorch extend/promote workflows: decouple `extend-mini` from `merge-manifests` so `FILTER=mini` runs no longer cascade-skip, add a pre-flight pass that verifies every planned staging source before any prod write, and replace the single-pass auto-tag create with a two-phase dance that picks a per-tag anchor whose resolved digest differs from both the current and intended content. Dry-runs now log into the registry, mirror the pre-flight, and print the full per-tag resolution.
- Wire multi-torch variants into both `build-pytorch.yml` and `promote-pytorch.yml` via a new `ALL_MULTI_CONFIGS` list (only `multi-210-291-271` cu128 py312 for now; appending a line adds future variants). Build gets `build-multi` / `merge-multi-manifests` layering on top of the freshly-built mini; promote produces per-python dated prod tags, a dated default-python alias, and a no-date latest alias. `FILTER=mini` also matches multi since multi layers on the mini base.
- Add `derivatives/pytorch/Dockerfile.multi-torch` (was untracked locally) and a no-op placeholder `derivatives/pytorch/Dockerfile.extend` the Extend PyTorch workflow can target without needing hotfix content.
- Bump every pytorch derivative Dockerfile + unsloth-studio README `PYTORCH_BASE` from 2026-03-19/26 to 2026-04-15. Update aio-studio to the new canonical multi-torch ref (`vastai/pytorch:multi-210-291-271-2026-04-15`, dropping the `-cu128` suffix and the staging namespace).

## Test plan
- [ ] `Extend Base Image` dry-run with `FILTER=mini` — extend-mini matrix is no longer skipped.
- [ ] `Promote Base Image` dry-run — pre-flight reports every staging source, auto-tag dance prints current/final/anchor digests for every `cuda-*-auto` tag.
- [ ] `Extend PyTorch` dry-run with `FILTER=mini` — extend-mini matrix populated, mini cascade bug gone.
- [ ] `Promote PyTorch` dry-run with `FILTER=mini` — pre-flight covers mini + multi sources, auto-tag dance resolves for every cuda-*-auto, Multi-torch Promotions section prints dated/alias/latest targets.
- [ ] `Build PyTorch` dry-run — Multi-torch Builds section shows the multi-210-291-271 config.
- [ ] Downstream pytorch derivative builds pick up the new 2026-04-15 mini base refs without error.
- [ ] aio-studio base build uses the new multi-torch ref.