### PR TITLE
Replace uv sync/run with uv pip install for ACE Step

### DIFF
--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -34,6 +34,7 @@ RUN \
         acestep/llm_inference.py && \
     # Strip torch ecosystem deps — provided by the base venv
     sed -i '/^[[:space:]]*"torch[>=<;",]/d; /^[[:space:]]*"torchvision[>=<;",]/d; /^[[:space:]]*"torchaudio[>=<;",]/d; /^[[:space:]]*"torchcodec[>=<;",]/d' pyproject.toml && \
+    uv pip install --no-cache-dir hatchling && \
     uv pip install --no-cache-dir --no-build-isolation ./acestep/third_parts/nano-vllm . && \
     # UI is not aware of the correct venv path and looks up this dir for python
     ln -s /venv/main .venv && \

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -33,12 +33,14 @@ RUN \
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
     # Pin torch ecosystem to versions from the base venv
-    torch_ver=$(python -c "import torch; print(torch.__version__)") && \
-    tv_ver=$(python -c "import torchvision; print(torchvision.__version__)") && \
-    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__)") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__)" 2>/dev/null || true) && \
+    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
+    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
     sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
+    sed -i '/^\[\[tool\.uv\.index\]\]/,/^$/d' pyproject.toml && \
+    sed -i '/^torch = \[$/,/^\]$/d; /^torchvision = \[$/,/^\]$/d; /^torchaudio = \[$/,/^\]$/d' pyproject.toml && \
     tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
     sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/main uv sync && \

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -32,18 +32,9 @@ RUN \
     # Blackwell (compute >= 12) fix: CUDA graph capture fails in nanovllm
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
-    # Pin torch ecosystem to versions from the base venv
-    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
-    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
-    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
-    sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
-    sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
-    sed -i '/^\[\[tool\.uv\.index\]\]/,/^$/d' pyproject.toml && \
-    sed -i '/^torch = \[$/,/^\]$/d; /^torchvision = \[$/,/^\]$/d; /^torchaudio = \[$/,/^\]$/d' pyproject.toml && \
-    tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
-    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
-    UV_PROJECT_ENVIRONMENT=/venv/main uv sync && \
+    # Strip torch ecosystem deps — provided by the base venv
+    sed -i '/^[[:space:]]*"torch[>=<;",]/d; /^[[:space:]]*"torchvision[>=<;",]/d; /^[[:space:]]*"torchaudio[>=<;",]/d; /^[[:space:]]*"torchcodec[>=<;",]/d' pyproject.toml && \
+    uv pip install --no-cache-dir --no-build-isolation ./acestep/third_parts/nano-vllm . && \
     # UI is not aware of the correct venv path and looks up this dir for python
     ln -s /venv/main .venv && \
     # Clone and install ace-step-ui

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -32,6 +32,13 @@ RUN \
     # Blackwell (compute >= 12) fix: CUDA graph capture fails in nanovllm
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
+    # Pin torch ecosystem to versions from the base venv
+    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
+    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])") && \
+    sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
+    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",\n    \"torchcodec==${tc_ver}\",|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/main uv sync && \
     # UI is not aware of the correct venv path and looks up this dir for python
     ln -s /venv/main .venv && \

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -38,6 +38,7 @@ RUN \
     ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
     tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
+    sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
     tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
     sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/main uv sync && \

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -33,10 +33,10 @@ RUN \
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
     # Pin torch ecosystem to versions from the base venv
-    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
-    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
-    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
+    torch_ver=$(python -c "import torch; print(torch.__version__)") && \
+    tv_ver=$(python -c "import torchvision; print(torchvision.__version__)") && \
+    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__)") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__)" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
     sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
     tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -36,9 +36,10 @@ RUN \
     torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
     tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
     ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
-    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",\n    \"torchcodec==${tc_ver}\",|" pyproject.toml && \
+    tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
+    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/main uv sync && \
     # UI is not aware of the correct venv path and looks up this dir for python
     ln -s /venv/main .venv && \

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -34,6 +34,13 @@ RUN \
         acestep/llm_inference.py && \
     # Strip torch ecosystem deps — provided by the base venv
     sed -i '/^[[:space:]]*"torch[>=<;",]/d; /^[[:space:]]*"torchvision[>=<;",]/d; /^[[:space:]]*"torchaudio[>=<;",]/d; /^[[:space:]]*"torchcodec[>=<;",]/d' pyproject.toml && \
