### PR TITLE
Add Whisper docker image and workflow

### DIFF
--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -92,18 +92,24 @@ jobs:
         id: decision
         run: |
           SECRETS="${{ steps.secrets.outputs.available }}"
-          MANUAL_REF="${{ inputs.WHISPER_REF }}"
+          TRIGGER="${{ github.event_name }}"
+          RESOLVED_REF="${{ steps.resolve-ref.outputs.ref }}"
           NEW_RELEASE="${{ steps.release-check.outputs.new-release }}"
 
           if [[ "$SECRETS" != "true" ]]; then
             echo "should-run=false" >> $GITHUB_OUTPUT
             echo "::notice::Skipping - Required secrets not configured"
-          elif [[ -n "$MANUAL_REF" ]]; then
+          elif [[ "$TRIGGER" == "workflow_dispatch" ]]; then
+            # Manual dispatch: always build, but fail fast if no ref could be resolved
+            if [[ -z "$RESOLVED_REF" ]]; then
+              echo "::error::workflow_dispatch requested a build but no ref could be resolved (manual input empty and release lookup returned no tag)"
+              exit 1
+            fi
             echo "should-run=true" >> $GITHUB_OUTPUT
-            echo "✓ Manual build for ref: ${{ steps.resolve-ref.outputs.ref }}"
-          elif [[ "$NEW_RELEASE" == "true" ]]; then
+            echo "✓ Manual build for ref: $RESOLVED_REF"
+          elif [[ "$NEW_RELEASE" == "true" && -n "$RESOLVED_REF" ]]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
-            echo "✓ New GitHub release detected, building ref: ${{ steps.resolve-ref.outputs.ref }}"
+            echo "✓ New GitHub release detected, building ref: $RESOLVED_REF"
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
             echo "::notice::Skipping - No new release detected on GitHub"

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -1,0 +1,250 @@
+# Build Whisper image - works on main repo (scheduled + manual) and forks (manual)
+# Required repository secrets:
+# DOCKERHUB_USERNAME
+# DOCKERHUB_TOKEN
+# DOCKERHUB_NAMESPACE
+# Optional:
+# SLACK_WEBHOOK_URL
+#
+# Release detection: Checks GitHub (jhj0517/Whisper-WebUI) for new release tags.
+
+name: Build Whisper Image
+
+on:
+  schedule:
+    # Run every 12 hours
+    - cron: '0 2,14 * * *'
+
+  workflow_dispatch:
+    inputs:
+      WHISPER_REF:
+        description: "Git ref (release tag, e.g. v1.0.8) - leave empty for latest"
+        required: false
+      DOCKERHUB_REPO:
+        description: "Push to namespace/<repo>"
+        required: true
+        default: "whisper"
+      MULTI_ARCH:
+        description: 'multi-arch build'
+        required: false
+        default: false
+        type: boolean
+      CUSTOM_IMAGE_TAG:
+        description: "Custom tag (Auto default)"
+        required: false
+
+env:
+  DEFAULT_DOCKERHUB_REPO: "whisper"
+  DEFAULT_MULTI_ARCH: "false"
+  # 12 hours
+  RELEASE_AGE_THRESHOLD: 43200
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.decision.outputs.should-run }}
+      whisper-ref: ${{ steps.resolve-ref.outputs.ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for required secrets
+        id: secrets
+        run: |
+          if [[ -n "${{ secrets.DOCKERHUB_USERNAME }}" && -n "${{ secrets.DOCKERHUB_TOKEN }}" && -n "${{ secrets.DOCKERHUB_NAMESPACE }}" ]]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+            echo "✓ Required secrets configured"
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - secrets not configured"
+          fi
+
+      - name: Check GitHub for new release
+        id: release-check
+        if: ${{ !inputs.WHISPER_REF }}
+        uses: ./.github/actions/check-github-release
+        with:
+          repository: jhj0517/Whisper-WebUI
+          age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          trigger: ${{ github.event_name }}
+          tag-pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+          resolve-master-to-commit: "false"
+
+      - name: Resolve Whisper ref
+        id: resolve-ref
+        run: |
+          if [[ -n "${{ inputs.WHISPER_REF }}" ]]; then
+            REF="${{ inputs.WHISPER_REF }}"
+            echo "Using manual ref: $REF"
+          elif [[ -n "${{ steps.release-check.outputs.release-tag }}" ]]; then
+            REF="${{ steps.release-check.outputs.release-tag }}"
+            echo "Using release tag: $REF"
+          else
+            REF=""
+            echo "::notice::No ref resolved"
+          fi
+
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+
+      - name: Determine if build should run
+        id: decision
+        run: |
+          SECRETS="${{ steps.secrets.outputs.available }}"
+          MANUAL_REF="${{ inputs.WHISPER_REF }}"
+          NEW_RELEASE="${{ steps.release-check.outputs.new-release }}"
+
+          if [[ "$SECRETS" != "true" ]]; then
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - Required secrets not configured"
+          elif [[ -n "$MANUAL_REF" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "✓ Manual build for ref: ${{ steps.resolve-ref.outputs.ref }}"
+          elif [[ "$NEW_RELEASE" == "true" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "✓ New GitHub release detected, building ref: ${{ steps.resolve-ref.outputs.ref }}"
+          else
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - No new release detected on GitHub"
+          fi
+
+  build:
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image:
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: ./.github/actions/maximize-build-space
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Derive image tag
+        id: meta
+        run: |
+          PYTORCH_BASE="${{ matrix.base_image }}"
+          TAG="${PYTORCH_BASE##*:}"
+
+          CUDA_VERSION=$(echo "$TAG" | sed -n 's/.*cuda-\([0-9.]*\).*/\1/p')
+          PYTHON_VERSION=$(echo "$TAG" | sed -n 's/.*-py\([0-9]*\).*/py\1/p')
+
+          if [ -z "$CUDA_VERSION" ] || [ -z "$PYTHON_VERSION" ]; then
+            echo "::error::Failed to parse base image: $PYTORCH_BASE"
+            exit 1
+          fi
+
+          WHISPER_REF="${{ needs.preflight.outputs.whisper-ref }}"
+          # Strip optional v prefix for a cleaner tag (e.g. v1.0.8 → 1.0.8)
+          WHISPER_VERSION="${WHISPER_REF#v}"
+
+          IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
+          if [ -z "$IMAGE_TAG_BASE" ]; then
+            IMAGE_TAG_BASE="${WHISPER_VERSION}-cuda-${CUDA_VERSION}-${PYTHON_VERSION}"
+          fi
+
+          DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
+          FULL_IMAGE="${{ secrets.DOCKERHUB_NAMESPACE }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+
+          MATRIX_ID=$(echo "$PYTORCH_BASE" | md5sum | cut -c1-8)
+
+          echo "IMAGE_TAG=$IMAGE_TAG_BASE" >> $GITHUB_ENV
+          echo "FULL_IMAGE=$FULL_IMAGE" >> $GITHUB_ENV
+          echo "MATRIX_ID=$MATRIX_ID" >> $GITHUB_ENV
+
+          echo "Derived image tag: $IMAGE_TAG_BASE"
+
+      - name: Build and push
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            MULTI_ARCH="${{ inputs.MULTI_ARCH }}"
+          else
+            MULTI_ARCH="${{ env.DEFAULT_MULTI_ARCH }}"
+          fi
+
+          platforms="linux/amd64"
+          [[ "$MULTI_ARCH" == "true" ]] && platforms+=",linux/arm64"
+
+          cd derivatives/pytorch/derivatives/whisper
+          docker buildx build \
+            --platform "$platforms" \
+            --build-arg PYTORCH_BASE=${{ matrix.base_image }} \
+            --build-arg WHISPER_REF=${{ needs.preflight.outputs.whisper-ref }} \
+            -t ${{ env.FULL_IMAGE }} \
+            . --push
+
+      - name: Record built tag
+        run: |
+          mkdir -p built-tags
+          echo "${{ env.FULL_IMAGE }}" > built-tags/tag-${{ env.MATRIX_ID }}.txt
+
+      - name: Upload built tag
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-tag-${{ env.MATRIX_ID }}
+          path: built-tags/
+          retention-days: 1
+
+  collect-tags:
+    needs: [preflight, build]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      all-tags: ${{ steps.collect.outputs.tags }}
+    steps:
+      - name: Download all tag artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: built-tag-*
+          path: all-tags/
+          merge-multiple: true
+
+      - name: Aggregate tags
+        id: collect
+        run: |
+          if [ -d all-tags ] && [ "$(ls -A all-tags 2>/dev/null)" ]; then
+            TAGS=$(cat all-tags/*.txt | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "Found tags: $TAGS"
+          else
+            echo "::warning::No tags found - build may have failed"
+            TAGS="[]"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+  notify:
+    needs: [preflight, build, collect-tags]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    uses: ./.github/workflows/notify-slack.yml
+    with:
+      build-result: ${{ needs.build.result }}
+      image-name: "Whisper"
+      image-ref: ${{ needs.preflight.outputs.whisper-ref }}
+      image-tags: ${{ needs.collect-tags.outputs.all-tags }}
+      trigger: ${{ github.event_name }}
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/derivatives/pytorch/derivatives/whisper/Dockerfile
+++ b/derivatives/pytorch/derivatives/whisper/Dockerfile
@@ -1,0 +1,41 @@
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15
+
+FROM ${PYTORCH_BASE}
+
+# Maintainer details
+LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="Whisper-WebUI image (API + UI) suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
+
+# Copy Supervisor configuration and startup scripts
+COPY ./ROOT /
+
+# Required or we will not build
+ARG WHISPER_REPO=https://github.com/jhj0517/Whisper-WebUI
+ARG WHISPER_REF
+
+RUN \
+    set -euo pipefail && \
+    [[ -n "${WHISPER_REF}" ]] || { echo "Must specify WHISPER_REF" && exit 1; } && \
+    . /venv/main/bin/activate && \
+    # We have PyTorch pre-installed so we will check at the end of the install that it has not been clobbered
+    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # Clone Whisper-WebUI
+    cd /opt/workspace-internal/ && \
+    git clone "${WHISPER_REPO}" Whisper-WebUI && \
+    cd Whisper-WebUI && \
+    git checkout "${WHISPER_REF}" && \
+    # Strip torch pins — provided by the base venv
+    sed -i '/^torch[>=<]/d; /^torchaudio[>=<]/d; /^--extra-index-url.*pytorch/d' requirements.txt && \
+    # Ensure setuptools<78 for legacy pkg_resources in build deps
+    uv pip install --no-cache-dir 'setuptools<78' && \
+    uv pip install --no-cache-dir --no-build-isolation -r requirements.txt -r backend/requirements-backend.txt && \
+    # Test 1: Verify PyTorch version is unaltered
+    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
+    [[ $torch_version_pre = $torch_version_post ]] || \
+        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+
+# Defend against environment clashes when syncing to volume
+RUN \
+    set -euo pipefail && \
+    env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/whisper/README.md
+++ b/derivatives/pytorch/derivatives/whisper/README.md
@@ -1,0 +1,111 @@
+# Whisper Image
+
+A Whisper-WebUI image derived from the Vast.ai [PyTorch image](../../README.md). This image ships **both** the Whisper-WebUI Gradio UI and its FastAPI backend, each managed as an independent Supervisor service, along with all features from the Vast.ai base image.
+
+For detailed documentation on Instance Portal, Supervisor, environment variables, and other features, see the [base image README](../../../../README.md).
+
+## Available Tags
+
+Pre-built images are available on [DockerHub](https://hub.docker.com/repository/docker/vastai/whisper/tags).
+
+## CUDA Compatibility
+
+Images are tagged with the CUDA version they were built against (e.g. `<ref>-<date>-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
+
+### Minor Version Compatibility
+
+NVIDIA's [minor version compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html) guarantees that an application built with any CUDA toolkit release within a major version family will run on a system with a driver from the same major family.
+
+- A `cuda-12.9` image will run on any machine with a CUDA 12.x driver (driver >= 525).
+- A `cuda-13.1` image will run on any machine with a CUDA 13.x driver (driver >= 580).
+- The 12.x and 13.x families are separate.
+
+**PTX caveat:** Applications that compile device code to PTX rather than pre-compiled SASS for the target architecture will not work on older drivers within the same major family.
+
+### Forward Compatibility
+
+[Forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html) allows newer CUDA toolkit versions to run on older drivers. It is only available on **datacenter GPUs** (and select NGC Server Ready RTX cards). All of our images include the CUDA Compatibility Package (`cuda-compat`) to support this.
+
+## Whisper Configuration
+
+### Services
+
+| Service | Description |
+|---------|-------------|
+| `whisper-api` | FastAPI backend (`uvicorn backend.main:app`) |
+| `whisper-ui` | Gradio WebUI (`python app.py`) — waits for the API before starting |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE` | `/workspace` | Directory for models, outputs, and configurations |
+| `WHISPER_API_ARGS` | `--host 0.0.0.0 --port 8000` | uvicorn args |
+| `WHISPER_UI_ARGS` | `--whisper_type whisper --server_port 7860` | Gradio app.py args |
+| `WHISPER_API_HEALTH_URL` | `http://localhost:8000/docs` | URL the UI polls before starting |
+| `PROVISIONING_SCRIPT` | (none) | URL to a setup script to run on first boot |
+
+### Port Reference
+
+| Service | External Port | Internal Port |
+|---------|---------------|---------------|
+| Instance Portal | 1111 | 11111 |
+| Whisper WebUI | 17860 | 7860 |
+| Whisper API | 18000 | 8000 |
+| Jupyter | 8080 | 8080 |
+
+### Service Management
+
+```bash
+# Check service status
+supervisorctl status whisper-api whisper-ui
+
+# Restart a service
+supervisorctl restart whisper-api
+supervisorctl restart whisper-ui
+
+# Run UI only (skip API startup by removing Whisper API from /etc/portal.yaml, then restart)
+supervisorctl restart whisper-api
+```
+
+Removing a service's display name from `/etc/portal.yaml` causes its Supervisor script to exit on start (via `exit_portal.sh`), so you can run the API alone, the UI alone, or both.
+
+## Building From Source
+
+```bash
+cd base-image/derivatives/pytorch/derivatives/whisper
+
+docker buildx build \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312 \
+    --build-arg WHISPER_REF=v1.0.8 \
+    -t yournamespace/whisper .
+```
+
+### Build Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15` | PyTorch mini base image |
+| `WHISPER_REPO` | `https://github.com/jhj0517/Whisper-WebUI` | Upstream repo |
+| `WHISPER_REF` | | Git ref (release tag e.g. `v1.0.8`) to build |
+
+## Building with GitHub Actions
+
+Fork this repository and use the included GitHub Actions workflow to build and push Whisper images to your own DockerHub account. The workflow polls the upstream GitHub repo for new release tags every 12 hours and rebuilds automatically.
+
+## Licenses
+
+This image ships vendor application(s) under the following license(s):
+
+- **Whisper-WebUI** — Apache-2.0 ([upstream](https://github.com/jhj0517/Whisper-WebUI))
+- **OpenAI Whisper** — MIT ([upstream](https://github.com/openai/whisper))
+
+See `/LICENSES.md` in the image for license details and file locations.
+
+## Useful Links
+
+- [Whisper-WebUI GitHub](https://github.com/jhj0517/Whisper-WebUI)
+- [OpenAI Whisper](https://github.com/openai/whisper)
+- [PyTorch Image Documentation](../../README.md)
+- [Base Image Documentation](../../../../README.md)
+- [Image Source](https://github.com/vast-ai/base-image/tree/main/derivatives/pytorch/derivatives/whisper)

--- a/derivatives/pytorch/derivatives/whisper/README.md
+++ b/derivatives/pytorch/derivatives/whisper/README.md
@@ -64,8 +64,9 @@ supervisorctl status whisper-api whisper-ui
 supervisorctl restart whisper-api
 supervisorctl restart whisper-ui
 
-# Run UI only (skip API startup by removing Whisper API from /etc/portal.yaml, then restart)
-supervisorctl restart whisper-api
+# Run UI only: remove the Whisper API entry from /etc/portal.yaml, then restart both
+# (the API exits via exit_portal.sh; the UI detects it's not configured and starts solo)
+supervisorctl restart whisper-api whisper-ui
 ```
 
 Removing a service's display name from `/etc/portal.yaml` causes its Supervisor script to exit on start (via `exit_portal.sh`), so you can run the API alone, the UI alone, or both.

--- a/derivatives/pytorch/derivatives/whisper/README.template.md
+++ b/derivatives/pytorch/derivatives/whisper/README.template.md
@@ -1,0 +1,99 @@
+# Whisper (API + UI)
+
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Whisper)**
+
+## What is this template?
+
+This template gives you a **speech-to-text environment** with both the Whisper-WebUI Gradio interface **and** its FastAPI backend, running side-by-side in a Docker container. Use the Web UI for interactive transcription / translation, or hit the API from your own applications.
+
+**Think:** *"Transcribe audio and video with OpenAI Whisper — through a friendly UI or a REST API."*
+
+> **Latest builds:** Docker images are automatically rebuilt when new Whisper-WebUI releases are detected. The default template tag is updated less frequently to allow for QA testing. To use a newly built image before it becomes the template default, select a specific version from the **version tag dropdown** on the template configuration page.
+
+---
+
+## What can I do with this?
+
+- **Transcribe audio / video** to text using Whisper (tiny → large-v3)
+- **Translate** audio in any supported language to English
+- **Use the Gradio UI** for drag-and-drop transcription with speaker diarization
+- **Call the REST API** from your own apps, scripts, or workflows
+- **Access** via SSH, Jupyter, or Instance Portal
+
+---
+
+## Who is this for?
+
+This is **perfect** if you:
+- Want an out-of-the-box Whisper service without wrestling with dependencies
+- Need both a human-friendly UI and a machine-friendly API in one instance
+- Prefer a reproducible GPU environment with PyTorch pre-installed
+
+---
+
+## Quick Start Guide
+
+### **Step 1: Launch Instance**
+Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Whisper)"** when you've found a suitable GPU instance.
+
+### **Step 2: Access Your Instance**
+Click the **"Open"** button to reach the Whisper WebUI, or use the API endpoint directly (see port reference below).
+
+### **Step 3: Transcribe**
+- **UI:** upload a file, choose a model, click Transcribe.
+- **API:** POST audio to `/transcription` on port 18000.
+
+---
+
+## Services
+
+| Service | Description |
+|---------|-------------|
+| **Whisper WebUI** | Gradio front-end, starts after the API is reachable |
+| **Whisper API** | FastAPI backend exposing transcription / translation endpoints |
+
+Each runs as its own Supervisor process. To run **only** one of them, remove the other's entry from `/etc/portal.yaml` — its startup script will exit cleanly.
+
+---
+
+## Port Reference
+
+| Service | External Port | Internal Port |
+|---------|---------------|---------------|
+| Instance Portal | 1111 | 11111 |
+| Whisper WebUI | 17860 | 7860 |
+| Whisper API | 18000 | 8000 |
+| Jupyter | 8080 | 8080 |
+
+---
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE` | `/workspace` | Workspace directory |
+| `WHISPER_API_ARGS` | `--host 0.0.0.0 --port 8000` | uvicorn args |
+| `WHISPER_UI_ARGS` | `--whisper_type whisper --server_port 7860` | Gradio args |
+| `WHISPER_API_HEALTH_URL` | `http://localhost:8000/docs` | URL the UI polls before starting |
+| `PROVISIONING_SCRIPT` | (none) | URL to a setup script to run on first boot |
+
+---
+
+## CUDA Compatibility
+
+Images are tagged with the CUDA version they were built against (e.g. `<ref>-<date>-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
+
+**Minor version compatibility:** NVIDIA guarantees that an application built with any CUDA toolkit within a major version family will run on a driver from the same family. A `cuda-12.9` image runs on any CUDA 12.x driver (driver >= 525), and a `cuda-13.1` image runs on any CUDA 13.x driver (driver >= 580). The 12.x and 13.x families are separate.
+
+**Forward compatibility:** All images include the [CUDA Compatibility Package](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html) for use on **datacenter GPUs**.
+
+---
+
+## Need More Help?
+
+- **Whisper-WebUI Repository:** [jhj0517/Whisper-WebUI](https://github.com/jhj0517/Whisper-WebUI)
+- **OpenAI Whisper:** [openai/whisper](https://github.com/openai/whisper)
+- **Image Source & Features:** [GitHub Repository](https://github.com/vast-ai/base-image/tree/main/derivatives/pytorch/derivatives/whisper)
+- **Instance Portal Guide:** [Vast.ai Instance Portal Documentation](https://docs.vast.ai/instance-portal)
+- **SSH Setup Guide:** [Vast.ai SSH Documentation](https://docs.vast.ai/instances/sshscp)
+- **Template Configuration:** [Vast.ai Template Guide](https://docs.vast.ai/templates)

--- a/derivatives/pytorch/derivatives/whisper/ROOT/LICENSES.md
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/LICENSES.md
@@ -1,0 +1,27 @@
+# Third-Party Licenses
+
+This image bundles the following vendor application(s). Each is the property of
+its respective authors and is distributed under the license shown below. Where
+the vendor's source or LICENSE file is shipped inside this image at a known
+location, the path is given. Otherwise, the upstream repository is referenced
+as the canonical source for the license text.
+
+## PyTorch
+
+- **License:** BSD-3-Clause
+- **Upstream:** https://github.com/pytorch/pytorch
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/torch-*.dist-info/LICENSE`
+
+## Whisper-WebUI
+
+- **License:** Apache-2.0
+- **Upstream:** https://github.com/jhj0517/Whisper-WebUI
+- **License file in image:** `$WORKSPACE/Whisper-WebUI/LICENSE`
+
+## OpenAI Whisper
+
+- **License:** MIT
+- **Upstream:** https://github.com/openai/whisper
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/whisper-*.dist-info/LICENSE`

--- a/derivatives/pytorch/derivatives/whisper/ROOT/etc/supervisor/conf.d/whisper-api.conf
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/etc/supervisor/conf.d/whisper-api.conf
@@ -1,0 +1,17 @@
+[program:whisper-api]
+environment=PROC_NAME="%(program_name)s"
+command=/opt/supervisor-scripts/whisper-api.sh
+autostart=true
+autorestart=unexpected
+exitcodes=0
+startsecs=0
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
+stopwaitsecs=10
+# This is necessary for Vast logging to work alongside the Portal logs (Must output to /dev/stdout)
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+stdout_events_enabled=true
+stdout_logfile_maxbytes=0
+stdout_logfile_backups=0

--- a/derivatives/pytorch/derivatives/whisper/ROOT/etc/supervisor/conf.d/whisper-ui.conf
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/etc/supervisor/conf.d/whisper-ui.conf
@@ -1,0 +1,17 @@
+[program:whisper-ui]
+environment=PROC_NAME="%(program_name)s"
+command=/opt/supervisor-scripts/whisper-ui.sh
+autostart=true
+autorestart=unexpected
+exitcodes=0
+startsecs=0
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
+stopwaitsecs=10
+# This is necessary for Vast logging to work alongside the Portal logs (Must output to /dev/stdout)
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+stdout_events_enabled=true
+stdout_logfile_maxbytes=0
+stdout_logfile_backups=0

--- a/derivatives/pytorch/derivatives/whisper/ROOT/opt/supervisor-scripts/whisper-api.sh
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/opt/supervisor-scripts/whisper-api.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+utils=/opt/supervisor-scripts/utils
+. "${utils}/logging.sh"
+. "${utils}/cleanup_generic.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh" "Whisper API"
+
+echo "Starting Whisper API"
+
+. /venv/main/bin/activate
+
+# Wait for provisioning to complete
+while [ -f "/.provisioning" ]; do
+    echo "$PROC_NAME startup paused until instance provisioning has completed (/.provisioning present)"
+    sleep 10
+done
+
+cd "${WORKSPACE}/Whisper-WebUI"
+
+pty uvicorn backend.main:app ${WHISPER_API_ARGS:---host 0.0.0.0 --port 8000} 2>&1

--- a/derivatives/pytorch/derivatives/whisper/ROOT/opt/supervisor-scripts/whisper-ui.sh
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/opt/supervisor-scripts/whisper-ui.sh
@@ -14,13 +14,19 @@ while [ -f "/.provisioning" ]; do
     sleep 10
 done
 
-# Wait for the Whisper API to be ready so the UI backend calls succeed on first load
+# Only wait for the API when it's configured in the portal; otherwise run standalone
+# so the documented "UI-only" mode (remove "Whisper API" from /etc/portal.yaml) works.
+PORTAL_CONFIG_PATH=${PORTAL_CONFIG_PATH:-/etc/portal.yaml}
 WHISPER_API_HEALTH_URL=${WHISPER_API_HEALTH_URL:-http://localhost:8000/docs}
-until (curl -s -o /dev/null -w '%{http_code}' "${WHISPER_API_HEALTH_URL}" || echo "000") | grep -q 200; do
-    echo "Waiting for Whisper API at ${WHISPER_API_HEALTH_URL}..."
-    sleep 5
-done
-echo "Whisper API is up!"
+if [ -f "${PORTAL_CONFIG_PATH}" ] && grep -qiE '^[^#].*Whisper[ _-]API' "${PORTAL_CONFIG_PATH}"; then
+    until (curl -s -o /dev/null -w '%{http_code}' "${WHISPER_API_HEALTH_URL}" || echo "000") | grep -q 200; do
+        echo "Waiting for Whisper API at ${WHISPER_API_HEALTH_URL}..."
+        sleep 5
+    done
+    echo "Whisper API is up!"
+else
+    echo "Whisper API not in ${PORTAL_CONFIG_PATH}; skipping API readiness wait (UI-only mode)"
+fi
 
 echo "Starting Whisper WebUI"
 

--- a/derivatives/pytorch/derivatives/whisper/ROOT/opt/supervisor-scripts/whisper-ui.sh
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/opt/supervisor-scripts/whisper-ui.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+utils=/opt/supervisor-scripts/utils
+. "${utils}/logging.sh"
+. "${utils}/cleanup_generic.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh" "Whisper WebUI"
+
+. /venv/main/bin/activate
+
+# Wait for provisioning to complete
+while [ -f "/.provisioning" ]; do
+    echo "$PROC_NAME startup paused until instance provisioning has completed (/.provisioning present)"
+    sleep 10
+done
+
+# Wait for the Whisper API to be ready so the UI backend calls succeed on first load
+WHISPER_API_HEALTH_URL=${WHISPER_API_HEALTH_URL:-http://localhost:8000/docs}
+until (curl -s -o /dev/null -w '%{http_code}' "${WHISPER_API_HEALTH_URL}" || echo "000") | grep -q 200; do
+    echo "Waiting for Whisper API at ${WHISPER_API_HEALTH_URL}..."
+    sleep 5
+done
+echo "Whisper API is up!"
+
+echo "Starting Whisper WebUI"
+
+cd "${WORKSPACE}/Whisper-WebUI"
+
+pty python app.py ${WHISPER_UI_ARGS:---whisper_type whisper --server_port 7860} 2>&1


### PR DESCRIPTION
## Summary
- New standalone Whisper derivative at `derivatives/pytorch/derivatives/whisper/` bundles both the Whisper-WebUI Gradio interface and its FastAPI backend as independent supervisor services.
- UI service waits on the API's `/docs` endpoint before starting, matching the `ace-step-ui.sh` pattern, so first-load Gradio calls against the API succeed cleanly.
- Each service carries its own `exit_portal.sh` gate (`Whisper WebUI` / `Whisper API`) — removing either entry from `/etc/portal.yaml` runs the other alone.
- Workflow uses `check-github-release` against `jhj0517/Whisper-WebUI` so scheduled runs only rebuild when a new release tag is published. Manual `workflow_dispatch` always builds.
- Pushes to `vastai/whisper` on DockerHub (repo already exists).

## Test plan
- [ ] Trigger `Build Whisper Image` via `workflow_dispatch` and confirm the image builds and pushes to `vastai/whisper`.
- [ ] Launch the resulting image on Vast, confirm the WebUI reaches port 7860 and the API reaches port 8000 (portal maps 17860 / 18000 externally).
- [ ] POST a small audio file to `/transcription` on the API and confirm a valid response.
- [ ] Remove `Whisper API` from `/etc/portal.yaml`, restart supervisor, confirm the API exits via the portal gate and the UI still boots (API readiness poll will timeout-retry until the user re-enables).
- [ ] Remove `Whisper WebUI` instead, confirm API boots alone.
- [ ] `supervisorctl status whisper-api whisper-ui` shows both services running by default.