### PR TITLE
Add FluxGym docker image and workflow

### DIFF
--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -1,0 +1,258 @@
+# Build FluxGym image - works on main repo (scheduled + manual) and forks (manual)
+# Required repository secrets:
+# DOCKERHUB_USERNAME
+# DOCKERHUB_TOKEN
+# DOCKERHUB_NAMESPACE
+# Optional:
+# SLACK_WEBHOOK_URL
+#
+# Release detection: Resolves HEAD of the upstream main branch (fluxgym has no release tags).
+
+name: Build FluxGym Image
+
+on:
+  schedule:
+    # Run every 12 hours
+    - cron: '0 3,15 * * *'
+
+  workflow_dispatch:
+    inputs:
+      FLUXGYM_REF:
+        description: "Git ref (commit/branch) - leave empty for latest"
+        required: false
+      DOCKERHUB_REPO:
+        description: "Push to namespace/<repo>"
+        required: true
+        default: "fluxgym"
+      MULTI_ARCH:
+        description: 'multi-arch build'
+        required: false
+        default: false
+        type: boolean
+      CUSTOM_IMAGE_TAG:
+        description: "Custom tag (Auto default)"
+        required: false
+
+env:
+  DEFAULT_DOCKERHUB_REPO: "fluxgym"
+  DEFAULT_MULTI_ARCH: "false"
+  FLUXGYM_GITHUB_REPO: "cocktailpeanut/fluxgym"
+  FLUXGYM_BRANCH: "main"
+  # 12 hours (matches the schedule cron) — scheduled runs skip if the latest
+  # upstream commit is older than this.
+  COMMIT_AGE_THRESHOLD: 43200
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.decision.outputs.should-run }}
+      fluxgym-ref: ${{ steps.resolve-ref.outputs.ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for required secrets
+        id: secrets
+        run: |
+          if [[ -n "${{ secrets.DOCKERHUB_USERNAME }}" && -n "${{ secrets.DOCKERHUB_TOKEN }}" && -n "${{ secrets.DOCKERHUB_NAMESPACE }}" ]]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+            echo "✓ Required secrets configured"
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - secrets not configured"
+          fi
+
+      - name: Resolve FluxGym git ref
+        id: resolve-ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MANUAL_REF="${{ inputs.FLUXGYM_REF }}"
+
+          if [[ -n "$MANUAL_REF" ]]; then
+            echo "Using manual ref: $MANUAL_REF"
+            echo "ref=$MANUAL_REF" >> $GITHUB_OUTPUT
+            echo "commit-age=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Resolving HEAD of ${{ env.FLUXGYM_BRANCH }} branch via GitHub API..."
+          RESPONSE=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ env.FLUXGYM_GITHUB_REPO }}/commits/${{ env.FLUXGYM_BRANCH }}")
+          COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
+          COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
+
+          if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
+            echo "::error::Could not resolve HEAD of ${{ env.FLUXGYM_BRANCH }} branch"
+            exit 1
+          fi
+
+          COMMIT_EPOCH=$(date -d "$COMMIT_DATE" +%s)
+          NOW_EPOCH=$(date +%s)
+          AGE=$((NOW_EPOCH - COMMIT_EPOCH))
+
+          echo "Resolved ${{ env.FLUXGYM_BRANCH }} → $COMMIT_SHA (${AGE}s old)"
+          echo "ref=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "commit-age=$AGE" >> $GITHUB_OUTPUT
+
+      - name: Determine if build should run
+        id: decision
+        run: |
+          SECRETS="${{ steps.secrets.outputs.available }}"
+          TRIGGER="${{ github.event_name }}"
+          RESOLVED_REF="${{ steps.resolve-ref.outputs.ref }}"
+          COMMIT_AGE="${{ steps.resolve-ref.outputs.commit-age }}"
+
+          if [[ "$SECRETS" != "true" ]]; then
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - Required secrets not configured"
+          elif [[ "$TRIGGER" == "workflow_dispatch" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "✓ Manual build for ref: $RESOLVED_REF"
+          elif [[ "$COMMIT_AGE" -le "${{ env.COMMIT_AGE_THRESHOLD }}" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "✓ Scheduled build for ref: $RESOLVED_REF (${COMMIT_AGE}s old ≤ ${{ env.COMMIT_AGE_THRESHOLD }}s threshold)"
+          else
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping scheduled build - latest upstream commit is ${COMMIT_AGE}s old (threshold ${{ env.COMMIT_AGE_THRESHOLD }}s)"
+          fi
+
+  build:
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image:
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-04-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: ./.github/actions/maximize-build-space
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Derive image tag
+        id: meta
+        run: |
+          PYTORCH_BASE="${{ matrix.base_image }}"
+          TAG="${PYTORCH_BASE##*:}"
+
+          CUDA_VERSION=$(echo "$TAG" | sed -n 's/.*cuda-\([0-9.]*\).*/\1/p')
+
+          if [[ -z "$CUDA_VERSION" ]]; then
+            echo "::error::Failed to parse base image: $PYTORCH_BASE"
+            exit 1
+          fi
+
+          FLUXGYM_REF="${{ needs.preflight.outputs.fluxgym-ref }}"
+
+          BUILD_DATE=$(date -u +%Y-%m-%d)
+
+          IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
+          if [[ -z "$IMAGE_TAG_BASE" ]]; then
+            IMAGE_TAG_BASE="${FLUXGYM_REF}-${BUILD_DATE}-cuda-${CUDA_VERSION}"
+          fi
+
+          DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
+          FULL_IMAGE="${{ secrets.DOCKERHUB_NAMESPACE }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+
+          MATRIX_ID=$(echo "$PYTORCH_BASE" | md5sum | cut -c1-8)
+
+          echo "IMAGE_TAG=$IMAGE_TAG_BASE" >> $GITHUB_ENV
+          echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_ENV
+          echo "MATRIX_ID=$MATRIX_ID" >> $GITHUB_ENV
+
+          echo "Derived image tag: $IMAGE_TAG_BASE"
+
+      - name: Build and push
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            MULTI_ARCH="${{ inputs.MULTI_ARCH }}"
+          else
+            MULTI_ARCH="${{ env.DEFAULT_MULTI_ARCH }}"
+          fi
+
+          platforms="linux/amd64"
+          [[ "$MULTI_ARCH" == "true" ]] && platforms+=",linux/arm64"
+
+          cd derivatives/pytorch/derivatives/fluxgym
+          docker buildx build \
+            --platform "$platforms" \
+            --build-arg PYTORCH_BASE=${{ matrix.base_image }} \
+            --build-arg FLUXGYM_REF=${{ needs.preflight.outputs.fluxgym-ref }} \
+            -t ${{ env.FULL_IMAGE }} \
+            . --push
+
+      - name: Record built tag
+        run: |
+          mkdir -p built-tags
+          echo "${{ env.FULL_IMAGE }}" > built-tags/tag-${{ env.MATRIX_ID }}.txt
+
+      - name: Upload built tag
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-tag-${{ env.MATRIX_ID }}
+          path: built-tags/
+          retention-days: 1
+
+  collect-tags:
+    needs: [preflight, build]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      all-tags: ${{ steps.collect.outputs.tags }}
+    steps:
+      - name: Download all tag artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: built-tag-*
+          path: all-tags/
+          merge-multiple: true
+
+      - name: Aggregate tags
+        id: collect
+        run: |
+          if [ -d all-tags ] && [ "$(ls -A all-tags 2>/dev/null)" ]; then
+            TAGS=$(cat all-tags/*.txt | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "Found tags: $TAGS"
+          else
+            echo "::warning::No tags found - build may have failed"
+            TAGS="[]"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+  notify:
+    needs: [preflight, build, collect-tags]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    uses: ./.github/workflows/notify-slack.yml
+    with:
+      build-result: ${{ needs.build.result }}
+      image-name: "FluxGym"
+      image-ref: ${{ needs.preflight.outputs.fluxgym-ref }}
+      image-tags: ${{ needs.collect-tags.outputs.all-tags }}
+      trigger: ${{ github.event_name }}
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/derivatives/pytorch/derivatives/fluxgym/Dockerfile
+++ b/derivatives/pytorch/derivatives/fluxgym/Dockerfile
@@ -1,0 +1,53 @@
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-04-15
+
+FROM ${PYTORCH_BASE}
+
+# Maintainer details
+LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="FluxGym image suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
+
+# Copy Supervisor configuration and startup scripts
+COPY ./ROOT /
+
+# Ensure uv pulls CUDA 12.8 wheels for torch ecosystem packages
+ENV UV_TORCH_BACKEND=cu128
+
+# Required or we will not build
+ARG FLUXGYM_REPO=https://github.com/cocktailpeanut/fluxgym
+ARG FLUXGYM_REF
+ARG SD_SCRIPTS_REPO=https://github.com/kohya-ss/sd-scripts
+ARG SD_SCRIPTS_REF=sd3
+
+RUN \
+    set -euo pipefail && \
+    [[ -n "${FLUXGYM_REF}" ]] || { echo "Must specify FLUXGYM_REF" && exit 1; } && \
+    . /venv/main/bin/activate && \
+    # We have PyTorch pre-installed so we will check at the end of the install that it has not been clobbered
+    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # Clone FluxGym
+    cd /opt/workspace-internal/ && \
+    git clone "${FLUXGYM_REPO}" fluxgym && \
+    cd fluxgym && \
+    git checkout "${FLUXGYM_REF}" && \
+    # Clone Kohya sd-scripts (sd3 branch) as a sibling tree inside fluxgym
+    git clone -b "${SD_SCRIPTS_REF}" "${SD_SCRIPTS_REPO}" sd-scripts && \
+    # Install Kohya sd-scripts requirements first (fluxgym imports from it at runtime)
+    (cd sd-scripts && uv pip install --no-cache-dir -r requirements.txt) && \
+    # Install FluxGym requirements with pinned ecosystem versions.
+    # transformers==4.49.0 and peft<0.18 are load-bearing (auto-caption and training regressions otherwise)
+    uv pip install --no-cache-dir \
+        torch torchvision torchaudio bitsandbytes \
+        -r requirements.txt \
+        'peft<0.18' \
+        --torch-backend cu128 && \
+    uv pip install --no-cache-dir transformers==4.49.0 && \
+    # Test 1: Verify PyTorch version is unaltered
+    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
+    [[ $torch_version_pre = $torch_version_post ]] || \
+        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+
+# Defend against environment clashes when syncing to volume
+RUN \
+    set -euo pipefail && \
+    env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/fluxgym/README.md
+++ b/derivatives/pytorch/derivatives/fluxgym/README.md
@@ -1,0 +1,111 @@
+# FluxGym Image
+
+A FluxGym image derived from the Vast.ai [PyTorch image](../../README.md). This image ships FluxGym pre-installed alongside Kohya `sd-scripts` (sd3 branch), ready for FLUX LoRA training through a simple Gradio UI.
+
+For detailed documentation on Instance Portal, Supervisor, environment variables, and other features, see the [base image README](../../../../README.md).
+
+## Available Tags
+
+Pre-built images are available on [DockerHub](https://hub.docker.com/repository/docker/vastai/fluxgym/tags).
+
+## CUDA Compatibility
+
+Images are tagged with the CUDA version they were built against (e.g. `<ref>-<date>-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
+
+### Minor Version Compatibility
+
+NVIDIA's [minor version compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html) guarantees that an application built with any CUDA toolkit release within a major version family will run on a system with a driver from the same major family.
+
+- A `cuda-12.9` image will run on any machine with a CUDA 12.x driver (driver >= 525).
+- A `cuda-13.1` image will run on any machine with a CUDA 13.x driver (driver >= 580).
+- The 12.x and 13.x families are separate.
+
+**PTX caveat:** Applications that compile device code to PTX rather than pre-compiled SASS for the target architecture will not work on older drivers within the same major family.
+
+### Forward Compatibility
+
+[Forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html) allows newer CUDA toolkit versions to run on older drivers. It is only available on **datacenter GPUs** (and select NGC Server Ready RTX cards). All of our images include the CUDA Compatibility Package (`cuda-compat`) to support this.
+
+## Python Version
+
+The FluxGym image is built on the **Python 3.10** variant of the PyTorch mini base (`*-mini-py310-*`). FluxGym and Kohya sd-scripts are validated against Python 3.10 and newer interpreters have occasionally surfaced incompatibilities in the wider training-tools ecosystem.
+
+## Pinned Dependencies
+
+The following pins are load-bearing — changing them will typically break training or auto-captioning:
+
+| Package | Pin | Reason |
+|---------|-----|--------|
+| `transformers` | `==4.49.0` | Later versions regress florence-2 auto-caption output |
+| `peft` | `<0.18` | 0.18+ breaks the LoRA injection path used by sd-scripts sd3 branch |
+| `torch-backend` | `cu128` | Matches FluxGym's upstream `gpu.txt` |
+
+## FluxGym Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE` | `/workspace` | Directory for models, datasets, and training outputs |
+| `FLUXGYM_PORT` | `17860` | Gradio server port (internal) |
+| `PROVISIONING_SCRIPT` | (none) | URL to a setup script to run on first boot |
+
+### Port Reference
+
+| Service | External Port | Internal Port |
+|---------|---------------|---------------|
+| Instance Portal | 1111 | 11111 |
+| FluxGym | 17860 | 17860 |
+| Jupyter | 8080 | 8080 |
+
+### Service Management
+
+FluxGym runs as a Supervisor-managed service:
+
+```bash
+supervisorctl status fluxgym
+supervisorctl restart fluxgym
+supervisorctl tail -f fluxgym
+```
+
+## Building From Source
+
+```bash
+cd base-image/derivatives/pytorch/derivatives/fluxgym
+
+docker buildx build \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310 \
+    --build-arg FLUXGYM_REF=<commit-or-tag> \
+    -t yournamespace/fluxgym .
+```
+
+### Build Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-04-15` | PyTorch mini base image (Python 3.10) |
+| `FLUXGYM_REPO` | `https://github.com/cocktailpeanut/fluxgym` | Upstream FluxGym repo |
+| `FLUXGYM_REF` | | Git ref (commit/branch) to build |
+| `SD_SCRIPTS_REPO` | `https://github.com/kohya-ss/sd-scripts` | Upstream Kohya sd-scripts repo |
+| `SD_SCRIPTS_REF` | `sd3` | Kohya sd-scripts branch (FluxGym expects `sd3`) |
+
+## Building with GitHub Actions
+
+Fork this repository and use the included GitHub Actions workflow to build and push FluxGym images to your own DockerHub account. Scheduled builds poll upstream for new commits every 12 hours.
+
+## Licenses
+
+This image ships vendor application(s) under the following license(s):
+
+- **FluxGym** — Apache-2.0 ([upstream](https://github.com/cocktailpeanut/fluxgym))
+- **Kohya sd-scripts** — Apache-2.0 ([upstream](https://github.com/kohya-ss/sd-scripts))
+
+See `/LICENSES.md` in the image for license details and file locations.
+
+## Useful Links
+
+- [FluxGym GitHub](https://github.com/cocktailpeanut/fluxgym)
+- [Kohya sd-scripts](https://github.com/kohya-ss/sd-scripts)
+- [PyTorch Image Documentation](../../README.md)
+- [Base Image Documentation](../../../../README.md)
+- [Image Source](https://github.com/vast-ai/base-image/tree/main/derivatives/pytorch/derivatives/fluxgym)

--- a/derivatives/pytorch/derivatives/fluxgym/README.template.md
+++ b/derivatives/pytorch/derivatives/fluxgym/README.template.md
@@ -1,0 +1,91 @@
+# FluxGym
+
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=FluxGym)**
+
+## What is this template?
+
+This template gives you a **FLUX LoRA training environment** with FluxGym running in a Docker container. FluxGym wraps Kohya `sd-scripts` with a simple Gradio UI so you can train FLUX LoRAs from your own datasets without writing command-line configs by hand.
+
+**Think:** *"Train FLUX LoRAs through a web UI — upload images, caption, train, download."*
+
+> **Latest builds:** Docker images are automatically rebuilt when new upstream commits are detected. The default template tag is updated less frequently to allow for QA testing.
+
+---
+
+## What can I do with this?
+
+- **Train FLUX LoRAs** from your own image datasets
+- **Auto-caption** training data with Florence-2 (pre-installed)
+- **Monitor training** through the Gradio UI
+- **Resume** interrupted runs
+- **Download** trained LoRAs directly from the UI
+
+---
+
+## Who is this for?
+
+This is **perfect** if you:
+- Want to train custom FLUX LoRAs without wrestling with Kohya config files
+- Prefer a web UI for dataset management and training runs
+- Need a reproducible GPU environment with the right PyTorch + `transformers` + `peft` combo pre-pinned
+
+---
+
+## Quick Start Guide
+
+### **Step 1: Launch Instance**
+Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=FluxGym)"** when you've found a suitable GPU instance.
+
+### **Step 2: Access Your Instance**
+Click the **"Open"** button to reach the FluxGym UI.
+
+### **Step 3: Train**
+Upload your dataset, configure the training parameters, and start the run. Trained LoRAs appear in the output folder when finished.
+
+---
+
+## Port Reference
+
+| Service | External Port | Internal Port |
+|---------|---------------|---------------|
+| Instance Portal | 1111 | 11111 |
+| FluxGym | 17860 | 17860 |
+| Jupyter | 8080 | 8080 |
+
+---
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE` | `/workspace` | Workspace directory |
+| `FLUXGYM_PORT` | `17860` | Gradio server port |
+| `PROVISIONING_SCRIPT` | (none) | URL to a setup script to run on first boot |
+
+---
+
+### **Recommended GPU Memory**
+| Use Case | Minimum VRAM | Recommended VRAM |
+|----------|--------------|------------------|
+| FLUX LoRA training | 16 GB | 24 GB+ |
+
+---
+
+## CUDA Compatibility
+
+Images are tagged with the CUDA version they were built against (e.g. `<ref>-<date>-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
+
+**Minor version compatibility:** NVIDIA guarantees that an application built with any CUDA toolkit within a major version family will run on a driver from the same family. A `cuda-12.9` image runs on any CUDA 12.x driver (driver >= 525), and a `cuda-13.1` image runs on any CUDA 13.x driver (driver >= 580). The 12.x and 13.x families are separate.
+
+**Forward compatibility:** All images include the [CUDA Compatibility Package](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html) for use on **datacenter GPUs**.
+
+---
+
+## Need More Help?
+
+- **FluxGym Repository:** [cocktailpeanut/fluxgym](https://github.com/cocktailpeanut/fluxgym)
+- **Kohya sd-scripts:** [kohya-ss/sd-scripts](https://github.com/kohya-ss/sd-scripts)
+- **Image Source & Features:** [GitHub Repository](https://github.com/vast-ai/base-image/tree/main/derivatives/pytorch/derivatives/fluxgym)
+- **Instance Portal Guide:** [Vast.ai Instance Portal Documentation](https://docs.vast.ai/instance-portal)
+- **SSH Setup Guide:** [Vast.ai SSH Documentation](https://docs.vast.ai/instances/sshscp)
+- **Template Configuration:** [Vast.ai Template Guide](https://docs.vast.ai/templates)

--- a/derivatives/pytorch/derivatives/fluxgym/ROOT/LICENSES.md
+++ b/derivatives/pytorch/derivatives/fluxgym/ROOT/LICENSES.md
@@ -1,0 +1,26 @@
+# Third-Party Licenses
+
+This image bundles the following vendor application(s). Each is the property of
+its respective authors and is distributed under the license shown below. Where
+the vendor's source or LICENSE file is shipped inside this image at a known
+location, the path is given. Otherwise, the upstream repository is referenced
+as the canonical source for the license text.
+
+## PyTorch
+
+- **License:** BSD-3-Clause
+- **Upstream:** https://github.com/pytorch/pytorch
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/torch-*.dist-info/LICENSE`
+
+## FluxGym
+
+- **License:** Apache-2.0
+- **Upstream:** https://github.com/cocktailpeanut/fluxgym
+- **License file in image:** `$WORKSPACE/fluxgym/LICENSE`
+
+## Kohya sd-scripts
+
+- **License:** Apache-2.0
+- **Upstream:** https://github.com/kohya-ss/sd-scripts
+- **License file in image:** `$WORKSPACE/fluxgym/sd-scripts/LICENSE.md`

--- a/derivatives/pytorch/derivatives/fluxgym/ROOT/etc/supervisor/conf.d/fluxgym.conf
+++ b/derivatives/pytorch/derivatives/fluxgym/ROOT/etc/supervisor/conf.d/fluxgym.conf
@@ -1,0 +1,17 @@
+[program:fluxgym]
+environment=PROC_NAME="%(program_name)s"
+command=/opt/supervisor-scripts/fluxgym.sh
+autostart=true
+autorestart=unexpected
+exitcodes=0
+startsecs=0
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
+stopwaitsecs=10
+# This is necessary for Vast logging to work alongside the Portal logs (Must output to /dev/stdout)
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+stdout_events_enabled=true
+stdout_logfile_maxbytes=0
+stdout_logfile_backups=0

--- a/derivatives/pytorch/derivatives/fluxgym/ROOT/opt/supervisor-scripts/fluxgym.sh
+++ b/derivatives/pytorch/derivatives/fluxgym/ROOT/opt/supervisor-scripts/fluxgym.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+utils=/opt/supervisor-scripts/utils
+. "${utils}/logging.sh"
+. "${utils}/cleanup_generic.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh" "Flux Gym"
+
+echo "Starting Flux Gym"
+
+. /venv/main/bin/activate
+
+# Wait for provisioning to complete
+while [ -f "/.provisioning" ]; do
+    echo "$PROC_NAME startup paused until instance provisioning has completed (/.provisioning present)"
+    sleep 10
+done
+
+cd "${WORKSPACE}/fluxgym"
+
+GRADIO_SERVER_PORT=${FLUXGYM_PORT:-17860} pty python app.py 2>&1


### PR DESCRIPTION
## Summary
- New standalone FluxGym derivative at `derivatives/pytorch/derivatives/fluxgym/`, based on the py310 PyTorch mini base so we skip the `conda install -y python=3.10` step the runtime provisioning script did.
- Bakes Kohya `sd-scripts` (sd3 branch) alongside fluxgym, with the pinned ecosystem: `transformers==4.49.0`, `peft<0.18`, `--torch-backend cu128`.
- Supervisor service retains the portal gate via `exit_portal.sh \"Flux Gym\"` (removing the entry from `/etc/portal.yaml` skips startup).
- Workflow follows `build-sd-forge.yml`: scheduled runs skip unless the latest upstream commit is inside the 12 h window; manual `workflow_dispatch` always builds.

## Test plan
- [x] Trigger `Build FluxGym Image` via `workflow_dispatch` and confirm an image is built and pushed.
- [x] Launch the resulting image on Vast, open the portal, confirm the Gradio UI loads on port 17860.
- [x] Run a short LoRA training to exercise sd-scripts + bitsandbytes + transformers + peft.
- [x] Confirm `supervisorctl status fluxgym` / `restart` behaves as expected.
- [x] Remove the FluxGym entry from `/etc/portal.yaml`, restart fluxgym, confirm it exits via the portal gate.