+    # Fail loudly if upstream pyproject formatting changes and the strip misses a dep —
+    # silent passthrough would let uv pip install clobber the base venv's torch stack
+    if grep -qE '^[[:space:]]*"(torch|torchvision|torchaudio|torchcodec)([^A-Za-z0-9_-]|$)' pyproject.toml; then \
+        echo "ERROR: torch ecosystem deps still present in pyproject.toml after strip:" >&2; \
+        grep -nE '^[[:space:]]*"(torch|torchvision|torchaudio|torchcodec)' pyproject.toml >&2; \
+        exit 1; \
+    fi && \
     uv pip install --no-cache-dir hatchling && \
     uv pip install --no-cache-dir --no-build-isolation ./acestep/third_parts/nano-vllm . && \
     # UI is not aware of the correct venv path and looks up this dir for python

--- a/derivatives/pytorch/derivatives/ace-step/ROOT/opt/supervisor-scripts/ace-step-api.sh
+++ b/derivatives/pytorch/derivatives/ace-step/ROOT/opt/supervisor-scripts/ace-step-api.sh
@@ -16,4 +16,4 @@ done
 echo "Starting ACE Step API"
 
 cd "${WORKSPACE}/ACE-Step-1.5"
-UV_PROJECT_ENVIRONMENT=/venv/main pty uv run acestep-api --port 8001
+UV_PROJECT_ENVIRONMENT=/venv/main pty uv run --no-sync acestep-api --port 8001

--- a/derivatives/pytorch/derivatives/ace-step/ROOT/opt/supervisor-scripts/ace-step-api.sh
+++ b/derivatives/pytorch/derivatives/ace-step/ROOT/opt/supervisor-scripts/ace-step-api.sh
@@ -16,4 +16,4 @@ done
 echo "Starting ACE Step API"
 
 cd "${WORKSPACE}/ACE-Step-1.5"
-UV_PROJECT_ENVIRONMENT=/venv/main pty uv run --no-sync acestep-api --port 8001
+pty acestep-api --port 8001

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -211,10 +211,10 @@ RUN \
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
     # Pin torch ecosystem to versions from the base venv
-    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
-    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
-    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
+    torch_ver=$(python -c "import torch; print(torch.__version__)") && \
+    tv_ver=$(python -c "import torchvision; print(torchvision.__version__)") && \
+    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__)") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__)" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
     sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
     tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -214,9 +214,10 @@ RUN \
     torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
     tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
     ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
-    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",\n    \"torchcodec==${tc_ver}\",|" pyproject.toml && \
+    tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
+    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/ace-step uv sync && \
     uv pip install --no-cache-dir bitsandbytes && \
     # UI looks for .venv in the project root

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -216,6 +216,7 @@ RUN \
     ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
     tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
+    sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
     tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
     sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/ace-step uv sync && \

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -212,6 +212,13 @@ RUN \
         acestep/llm_inference.py && \
     # Strip torch ecosystem deps — provided by the base venv
     sed -i '/^[[:space:]]*"torch[>=<;",]/d; /^[[:space:]]*"torchvision[>=<;",]/d; /^[[:space:]]*"torchaudio[>=<;",]/d; /^[[:space:]]*"torchcodec[>=<;",]/d' pyproject.toml && \
