### PR TITLE
Add inference serving tests for sglang and llama.cpp

### DIFF
--- a/derivatives/llama-cpp/Dockerfile
+++ b/derivatives/llama-cpp/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312
+ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-04-15
 
 FROM ${BASE_IMAGE}
 ARG BASE_IMAGE

--- a/derivatives/llama-cpp/ROOT/opt/instance-tools/tests/llama.d/10-llama-serving.sh
+++ b/derivatives/llama-cpp/ROOT/opt/instance-tools/tests/llama.d/10-llama-serving.sh
@@ -1,0 +1,369 @@
+#!/bin/bash
+# Test: llama.cpp serving pipeline — service, API readiness, and inference.
+# TEST_TIMEOUT=7200
+source "$(dirname "$0")/../lib.sh"
+
+# ── Constants ────────────────────────────────────────────────────────
+LLAMA_INTERNAL_PORT=18000         # llama-server listens here (localhost); Caddy proxies 8000 with auth
+LLAMA_LOG="/var/log/llama.log"
+HEALTH_TIMEOUT="${LLAMA_HEALTH_TIMEOUT:-3600}"  # 1 hour for model download + load
+MAX_RESTARTS=2                                  # fail after this many supervisor restarts (crash loop)
+
+# ── Skip if llama.cpp is not configured ──────────────────────────────
+
+[[ -n "${LLAMA_MODEL:-}" ]] || test_skip "LLAMA_MODEL not set"
+echo "  LLAMA_MODEL=${LLAMA_MODEL}"
+echo "  LLAMA_ARGS=${LLAMA_ARGS:-<empty>}"
+
+# Flag the llama.sh wrapper quirk: ${LLAMA_ARGS:---port 18000} means that
+# if LLAMA_ARGS is set at all, the default --port 18000 is *not* added.
+# Operators who set LLAMA_ARGS without --port end up on port 8080 and
+# this test's /health probe on 18000 will time out.
+if [[ -n "${LLAMA_ARGS:-}" && ! "$LLAMA_ARGS" =~ --port ]]; then
+    echo "  hint: LLAMA_ARGS is set without --port; llama-server will bind to its default (8080), not ${LLAMA_INTERNAL_PORT}"
+fi
+
+# ── Helper: check if PORTAL_CONFIG has an entry whose label matches ──
+
+portal_config_has() {
+    local pattern="$1"
+    [[ -n "${PORTAL_CONFIG:-}" ]] && echo "$PORTAL_CONFIG" | tr '|' '\n' | grep -qiE "$pattern"
+}
+
+# ── llama service ────────────────────────────────────────────────────
+
+echo ""
+echo "  -- llama --"
+
+assert_service_running llama
+echo "  llama: supervisor service running"
+
+# Check for early fatal errors in the log before waiting for the API.
+if [[ -f "$LLAMA_LOG" ]]; then
+    fatal_patterns="Traceback|CUDA out of memory|RuntimeError:|OSError:|ValueError:|Failed to|Cannot find|error loading model"
+    early_errors=$(head -100 "$LLAMA_LOG" | grep -cE "$fatal_patterns" || true)
+    if [[ "$early_errors" -gt 0 ]]; then
+        echo "  WARN: ${early_errors} potential error(s) in early llama log — may be transient"
+        head -100 "$LLAMA_LOG" | grep -E "$fatal_patterns" | head -5 | sed 's/^/    /'
+    fi
+fi
+
+# ── Wait for llama API health ────────────────────────────────────────
+
+echo ""
+echo "  -- api health --"
+
+HEALTH_URL="http://127.0.0.1:${LLAMA_INTERNAL_PORT}/health"
+elapsed=0
+healthy=false
+last_report=0
+restart_count=0
+last_pid=""
+
+last_pid=$(supervisorctl status llama 2>/dev/null | grep -oP 'pid \K[0-9]+' || true)
+
+_dump_log_tail() {
+    if [[ -f "$LLAMA_LOG" ]]; then
+        echo "  last 10 lines of llama log:"
+        tail -10 "$LLAMA_LOG" | sed 's/^/    /'
+    fi
+}
+
+while (( elapsed < HEALTH_TIMEOUT )); do
+    status=$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' "$HEALTH_URL" 2>/dev/null)
+    if [[ "$status" == "200" ]]; then
+        healthy=true
+        break
+    fi
+
+    sup_line=$(supervisorctl status llama 2>/dev/null)
+    llama_sup_state=$(echo "$sup_line" | awk '{print $2}')
+    cur_pid=$(echo "$sup_line" | grep -oP 'pid \K[0-9]+' || true)
+
+    if [[ "$llama_sup_state" == "FATAL" ]]; then
+        echo "  llama entered FATAL state — supervisor gave up restarting"
+        _dump_log_tail
+        test_fail "llama service FATAL (supervisor stopped restarting)"
+    fi
+
+    if [[ "$llama_sup_state" != "RUNNING" && "$llama_sup_state" != "STARTING" ]]; then
+        echo "  llama service in state: ${llama_sup_state}"
+        _dump_log_tail
+        test_fail "llama service not running (state: ${llama_sup_state})"
+    fi
+
+    if [[ -n "$last_pid" && -n "$cur_pid" && "$cur_pid" != "$last_pid" ]]; then
+        restart_count=$((restart_count + 1))
+        echo "  llama restarted (pid ${last_pid} → ${cur_pid}, restart #${restart_count})"
+        _dump_log_tail
+        if (( restart_count >= MAX_RESTARTS )); then
+            test_fail "llama crash loop: ${restart_count} restarts detected (bad config or OOM?)"
+        fi
+    fi
+    last_pid="$cur_pid"
+
+    if (( elapsed - last_report >= 30 )); then
+        last_report=$elapsed
+        log_size=$(stat -c '%s' "$LLAMA_LOG" 2>/dev/null || echo "0")
+        echo "  [${elapsed}s] waiting for /health (log=${log_size}B, http=${status}, restarts=${restart_count})"
+    fi
+
+    sleep 5
+    elapsed=$((elapsed + 5))
+done
+
+if ! $healthy; then
+    echo "  llama API did not become healthy within ${HEALTH_TIMEOUT}s"
+    if [[ -f "$LLAMA_LOG" ]]; then
+        echo "  last 15 lines of llama log:"
+        tail -15 "$LLAMA_LOG" | sed 's/^/    /'
+    fi
+    test_fail "llama API /health not reachable after ${HEALTH_TIMEOUT}s"
+fi
+
+echo "  llama API healthy after ${elapsed}s (${restart_count} restart(s))"
+
+# ── Verify /v1/models ────────────────────────────────────────────────
+
+echo ""
+echo "  -- model verification --"
+
+models_json=$(curl -sf --max-time 10 "http://127.0.0.1:${LLAMA_INTERNAL_PORT}/v1/models" 2>/dev/null)
+if [[ -z "$models_json" ]]; then
+    fail_later "v1-models" "/v1/models returned empty response"
+else
+    model_info=$(echo "$models_json" | python3 -c "
+import sys, json, os
+d = json.load(sys.stdin)
+models = d.get('data', [])
+print(len(models))
+for m in models:
+    print(m.get('id', '?'))
+want = os.environ.get('LLAMA_MODEL', '')
+ids = [m.get('id', '') for m in models]
+found = any(want in mid or mid in want for mid in ids)
+print('found' if found else 'missing')
+" 2>/dev/null)
+
+    count=$(echo "$model_info" | head -1)
+    match=$(echo "$model_info" | tail -1)
+
+    if [[ "${count:-0}" -gt 0 ]]; then
+        echo "  /v1/models: ${count} model(s) loaded"
+        echo "$model_info" | sed '1d;$d' | sed 's/^/    /'
+    else
+        fail_later "v1-models-empty" "/v1/models returned 0 models"
+    fi
+
+    # llama-server reports its own model id (often derived from the GGUF
+    # filename), so a verbatim match against the HF repo in LLAMA_MODEL
+    # is informational only.
+    if [[ "$match" == "found" ]]; then
+        echo "  LLAMA_MODEL found in /v1/models"
+    else
+        echo "  WARN: LLAMA_MODEL '${LLAMA_MODEL}' not found verbatim in /v1/models (llama-server typically reports the GGUF filename)"
+    fi
+fi
+
+# ── Log error check ──────────────────────────────────────────────────
+
+echo ""
+echo "  -- log analysis --"
+
+check_log_errors() {
+    local label="$1" path="$2" exclude="${3:-}"
+    [[ -f "$path" ]] || return 0
+    local error_lines
+    if [[ -n "$exclude" ]]; then
+        error_lines=$(grep -P "\b(ERROR|CRITICAL)\b" "$path" 2>/dev/null \
+            | grep -vE "$exclude" || true)
+    else
+        error_lines=$(grep -P "\b(ERROR|CRITICAL)\b" "$path" 2>/dev/null || true)
+    fi
+    local error_count
+    error_count=$(echo "$error_lines" | grep -c . 2>/dev/null || true)
+    if [[ "$error_count" -gt 0 ]]; then
+        echo "  ${error_count} ERROR/CRITICAL line(s) in ${label} log:"
+        echo "$error_lines" | tail -5 | sed 's/^/    /'
+        fail_later "${label}-log-errors" "${error_count} ERROR/CRITICAL line(s) in ${label} log"
+    else
+        echo "  ${label} log clean"
+    fi
+}
+
+if [[ -f "$LLAMA_LOG" ]]; then
+    log_size=$(stat -c '%s' "$LLAMA_LOG" 2>/dev/null || echo "0")
+    echo "  llama log: ${log_size}B"
+fi
+
+check_log_errors "llama" "$LLAMA_LOG" "deprecat"
+
+# ── Port exposure check ──────────────────────────────────────────────
+
+echo ""
+echo "  -- port exposure --"
+
+declare -A PORT_CHECKS=(
+    ["llama"]="8000:Llama.cpp UI:llama"
+)
+
+if is_serverless; then
+    echo "  skip: port exposure checks (caddy not running in serverless)"
+else
+    for key in "${!PORT_CHECKS[@]}"; do
+        IFS=: read -r port label pattern <<< "${PORT_CHECKS[$key]}"
+        if portal_config_has "$pattern"; then
+            if ss -tln | grep -q ":${port} "; then
+                echo "  ${label}: listening on port ${port}"
+            else
+                fail_later "port-${port}" "${label} in PORTAL_CONFIG but port ${port} not listening"
+            fi
+        else
+            echo "  skip: ${label} (not in PORTAL_CONFIG)"
+        fi
+    done
+fi
+
+# ── Inference check ──────────────────────────────────────────────────
+# LLAMA_TEST_ENDPOINT controls inference testing:
+#   "chat"  (default) — test via /v1/chat/completions
+#   "none"  — skip inference test (for embedding/reranker models)
+
+echo ""
+echo "  -- inference --"
+
+LLAMA_TEST_ENDPOINT="${LLAMA_TEST_ENDPOINT:-chat}"
+case "$LLAMA_TEST_ENDPOINT" in
+    chat|none) ;;
+    *) test_fail "unsupported LLAMA_TEST_ENDPOINT='${LLAMA_TEST_ENDPOINT}' (must be 'chat' or 'none')" ;;
+esac
+LLAMA_API="http://127.0.0.1:${LLAMA_INTERNAL_PORT}"
+# Use the model ID that llama-server is actually serving (from /v1/models)
+SERVED_MODEL=$(curl -sf --max-time 10 "${LLAMA_API}/v1/models" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['data'][0]['id'])" 2>/dev/null)
+SERVED_MODEL="${SERVED_MODEL:-${LLAMA_MODEL}}"
+
+if [[ "${LLAMA_TEST_ENDPOINT}" == "none" ]]; then
+    echo "  inference test skipped (LLAMA_TEST_ENDPOINT=none)"
+else
+    echo "  endpoint: ${LLAMA_TEST_ENDPOINT} (/v1/chat/completions)"
+    echo "  model: ${SERVED_MODEL}"
+
+    # Warmup: /health goes green before the engine is fully warm (model
+    # load finish, KV cache cold, CUDA autotune on first batch). Send a
+    # throwaway request so the scored prompts run on a hot server.
+    # Failures here are tolerated — the scored loop is what we judge on.
+    warmup_body=$(mktemp)
+    warmup_code=$(curl -s --max-time 300 -o "$warmup_body" -w '%{http_code}' \
+        "${LLAMA_API}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "$(python3 -c "
+import json, sys
+print(json.dumps({
+    'model': sys.argv[1],
+    'messages': [{'role': 'user', 'content': 'hi'}],
+    'temperature': 0.1,
+    'max_tokens': 8
+}))
+" "$SERVED_MODEL")" 2>/dev/null)
+    rm -f "$warmup_body"
+    echo "  warmup: HTTP ${warmup_code}"
+
+    declare -a PROMPTS=(
+        "Say hello in one sentence."
+        "What is 2+2? Reply with just the number."
+        "Write a haiku about computers."
+    )
+    inference_pass=0
+    inference_fail=0
+
+    for i in "${!PROMPTS[@]}"; do
+        prompt="${PROMPTS[$i]}"
+        echo ""
+        echo "  request $((i+1))/${#PROMPTS[@]}: ${prompt}"
+
+        http_body=$(mktemp)
+        http_code=$(curl -s --max-time 180 -o "$http_body" -w '%{http_code}' \
+            "${LLAMA_API}/v1/chat/completions" \
+            -H "Content-Type: application/json" \
+            -d "$(python3 -c "
+import json, sys
+print(json.dumps({
+    'model': sys.argv[1],
+    'messages': [{'role': 'user', 'content': sys.argv[2]}],
+    'temperature': 0.1,
+    'max_tokens': 256
+}))
+" "$SERVED_MODEL" "$prompt")" 2>/dev/null)
+        response=$(cat "$http_body")
+        rm -f "$http_body"
+
+        if [[ "$http_code" != "200" ]]; then
+            echo "    FAIL: HTTP ${http_code}"
+            [[ -n "$response" ]] && echo "    body: ${response:0:200}"
+            inference_fail=$((inference_fail + 1))
+            continue
+        fi
+
+        eval "$(echo "$response" | python3 -c "
+import sys, json, shlex
+try:
+    d = json.load(sys.stdin)
+    c = (d.get('choices') or [{}])[0]
+    m = c.get('message', {})
+    content = (m.get('content') or '').strip()
+    reasoning = (m.get('reasoning_content') or m.get('thinking_content') or '').strip()
+    finish = c.get('finish_reason', '?')
+    usage = d.get('usage', {})
+    prompt_tok = usage.get('prompt_tokens', 0)
+    compl_tok = usage.get('completion_tokens', 0)
+    msg = content or reasoning
+    kind = 'content' if content else ('reasoning' if reasoning else 'none')
+    print(f'finish_reason={shlex.quote(str(finish))}')
+    print(f'prompt_tokens={shlex.quote(str(prompt_tok))}')
+    print(f'compl_tokens={shlex.quote(str(compl_tok))}')
+    print(f'content={shlex.quote(msg)}')
+    print(f'content_kind={shlex.quote(kind)}')
+    print(f'parse_ok=true')
+except Exception:
+    print('finish_reason=error prompt_tokens=0 compl_tokens=0 content= content_kind=none parse_ok=false')
+" 2>/dev/null)"
+
+        if [[ "${parse_ok:-false}" != "true" ]]; then
+            echo "    FAIL: malformed response"
+            echo "    raw: ${response:0:200}"
+            inference_fail=$((inference_fail + 1))
+            continue
+        fi
+
+        if (( ${compl_tokens:-0} > 0 )); then
+            if [[ -n "$content" ]]; then
+                display="${content:0:120}"
+                [[ ${#content} -gt 120 ]] && display="${display}..."
+                [[ "$content_kind" == "reasoning" ]] && echo "    (reasoning_content/thinking_content only)"
+                echo "    response: ${display}"
+            else
+                echo "    (no visible content — reasoning/empty output, but inference ran)"
+            fi
+            echo "    tokens: ${prompt_tokens} prompt → ${compl_tokens} completion, finish=${finish_reason}"
+            inference_pass=$((inference_pass + 1))
+        else
+            echo "    FAIL: 0 completion tokens (finish_reason=${finish_reason})"
+            echo "    raw: ${response:0:200}"
+            inference_fail=$((inference_fail + 1))
+        fi
+    done
+
+    echo ""
+    echo "  inference: ${inference_pass}/${#PROMPTS[@]} produced completion tokens, ${inference_fail} failed"
+    if (( inference_pass == 0 )); then
+        fail_later "inference" "no prompts produced completion tokens (${inference_fail}/${#PROMPTS[@]} failed)"
+    elif (( inference_fail > 0 )); then
+        echo "  WARN: ${inference_fail} request(s) failed, but server is serving inference"
+    fi
+fi
+
+# ── Report ───────────────────────────────────────────────────────────
+
+report_failures
+test_pass "llama.cpp serving pipeline verified (model: ${LLAMA_MODEL}, health: ${elapsed}s)"

--- a/external/sglang/Dockerfile
+++ b/external/sglang/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV TCLLIBPATH=/usr/lib/tcltk/default
 ENV PATH=/opt/instance-tools/bin:/opt/sys-venv/shim:${PATH}
+# uv hardlinks break volume sync; force copy (matches vastai/base-image)
+ENV UV_LINK_MODE=copy
 WORKDIR /
 
 COPY --from=base_image_source /ROOT /

--- a/external/sglang/ROOT/opt/instance-tools/tests/sglang.d/10-sglang-serving.sh
+++ b/external/sglang/ROOT/opt/instance-tools/tests/sglang.d/10-sglang-serving.sh
@@ -1,21 +1,19 @@
 #!/bin/bash
-# Test: vLLM serving pipeline — Ray, vLLM service, and API readiness.
+# Test: SGLang serving pipeline — service, API readiness, and inference.
 # TEST_TIMEOUT=7200
 source "$(dirname "$0")/../lib.sh"
 
-# ── Constants (adjust as needed) ──────────────────────────────────────
-VLLM_INTERNAL_PORT=18000          # vLLM listens here (localhost); Caddy proxies 8000 with auth
-VLLM_LOG="/var/log/vllm.log"
-RAY_LOG="/var/log/ray.log"
-HEALTH_TIMEOUT="${VLLM_HEALTH_TIMEOUT:-3600}"  # 1 hour for model loading + graph compilation
-MAX_RESTARTS=2                                  # fail after this many supervisor restarts (crash loop)
+# ── Constants ────────────────────────────────────────────────────────
+SGLANG_INTERNAL_PORT=18000        # SGLang listens here (localhost); Caddy proxies 8000 with auth
+SGLANG_LOG="/var/log/sglang.log"
+HEALTH_TIMEOUT="${SGLANG_HEALTH_TIMEOUT:-3600}"  # 1 hour for model loading + warmup
+MAX_RESTARTS=2                                   # fail after this many supervisor restarts (crash loop)
 
-# ── Skip if vLLM is not configured ──────────────────────────────────
+# ── Skip if SGLang is not configured ─────────────────────────────────
 
-[[ -n "${VLLM_MODEL:-}" ]] || test_skip "VLLM_MODEL not set"
-[[ -n "${VLLM_ARGS+x}" ]] || test_fail "VLLM_ARGS is not set (must be set, even if empty)"
-echo "  VLLM_MODEL=${VLLM_MODEL}"
-echo "  VLLM_ARGS=${VLLM_ARGS:-<empty>}"
+[[ -n "${SGLANG_MODEL:-}" ]] || test_skip "SGLANG_MODEL not set"
+echo "  SGLANG_MODEL=${SGLANG_MODEL}"
+echo "  SGLANG_ARGS=${SGLANG_ARGS:-<empty>}"
 
 # ── Helper: check if PORTAL_CONFIG has an entry whose label matches ──
 
@@ -24,73 +22,43 @@ portal_config_has() {
     [[ -n "${PORTAL_CONFIG:-}" ]] && echo "$PORTAL_CONFIG" | tr '|' '\n' | grep -qiE "$pattern"
 }
 
-# ── Ray service ─────────────────────────────────────────────────────
+# ── SGLang service ───────────────────────────────────────────────────
 
 echo ""
-echo "  -- ray --"
+echo "  -- sglang --"
 
-if [[ -f /etc/supervisor/conf.d/ray.conf ]]; then
-    assert_service_running ray
-    echo "  ray: supervisor service running"
-
-    # Verify gcs_server process is alive (vllm.sh waits for this)
-    if pgrep -f gcs_server &>/dev/null; then
-        echo "  ray: gcs_server process present"
-    else
-        fail_later "ray-gcs" "ray service running but gcs_server process not found"
-    fi
-
-    # Ray dashboard (informational — not critical for serving)
-    ray_dash_port="${RAY_DASHBOARD_PORT:-28265}"
-    if wait_for_port "$ray_dash_port" 10; then
-        echo "  ray: dashboard listening on port ${ray_dash_port}"
-    else
-        echo "  WARN: ray dashboard not listening on port ${ray_dash_port}"
-    fi
-else
-    echo "  skip: ray (no supervisor conf — external Ray cluster?)"
-fi
-
-# ── vLLM service ────────────────────────────────────────────────────
-
-echo ""
-echo "  -- vllm --"
-
-assert_service_running vllm
-echo "  vllm: supervisor service running"
+assert_service_running sglang
+echo "  sglang: supervisor service running"
 
 # Check for early fatal errors in the log before waiting for the API.
-# vLLM logs to /var/log/vllm.log (clean, ANSI-stripped).
-if [[ -f "$VLLM_LOG" ]]; then
-    # Look for Python tracebacks or known fatal patterns in the first
-    # portion of the log (before model loading begins).
+if [[ -f "$SGLANG_LOG" ]]; then
     fatal_patterns="Traceback|CUDA out of memory|RuntimeError:|OSError:|ValueError:|Failed to|Cannot find"
-    early_errors=$(head -100 "$VLLM_LOG" | grep -cE "$fatal_patterns" || true)
+    early_errors=$(head -100 "$SGLANG_LOG" | grep -cE "$fatal_patterns" || true)
     if [[ "$early_errors" -gt 0 ]]; then
-        echo "  WARN: ${early_errors} potential error(s) in early vLLM log — may be transient"
-        head -100 "$VLLM_LOG" | grep -E "$fatal_patterns" | head -5 | sed 's/^/    /'
+        echo "  WARN: ${early_errors} potential error(s) in early sglang log — may be transient"
+        head -100 "$SGLANG_LOG" | grep -E "$fatal_patterns" | head -5 | sed 's/^/    /'
     fi
 fi
 
-# ── Wait for vLLM API health ────────────────────────────────────────
+# ── Wait for SGLang API health ───────────────────────────────────────
 
 echo ""
 echo "  -- api health --"
 
-HEALTH_URL="http://127.0.0.1:${VLLM_INTERNAL_PORT}/health"
+HEALTH_URL="http://127.0.0.1:${SGLANG_INTERNAL_PORT}/health"
 elapsed=0
 healthy=false
 last_report=0
 restart_count=0
 last_pid=""
 
-# Get initial vLLM PID from supervisor
-last_pid=$(supervisorctl status vllm 2>/dev/null | grep -oP 'pid \K[0-9]+' || true)
+# Get initial SGLang PID from supervisor
+last_pid=$(supervisorctl status sglang 2>/dev/null | grep -oP 'pid \K[0-9]+' || true)
 
 _dump_log_tail() {
-    if [[ -f "$VLLM_LOG" ]]; then
-        echo "  last 10 lines of vllm log:"
-        tail -10 "$VLLM_LOG" | sed 's/^/    /'
+    if [[ -f "$SGLANG_LOG" ]]; then
+        echo "  last 10 lines of sglang log:"
+        tail -10 "$SGLANG_LOG" | sed 's/^/    /'
     fi
 }
 
@@ -102,29 +70,29 @@ while (( elapsed < HEALTH_TIMEOUT )); do
     fi
 
     # Track supervisor restarts by PID change
-    sup_line=$(supervisorctl status vllm 2>/dev/null)
-    vllm_sup_state=$(echo "$sup_line" | awk '{print $2}')
+    sup_line=$(supervisorctl status sglang 2>/dev/null)
+    sglang_sup_state=$(echo "$sup_line" | awk '{print $2}')
     cur_pid=$(echo "$sup_line" | grep -oP 'pid \K[0-9]+' || true)
 
-    if [[ "$vllm_sup_state" == "FATAL" ]]; then
-        echo "  vllm entered FATAL state — supervisor gave up restarting"
+    if [[ "$sglang_sup_state" == "FATAL" ]]; then
+        echo "  sglang entered FATAL state — supervisor gave up restarting"
         _dump_log_tail
-        test_fail "vllm service FATAL (supervisor stopped restarting)"
+        test_fail "sglang service FATAL (supervisor stopped restarting)"
     fi
 
-    if [[ "$vllm_sup_state" != "RUNNING" && "$vllm_sup_state" != "STARTING" ]]; then
-        echo "  vllm service in state: ${vllm_sup_state}"
+    if [[ "$sglang_sup_state" != "RUNNING" && "$sglang_sup_state" != "STARTING" ]]; then
+        echo "  sglang service in state: ${sglang_sup_state}"
         _dump_log_tail
-        test_fail "vllm service not running (state: ${vllm_sup_state})"
+        test_fail "sglang service not running (state: ${sglang_sup_state})"
     fi
 
     # Detect restart: PID changed while we were waiting
     if [[ -n "$last_pid" && -n "$cur_pid" && "$cur_pid" != "$last_pid" ]]; then
         restart_count=$((restart_count + 1))
-        echo "  vllm restarted (pid ${last_pid} → ${cur_pid}, restart #${restart_count})"
+        echo "  sglang restarted (pid ${last_pid} → ${cur_pid}, restart #${restart_count})"
         _dump_log_tail
         if (( restart_count >= MAX_RESTARTS )); then
-            test_fail "vllm crash loop: ${restart_count} restarts detected (bad config or OOM?)"
+            test_fail "sglang crash loop: ${restart_count} restarts detected (bad config or OOM?)"
         fi
     fi
     last_pid="$cur_pid"
@@ -132,7 +100,7 @@ while (( elapsed < HEALTH_TIMEOUT )); do
     # Progress report every 30s
     if (( elapsed - last_report >= 30 )); then
         last_report=$elapsed
-        log_size=$(stat -c '%s' "$VLLM_LOG" 2>/dev/null || echo "0")
+        log_size=$(stat -c '%s' "$SGLANG_LOG" 2>/dev/null || echo "0")
         echo "  [${elapsed}s] waiting for /health (log=${log_size}B, http=${status}, restarts=${restart_count})"
     fi
 
@@ -141,26 +109,25 @@ while (( elapsed < HEALTH_TIMEOUT )); do
 done
 
 if ! $healthy; then
-    echo "  vLLM API did not become healthy within ${HEALTH_TIMEOUT}s"
-    if [[ -f "$VLLM_LOG" ]]; then
-        echo "  last 15 lines of vllm log:"
-        tail -15 "$VLLM_LOG" | sed 's/^/    /'
+    echo "  SGLang API did not become healthy within ${HEALTH_TIMEOUT}s"
+    if [[ -f "$SGLANG_LOG" ]]; then
+        echo "  last 15 lines of sglang log:"
+        tail -15 "$SGLANG_LOG" | sed 's/^/    /'
     fi
-    test_fail "vLLM API /health not reachable after ${HEALTH_TIMEOUT}s"
+    test_fail "SGLang API /health not reachable after ${HEALTH_TIMEOUT}s"
 fi
 
-echo "  vLLM API healthy after ${elapsed}s (${restart_count} restart(s))"
+echo "  SGLang API healthy after ${elapsed}s (${restart_count} restart(s))"
 
-# ── Verify /v1/models ───────────────────────────────────────────────
+# ── Verify /v1/models ────────────────────────────────────────────────
 
 echo ""
 echo "  -- model verification --"
 
-models_json=$(curl -sf --max-time 10 "http://127.0.0.1:${VLLM_INTERNAL_PORT}/v1/models" 2>/dev/null)
+models_json=$(curl -sf --max-time 10 "http://127.0.0.1:${SGLANG_INTERNAL_PORT}/v1/models" 2>/dev/null)
 if [[ -z "$models_json" ]]; then
     fail_later "v1-models" "/v1/models returned empty response"
 else
-    # Parse model list, print details, and check if VLLM_MODEL is present
     model_info=$(echo "$models_json" | python3 -c "
 import sys, json, os
 d = json.load(sys.stdin)
@@ -168,14 +135,12 @@ models = d.get('data', [])
 print(len(models))
 for m in models:
     print(m.get('id', '?'))
-# Check if VLLM_MODEL appears in model IDs
-want = os.environ.get('VLLM_MODEL', '')
+want = os.environ.get('SGLANG_MODEL', '')
 ids = [m.get('id', '') for m in models]
 found = any(want in mid or mid in want for mid in ids)
 print('found' if found else 'missing')
 " 2>/dev/null)
 
-    # First line: count, middle lines: model IDs, last line: found/missing
     count=$(echo "$model_info" | head -1)
     match=$(echo "$model_info" | tail -1)
 
@@ -187,19 +152,17 @@ print('found' if found else 'missing')
     fi
 
     if [[ "$match" == "found" ]]; then
-        echo "  VLLM_MODEL found in /v1/models"
+        echo "  SGLANG_MODEL found in /v1/models"
     else
-        echo "  WARN: VLLM_MODEL '${VLLM_MODEL}' not found verbatim in /v1/models (may use a different ID)"
+        echo "  WARN: SGLANG_MODEL '${SGLANG_MODEL}' not found verbatim in /v1/models (may use a different ID)"
     fi
 fi
 
-# ── Log error check ─────────────────────────────────────────────────
+# ── Log error check ──────────────────────────────────────────────────
 
 echo ""
 echo "  -- log analysis --"
 
-# check_log_errors LABEL PATH [exclude_pattern]
-# Grep for ERROR/CRITICAL lines in a log file, fail_later if any found.
 check_log_errors() {
     local label="$1" path="$2" exclude="${3:-}"
     [[ -f "$path" ]] || return 0
@@ -221,26 +184,20 @@ check_log_errors() {
     fi
 }
 
-if [[ -f "$VLLM_LOG" ]]; then
-    log_size=$(stat -c '%s' "$VLLM_LOG" 2>/dev/null || echo "0")
-    echo "  vllm log: ${log_size}B"
+if [[ -f "$SGLANG_LOG" ]]; then
+    log_size=$(stat -c '%s' "$SGLANG_LOG" 2>/dev/null || echo "0")
+    echo "  sglang log: ${log_size}B"
 fi
 
-check_log_errors "vllm" "$VLLM_LOG" "torch\.distributed|CUDAGraph|deprecat"
-check_log_errors "ray" "$RAY_LOG"
+check_log_errors "sglang" "$SGLANG_LOG" "deprecat"
 
-# ── Port exposure check ─────────────────────────────────────────────
-# Verify that services configured in PORTAL_CONFIG have their ports listening.
-# This is especially important for serverless where caddy doesn't proxy —
-# the services must bind directly.
+# ── Port exposure check ──────────────────────────────────────────────
 
 echo ""
 echo "  -- port exposure --"
 
 declare -A PORT_CHECKS=(
-    ["vllm"]="8000:vLLM API:vllm"
-    ["model.ui"]="7860:Model UI:model.ui"
-    ["ray"]="8265:Ray Dashboard:ray"
+    ["sglang"]="8000:SGLang API:sglang"
 )
 
 if is_serverless; then
@@ -260,58 +217,29 @@ else
     done
 fi
 
-# ── Model UI (optional) ─────────────────────────────────────────────
-
-if [[ -f /etc/supervisor/conf.d/model-ui.conf ]] && ! is_serverless; then
-    echo ""
-    echo "  -- model-ui --"
-    model_ui_port=7860
-    model_ui_state=$(supervisorctl status model-ui 2>/dev/null | awk '{print $2}')
-    if [[ "$model_ui_state" == "RUNNING" ]]; then
-        echo "  model-ui: RUNNING"
-        if wait_for_port "$model_ui_port" 10; then
-            echo "  model-ui: listening on port ${model_ui_port}"
-            body=$(curl -sf --max-time 5 "http://127.0.0.1:${model_ui_port}/" 2>/dev/null)
-            if [[ -n "$body" ]]; then
-                echo "  model-ui: serves content"
-            else
-                echo "  WARN: model-ui port open but / returned empty"
-            fi
-        else
-            echo "  WARN: model-ui running but port ${model_ui_port} not listening"
-        fi
-    elif [[ -z "${MODEL_NAME:-}" ]]; then
-        echo "  model-ui: correctly not running (MODEL_NAME not set)"
-    else
-        echo "  WARN: model-ui state: ${model_ui_state:-unknown}"
-    fi
-fi
-
-# ── Inference check ───────────────────────────────────────────────────
-# VLLM_TEST_ENDPOINT controls inference testing:
+# ── Inference check ──────────────────────────────────────────────────
+# SGLANG_TEST_ENDPOINT controls inference testing:
 #   "chat"  (default) — test via /v1/chat/completions
 #   "none"  — skip inference test (for embedding/reranker models)
-# Future: additional endpoints (e.g. "completions", "embeddings") can be
-# added here as new branches.
 
 echo ""
 echo "  -- inference --"
 
-VLLM_TEST_ENDPOINT="${VLLM_TEST_ENDPOINT:-chat}"
-case "$VLLM_TEST_ENDPOINT" in
+SGLANG_TEST_ENDPOINT="${SGLANG_TEST_ENDPOINT:-chat}"
+case "$SGLANG_TEST_ENDPOINT" in
     chat|none) ;;
-    *) test_fail "unsupported VLLM_TEST_ENDPOINT='${VLLM_TEST_ENDPOINT}' (must be 'chat' or 'none')" ;;
+    *) test_fail "unsupported SGLANG_TEST_ENDPOINT='${SGLANG_TEST_ENDPOINT}' (must be 'chat' or 'none')" ;;
 esac
-VLLM_API="http://127.0.0.1:${VLLM_INTERNAL_PORT}"
-# Use the model ID that vLLM is actually serving (from /v1/models)
-SERVED_MODEL=$(curl -sf --max-time 10 "${VLLM_API}/v1/models" 2>/dev/null \
+SGLANG_API="http://127.0.0.1:${SGLANG_INTERNAL_PORT}"
+# Use the model ID that SGLang is actually serving (from /v1/models)
+SERVED_MODEL=$(curl -sf --max-time 10 "${SGLANG_API}/v1/models" 2>/dev/null \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['data'][0]['id'])" 2>/dev/null)
-SERVED_MODEL="${SERVED_MODEL:-${VLLM_MODEL}}"
+SERVED_MODEL="${SERVED_MODEL:-${SGLANG_MODEL}}"
 
-if [[ "${VLLM_TEST_ENDPOINT}" == "none" ]]; then
-    echo "  inference test skipped (VLLM_TEST_ENDPOINT=none)"
+if [[ "${SGLANG_TEST_ENDPOINT}" == "none" ]]; then
+    echo "  inference test skipped (SGLANG_TEST_ENDPOINT=none)"
 else
-    echo "  endpoint: ${VLLM_TEST_ENDPOINT} (/v1/chat/completions)"
+    echo "  endpoint: ${SGLANG_TEST_ENDPOINT} (/v1/chat/completions)"
     echo "  model: ${SERVED_MODEL}"
 
     # Warmup: /health goes green before the engine is fully warm (graph
@@ -320,7 +248,7 @@ else
     # Failures here are tolerated — the scored loop is what we judge on.
     warmup_body=$(mktemp)
     warmup_code=$(curl -s --max-time 300 -o "$warmup_body" -w '%{http_code}' \
-        "${VLLM_API}/v1/chat/completions" \
+        "${SGLANG_API}/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d "$(python3 -c "
 import json, sys
@@ -352,10 +280,9 @@ print(json.dumps({
         echo ""
         echo "  request $((i+1))/${#PROMPTS[@]}: ${prompt}"
 
-        # Capture body and HTTP status separately so we can diagnose non-2xx.
         http_body=$(mktemp)
         http_code=$(curl -s --max-time 180 -o "$http_body" -w '%{http_code}' \
-            "${VLLM_API}/v1/chat/completions" \
+            "${SGLANG_API}/v1/chat/completions" \
             -H "Content-Type: application/json" \
             -d "$(python3 -c "
 import json, sys
@@ -376,7 +303,6 @@ print(json.dumps({
             continue
         fi
 
-        # Parse response: extract token counts, finish reason, any content.
         eval "$(echo "$response" | python3 -c "
 import sys, json, shlex
 try:
@@ -408,8 +334,6 @@ except Exception:
             continue
         fi
 
-        # Inference ran if the model produced any completion tokens — even
-        # if content is empty (reasoning model truncated, filtered, etc.).
         if (( ${compl_tokens:-0} > 0 )); then
             if [[ -n "$content" ]]; then
                 display="${content:0:120}"
@@ -437,7 +361,7 @@ except Exception:
     fi
 fi
 
-# ── Report ──────────────────────────────────────────────────────────
+# ── Report ───────────────────────────────────────────────────────────
 
 report_failures
-test_pass "vLLM serving pipeline verified (model: ${VLLM_MODEL}, health: ${elapsed}s)"
+test_pass "SGLang serving pipeline verified (model: ${SGLANG_MODEL}, health: ${elapsed}s)"

--- a/external/vllm/Dockerfile
+++ b/external/vllm/Dockerfile
@@ -18,6 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV TCLLIBPATH=/usr/lib/tcltk/default
 ENV PATH=/opt/instance-tools/bin:/opt/sys-venv/shim:${PATH}
+# uv hardlinks break volume sync; force copy (matches vastai/base-image)
+ENV UV_LINK_MODE=copy
 WORKDIR /
 
 COPY --from=base_image_source /ROOT /


### PR DESCRIPTION
## Summary

- Mirror `external/vllm/ROOT/opt/instance-tools/tests/vllm.d/10-vllm-serving.sh` for the **sglang** external image and the **llama.cpp** derivative so their OpenAI-compatible APIs get the same boot-time validation (health, `/v1/models`, 3-prompt inference with `completion_tokens > 0` as the pass signal). Ray and model-ui blocks are dropped since neither image runs those services.
- Harden the vLLM test (and its new siblings) with a throwaway warmup request before the scored loop, a `max_tokens=256` cap on scored requests, and a 180s per-request curl timeout. `/health` going green doesn't guarantee the engine is fully warm, and reasoning-model replies previously blew past the 60s timeout on the first scored request.
- Set `ENV UV_LINK_MODE=copy` explicitly on `external/sglang/Dockerfile` and `external/vllm/Dockerfile`. Previously only `vllm/vllm-openai` set it upstream, so `base/55-environment` passed for vLLM by accident and failed for sglang (whose `lmsysorg/sglang` base doesn't set it).
- Bump `derivatives/llama-cpp/Dockerfile` default `BASE_IMAGE` to `cuda-12.9-mini-py312-2026-04-15` to match `.github/workflows/build-llama-cpp.yml`. The floating `cuda-12.9-mini-py312` tag predated `ROOT/opt/supervisor-scripts/utils/pty.sh`, so local builds ended up with `llama.sh` calling a `pty` function that was never sourced.

## Test plan

- [x] Build and boot the **sglang** image with `SGLANG_MODEL` set and a small GPU-friendly model; confirm `10-sglang-serving` PASSes via `/opt/instance-tools/tests/runner.sh --manual`.
- [x] Build and boot the **sglang** image with `SGLANG_MODEL` unset; confirm the test SKIPs cleanly and `base/55-environment` PASSes (this was the `UV_LINK_MODE` failure before).
- [x] Build and boot the **llama.cpp** image with `LLAMA_MODEL` set; confirm `10-llama-serving` PASSes and no `pty: command not found` errors appear in the supervisor log.
- [x] Build and boot the **llama.cpp** image with `LLAMA_MODEL` unset; confirm the test SKIPs cleanly.
- [x] Re-run the vLLM serving test against a reasoning model to confirm the warmup + `max_tokens` cap eliminates the first-request timeout failures.