+    # Fail loudly if upstream pyproject formatting changes and the strip misses a dep —
+    # silent passthrough would let uv pip install clobber the base venv's torch stack
+    if grep -qE '^[[:space:]]*"(torch|torchvision|torchaudio|torchcodec)([^A-Za-z0-9_-]|$)' pyproject.toml; then \
+        echo "ERROR: torch ecosystem deps still present in pyproject.toml after strip:" >&2; \
+        grep -nE '^[[:space:]]*"(torch|torchvision|torchaudio|torchcodec)' pyproject.toml >&2; \
+        exit 1; \
+    fi && \
     uv pip install --no-cache-dir hatchling && \
     uv pip install --no-cache-dir --no-build-isolation ./acestep/third_parts/nano-vllm . && \
     uv pip install --no-cache-dir bitsandbytes && \

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -210,18 +210,9 @@ RUN \
     # Blackwell (compute >= 12) fix: CUDA graph capture fails in nanovllm
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
-    # Pin torch ecosystem to versions from the base venv
-    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
-    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
-    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
-    sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
-    sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
-    sed -i '/^\[\[tool\.uv\.index\]\]/,/^$/d' pyproject.toml && \
-    sed -i '/^torch = \[$/,/^\]$/d; /^torchvision = \[$/,/^\]$/d; /^torchaudio = \[$/,/^\]$/d' pyproject.toml && \
-    tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
-    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
-    UV_PROJECT_ENVIRONMENT=/venv/ace-step uv sync && \
+    # Strip torch ecosystem deps — provided by the base venv
+    sed -i '/^[[:space:]]*"torch[>=<;",]/d; /^[[:space:]]*"torchvision[>=<;",]/d; /^[[:space:]]*"torchaudio[>=<;",]/d; /^[[:space:]]*"torchcodec[>=<;",]/d' pyproject.toml && \
+    uv pip install --no-cache-dir --no-build-isolation ./acestep/third_parts/nano-vllm . && \
     uv pip install --no-cache-dir bitsandbytes && \
     # UI looks for .venv in the project root
     ln -s /venv/ace-step .venv && \

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -211,12 +211,14 @@ RUN \
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
     # Pin torch ecosystem to versions from the base venv
-    torch_ver=$(python -c "import torch; print(torch.__version__)") && \
-    tv_ver=$(python -c "import torchvision; print(torchvision.__version__)") && \
-    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__)") && \
-    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__)" 2>/dev/null || true) && \
+    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
+    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])" 2>/dev/null || true) && \
     sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
     sed -i '/^required-environments/,/^\]/d' pyproject.toml && \
+    sed -i '/^\[\[tool\.uv\.index\]\]/,/^$/d' pyproject.toml && \
+    sed -i '/^torch = \[$/,/^\]$/d; /^torchvision = \[$/,/^\]$/d; /^torchaudio = \[$/,/^\]$/d' pyproject.toml && \
     tc_pin="" && [ -n "${tc_ver}" ] && tc_pin="\n    \"torchcodec==${tc_ver}\"," && \
     sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",${tc_pin}|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/ace-step uv sync && \

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -212,6 +212,7 @@ RUN \
         acestep/llm_inference.py && \
     # Strip torch ecosystem deps — provided by the base venv
     sed -i '/^[[:space:]]*"torch[>=<;",]/d; /^[[:space:]]*"torchvision[>=<;",]/d; /^[[:space:]]*"torchaudio[>=<;",]/d; /^[[:space:]]*"torchcodec[>=<;",]/d' pyproject.toml && \
+    uv pip install --no-cache-dir hatchling && \
     uv pip install --no-cache-dir --no-build-isolation ./acestep/third_parts/nano-vllm . && \
     uv pip install --no-cache-dir bitsandbytes && \
     # UI looks for .venv in the project root

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -210,6 +210,13 @@ RUN \
     # Blackwell (compute >= 12) fix: CUDA graph capture fails in nanovllm
     sed -i 's/enforce_eager_for_vllm = bool(is_rocm or is_jetson)/is_blackwell = False\n            try:\n                cc = torch.cuda.get_device_capability()\n                is_blackwell = cc[0] >= 12\n            except Exception:\n                pass\n            enforce_eager_for_vllm = bool(is_rocm or is_jetson or is_blackwell)/' \
         acestep/llm_inference.py && \
+    # Pin torch ecosystem to versions from the base venv
+    torch_ver=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+    tv_ver=$(python -c "import torchvision; print(torchvision.__version__.split('+')[0])") && \
+    ta_ver=$(python -c "import torchaudio; print(torchaudio.__version__.split('+')[0])") && \
+    tc_ver=$(python -c "import torchcodec; print(torchcodec.__version__.split('+')[0])") && \
+    sed -i '/^[[:space:]]*"torch\(vision\|audio\|codec\)\{0,1\}[>=<;",]/d' pyproject.toml && \
+    sed -i "s|^dependencies = \[|dependencies = [\n    \"torch==${torch_ver}\",\n    \"torchvision==${tv_ver}\",\n    \"torchaudio==${ta_ver}\",\n    \"torchcodec==${tc_ver}\",|" pyproject.toml && \
     UV_PROJECT_ENVIRONMENT=/venv/ace-step uv sync && \
     uv pip install --no-cache-dir bitsandbytes && \
     # UI looks for .venv in the project root

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
@@ -18,7 +18,7 @@ export ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:=acestep-5Hz-lm-4B}
 # Start ACE Step API in background
 echo "Starting ACE Step API..."
 cd "${WORKSPACE}/ACE-Step-1.5"
-UV_PROJECT_ENVIRONMENT=/venv/ace-step uv run --no-sync acestep-api --port 8001 &
+pty acestep-api --port 8001 &
 API_PID=$!
 trap "kill $API_PID 2>/dev/null" EXIT
 

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
@@ -18,7 +18,7 @@ export ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:=acestep-5Hz-lm-4B}
 # Start ACE Step API in background
 echo "Starting ACE Step API..."
 cd "${WORKSPACE}/ACE-Step-1.5"
-UV_PROJECT_ENVIRONMENT=/venv/ace-step uv run acestep-api --port 8001 &
+UV_PROJECT_ENVIRONMENT=/venv/ace-step uv run --no-sync acestep-api --port 8001 &
 API_PID=$!
 trap "kill $API_PID 2>/dev/null" EXIT
 

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
@@ -18,13 +18,11 @@ export ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:=acestep-5Hz-lm-4B}
 # Start ACE Step API in background
 echo "Starting ACE Step API..."
 cd "${WORKSPACE}/ACE-Step-1.5"
-(pty acestep-api --port 8001) &
+pty acestep-api --port 8001 &
 API_PID=$!
-trap "kill -- -$API_PID 2>/dev/null" EXIT
 
 # Wait for ACE Step API to be ready
 until (curl -s -o /dev/null -w '%{http_code}' http://localhost:8001/docs || echo "000") | grep -q 200; do
-    # Check if API process is still alive
     if ! kill -0 $API_PID 2>/dev/null; then
         echo "ACE Step API process died unexpectedly"
         exit 1

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
@@ -18,9 +18,9 @@ export ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:=acestep-5Hz-lm-4B}
 # Start ACE Step API in background
 echo "Starting ACE Step API..."
 cd "${WORKSPACE}/ACE-Step-1.5"
-pty acestep-api --port 8001 &
+(pty acestep-api --port 8001) &
 API_PID=$!
-trap "kill $API_PID 2>/dev/null" EXIT
+trap "kill -- -$API_PID 2>/dev/null" EXIT
 
 # Wait for ACE Step API to be ready
 until (curl -s -o /dev/null -w '%{http_code}' http://localhost:8001/docs || echo "000") | grep -q 200; do

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
@@ -18,7 +18,7 @@ export ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:=acestep-5Hz-lm-4B}
 # Start ACE Step API in background
 echo "Starting ACE Step API..."
 cd "${WORKSPACE}/ACE-Step-1.5"
-pty acestep-api --port 8001 &
+(pty acestep-api --port 8001) &
 API_PID=$!
 
 # Wait for ACE Step API to be ready

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT/opt/supervisor-scripts/ace-step.sh
@@ -18,7 +18,7 @@ export ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:=acestep-5Hz-lm-4B}
 # Start ACE Step API in background
 echo "Starting ACE Step API..."
 cd "${WORKSPACE}/ACE-Step-1.5"
-(pty acestep-api --port 8001) &
+acestep-api --port 8001 &
 API_PID=$!
 
 # Wait for ACE Step API to be ready


### PR DESCRIPTION
## Summary
- `uv sync` resolves dependencies across all platforms declared in the upstream pyproject.toml, causing repeated failures for packages without cross-platform wheels (torchcodec, torchaudio).
- Replace `uv sync` with `uv pip install` which resolves only for the build platform. Strip torch ecosystem deps from pyproject.toml since they are provided by the base venv.
- At runtime, call `acestep-api` directly instead of via `uv run` since the venv is already activated.

## Test plan
- [x] Build standalone ace-step image successfully
- [ ] Build aio-studio image and confirm ACE Step component installs correctly
- [ ] Start an aio-studio instance and confirm the ACE Step API comes up without torch packages being clobbered
- [ ] Start the standalone ace-step image and confirm the same