### PR TITLE
Gate Unsloth Studio builds on PyPI releases

### DIFF
--- a/.github/actions/check-pypi-release/action.yml
+++ b/.github/actions/check-pypi-release/action.yml
@@ -1,0 +1,146 @@
+# .github/actions/check-pypi-release/action.yml
+name: Check PyPI Release
+description: Check for a new release on PyPI and resolve the version to build
+
+inputs:
+  package:
+    description: "PyPI package name (e.g. unsloth)"
+    required: true
+  age-threshold-seconds:
+    description: "Max age in seconds to consider a release 'new' for scheduled runs"
+    required: false
+    default: "86400"
+  trigger:
+    description: "What triggered the workflow (github.event_name)"
+    required: true
+  manual-version:
+    description: "Version provided via manual trigger (if any)"
+    required: false
+    default: ""
+  default-version:
+    description: "Fallback version if the PyPI query fails and no manual version was given"
+    required: false
+    default: ""
+  version-pattern:
+    description: "Regex to filter candidate version strings (e.g. '^[0-9]+\\.[0-9]+\\.[0-9]+$'). Empty matches all."
+    required: false
+    default: ""
+  include-prereleases:
+    description: "Whether to consider PEP 440 pre-releases (rc/a/b/dev). Default false."
+    required: false
+    default: "false"
+
+outputs:
+  new-release:
+    description: "Whether a new release was found (always true for manual/non-schedule triggers when a version is resolved)"
+    value: ${{ steps.result.outputs.new-release }}
+  resolved-version:
+    description: "The version to use for building"
+    value: ${{ steps.result.outputs.resolved-version }}
+  upload-time:
+    description: "Upload timestamp of the resolved release (ISO 8601)"
+    value: ${{ steps.result.outputs.upload-time }}
+
+runs:
+  using: composite
+  steps:
+    - name: Query PyPI for latest release
+      id: check
+      shell: bash
+      env:
+        PKG: ${{ inputs.package }}
+        TRIGGER: ${{ inputs.trigger }}
+        MANUAL_VERSION: ${{ inputs.manual-version }}
+        DEFAULT_VERSION: ${{ inputs.default-version }}
+        AGE_THRESHOLD: ${{ inputs.age-threshold-seconds }}
+        VERSION_PATTERN: ${{ inputs.version-pattern }}
+        INCLUDE_PRERELEASES: ${{ inputs.include-prereleases }}
+      run: |
+        set -euo pipefail
+        echo "Checking PyPI for latest release of ${PKG}..."
+
+        RESPONSE_FILE=$(mktemp)
+        HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" \
+          -H "Accept: application/json" \
+          "https://pypi.org/pypi/${PKG}/json" || echo "000")
+
+        if [[ "$HTTP_CODE" != "200" ]]; then
+          echo "::warning::PyPI API returned $HTTP_CODE for ${PKG}"
+          # Non-schedule triggers proceed with whatever fallback the caller provides.
+          if [[ "$TRIGGER" != "schedule" ]]; then
+            FALLBACK="${MANUAL_VERSION:-$DEFAULT_VERSION}"
+            echo "new-release=$([[ -n "$FALLBACK" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            echo "resolved-version=$FALLBACK" >> "$GITHUB_OUTPUT"
+          else
+            echo "new-release=false" >> "$GITHUB_OUTPUT"
+            echo "resolved-version=" >> "$GITHUB_OUTPUT"
+          fi
+          echo "upload-time=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Pick the most-recently-uploaded non-yanked release whose version matches
+        # the optional pattern. Sorting by upload_time_iso_8601 avoids needing
+        # PEP 440 version ordering in bash.
+        LATEST=$(jq -c \
+          --arg pattern "$VERSION_PATTERN" \
+          --argjson prereleases "$INCLUDE_PRERELEASES" '
+            .releases
+            | to_entries
+            | map(select(.value | length > 0))
+            | map(select(.value[0].yanked != true))
+            | map(select(($pattern == "") or (.key | test($pattern))))
+            | (if $prereleases then .
+               else map(select(.key | test("^[0-9]+(\\.[0-9]+)*$"))) end)
+            | map({version: .key, uploaded: (.value | map(.upload_time_iso_8601) | sort | last)})
+            | map(select(.uploaded != null))
+            | sort_by(.uploaded)
+            | reverse
+            | .[0] // empty
+          ' < "$RESPONSE_FILE")
+
+        if [[ -z "$LATEST" || "$LATEST" == "null" ]]; then
+          echo "::warning::No PyPI releases matched filters for ${PKG}"
+          echo "new-release=false" >> "$GITHUB_OUTPUT"
+          echo "resolved-version=" >> "$GITHUB_OUTPUT"
+          echo "upload-time=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        VERSION=$(echo "$LATEST" | jq -r '.version')
+        UPLOAD_TIME=$(echo "$LATEST" | jq -r '.uploaded')
+
+        echo "resolved-version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "upload-time=$UPLOAD_TIME" >> "$GITHUB_OUTPUT"
+
+        RELEASE_EPOCH=$(date -d "$UPLOAD_TIME" +%s)
+        NOW_EPOCH=$(date +%s)
+        AGE=$((NOW_EPOCH - RELEASE_EPOCH))
+        AGE_HOURS=$((AGE / 3600))
+        echo "Latest ${PKG}: $VERSION (uploaded $AGE_HOURS hours ago)"
+
+        if [[ "$TRIGGER" != "schedule" ]]; then
+          # Manual/workflow_dispatch: always proceed, but let manual-version override.
+          if [[ -n "$MANUAL_VERSION" ]]; then
+            echo "resolved-version=$MANUAL_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Using manual version: $MANUAL_VERSION"
+          fi
+          echo "new-release=true" >> "$GITHUB_OUTPUT"
+        elif [[ $AGE -lt $AGE_THRESHOLD ]]; then
+          echo "new-release=true" >> "$GITHUB_OUTPUT"
+          echo "New release detected (within threshold)"
+        else
+          echo "new-release=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No new ${PKG} release within threshold period"
+        fi
+
+    - name: Emit final outputs
+      id: result
+      shell: bash
+      run: |
+        # The `check` step writes the authoritative values; this step just
+        # re-exports them so callers see a consistent output surface even when
+        # `check` exits early.
+        echo "new-release=${{ steps.check.outputs.new-release }}" >> "$GITHUB_OUTPUT"
+        echo "resolved-version=${{ steps.check.outputs.resolved-version }}" >> "$GITHUB_OUTPUT"
+        echo "upload-time=${{ steps.check.outputs.upload-time }}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/check-pypi-release/action.yml
+++ b/.github/actions/check-pypi-release/action.yml
@@ -59,6 +59,13 @@ runs:
         set -euo pipefail
         echo "Checking PyPI for latest release of ${PKG}..."
 
+        # Sanity-check manual-version before it ever reaches $GITHUB_OUTPUT,
+        # so newlines or other funky chars can't corrupt the outputs file.
+        if [[ -n "$MANUAL_VERSION" && ! "$MANUAL_VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+          echo "::error::Invalid manual-version '$MANUAL_VERSION' (expected ^[0-9A-Za-z][0-9A-Za-z._+-]*$)"
+          exit 1
+        fi
+
         RESPONSE_FILE=$(mktemp)
         HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" \
           -H "Accept: application/json" \
@@ -66,10 +73,16 @@ runs:
 
         if [[ "$HTTP_CODE" != "200" ]]; then
           echo "::warning::PyPI API returned $HTTP_CODE for ${PKG}"
-          # Non-schedule triggers proceed with whatever fallback the caller provides.
           if [[ "$TRIGGER" != "schedule" ]]; then
+            # Manual trigger: proceed with whatever fallback the caller gave us.
+            # No fallback means the caller asked for "latest" but we can't
+            # resolve it — fail loudly rather than silently no-op'ing the build.
             FALLBACK="${MANUAL_VERSION:-$DEFAULT_VERSION}"
-            echo "new-release=$([[ -n "$FALLBACK" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            if [[ -z "$FALLBACK" ]]; then
+              echo "::error::PyPI unavailable and no manual-version/default-version provided"
+              exit 1
+            fi
+            echo "new-release=true" >> "$GITHUB_OUTPUT"
             echo "resolved-version=$FALLBACK" >> "$GITHUB_OUTPUT"
           else
             echo "new-release=false" >> "$GITHUB_OUTPUT"
@@ -79,20 +92,23 @@ runs:
           exit 0
         fi
 
-        # Pick the most-recently-uploaded non-yanked release whose version matches
-        # the optional pattern. Sorting by upload_time_iso_8601 avoids needing
-        # PEP 440 version ordering in bash.
+        # Pick the most-recently-uploaded release whose version matches the
+        # optional pattern. Yanked files are filtered per-file (a partial yank
+        # doesn't disqualify a version), and the prerelease filter excludes
+        # only PEP 440 prerelease segments (a/b/rc/dev/pre/alpha/beta) — it
+        # still allows post-releases, epochs, and local versions. Sorting by
+        # upload_time_iso_8601 avoids needing PEP 440 version ordering in bash.
         LATEST=$(jq -c \
           --arg pattern "$VERSION_PATTERN" \
           --argjson prereleases "$INCLUDE_PRERELEASES" '
             .releases
             | to_entries
+            | map({key: .key, value: (.value | map(select(.yanked != true)))})
             | map(select(.value | length > 0))
-            | map(select(.value[0].yanked != true))
             | map(select(($pattern == "") or (.key | test($pattern))))
             | (if $prereleases then .
-               else map(select(.key | test("^[0-9]+(\\.[0-9]+)*$"))) end)
-            | map({version: .key, uploaded: (.value | map(.upload_time_iso_8601) | sort | last)})
+               else map(select(.key | ascii_downcase | test("^(?:[0-9]+!)?[0-9]+(?:\\.[0-9]+)*(?:(?:[._-]?post[._-]?[0-9]*)|(?:-[0-9]+))?(?:\\+[a-z0-9]+(?:[-_.][a-z0-9]+)*)?$"))) end)
+            | map({version: .key, uploaded: (.value | map(.upload_time_iso_8601) | map(select(. != null)) | sort | last)})
             | map(select(.uploaded != null))
             | sort_by(.uploaded)
             | reverse

--- a/.github/actions/check-pypi-release/action.yml
+++ b/.github/actions/check-pypi-release/action.yml
@@ -59,10 +59,27 @@ runs:
         set -euo pipefail
         echo "Checking PyPI for latest release of ${PKG}..."
 
-        # Sanity-check manual-version before it ever reaches $GITHUB_OUTPUT,
+        # Validate any version string that might flow into $GITHUB_OUTPUT,
         # so newlines or other funky chars can't corrupt the outputs file.
-        if [[ -n "$MANUAL_VERSION" && ! "$MANUAL_VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
-          echo "::error::Invalid manual-version '$MANUAL_VERSION' (expected ^[0-9A-Za-z][0-9A-Za-z._+-]*$)"
+        version_re='^[0-9A-Za-z][0-9A-Za-z._+-]*$'
+        if [[ -n "$MANUAL_VERSION" && ! "$MANUAL_VERSION" =~ $version_re ]]; then
+          echo "::error::Invalid manual-version '$MANUAL_VERSION' (expected $version_re)"
+          exit 1
+        fi
+        if [[ -n "$DEFAULT_VERSION" && ! "$DEFAULT_VERSION" =~ $version_re ]]; then
+          echo "::error::Invalid default-version '$DEFAULT_VERSION' (expected $version_re)"
+          exit 1
+        fi
+
+        # Normalize include-prereleases to strict "true"/"false" for jq --argjson,
+        # and ensure age-threshold-seconds is an integer before `-lt`.
+        case "${INCLUDE_PRERELEASES,,}" in
+          true|1|yes)  INCLUDE_PRERELEASES=true ;;
+          false|0|no|"") INCLUDE_PRERELEASES=false ;;
+          *) echo "::error::Invalid include-prereleases '$INCLUDE_PRERELEASES' (expected true/false)"; exit 1 ;;
+        esac
+        if [[ ! "$AGE_THRESHOLD" =~ ^[0-9]+$ ]]; then
+          echo "::error::Invalid age-threshold-seconds '$AGE_THRESHOLD' (expected non-negative integer)"
           exit 1
         fi
 
@@ -117,8 +134,21 @@ runs:
 
         if [[ -z "$LATEST" || "$LATEST" == "null" ]]; then
           echo "::warning::No PyPI releases matched filters for ${PKG}"
-          echo "new-release=false" >> "$GITHUB_OUTPUT"
-          echo "resolved-version=" >> "$GITHUB_OUTPUT"
+          if [[ "$TRIGGER" != "schedule" ]]; then
+            # Manual trigger with no matching release: same reasoning as the
+            # PyPI-unavailable path — honor caller's fallback, otherwise fail
+            # loudly rather than silently no-op'ing.
+            FALLBACK="${MANUAL_VERSION:-$DEFAULT_VERSION}"
+            if [[ -z "$FALLBACK" ]]; then
+              echo "::error::No PyPI releases matched filters and no manual-version/default-version provided"
+              exit 1
+            fi
+            echo "new-release=true" >> "$GITHUB_OUTPUT"
+            echo "resolved-version=$FALLBACK" >> "$GITHUB_OUTPUT"
+          else
+            echo "new-release=false" >> "$GITHUB_OUTPUT"
+            echo "resolved-version=" >> "$GITHUB_OUTPUT"
+          fi
           echo "upload-time=" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/.github/actions/check-pypi-release/action.yml
+++ b/.github/actions/check-pypi-release/action.yml
@@ -167,8 +167,11 @@ runs:
 
         if [[ "$TRIGGER" != "schedule" ]]; then
           # Manual/workflow_dispatch: always proceed, but let manual-version override.
+          # When overriding, clear upload-time — the timestamp we fetched
+          # describes the PyPI-latest version, not the one we're actually building.
           if [[ -n "$MANUAL_VERSION" ]]; then
             echo "resolved-version=$MANUAL_VERSION" >> "$GITHUB_OUTPUT"
+            echo "upload-time=" >> "$GITHUB_OUTPUT"
             echo "Using manual version: $MANUAL_VERSION"
           fi
           echo "new-release=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -16,8 +16,8 @@ on:
 
   workflow_dispatch:
     inputs:
-      UNSLOTH_REF:
-        description: "Unsloth Studio release tag - leave empty for latest"
+      UNSLOTH_VERSION:
+        description: "Unsloth PyPI version - leave empty for latest"
         required: false
       DOCKERHUB_REPO:
         description: "Push to username/<repo>"
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.decision.outputs.should-run }}
-      unsloth-ref: ${{ steps.release-check.outputs.resolved-ref }}
+      unsloth-version: ${{ steps.release-check.outputs.resolved-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,26 +59,21 @@ jobs:
             echo "::notice::Skipping - secrets not configured"
           fi
 
-      - name: Check release and resolve ref
+      - name: Check PyPI release
         id: release-check
-        uses: ./.github/actions/check-github-release
+        uses: ./.github/actions/check-pypi-release
         with:
-          repository: unslothai/unsloth
+          package: unsloth
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           trigger: ${{ github.event_name }}
-          manual-ref: ${{ inputs.UNSLOTH_REF }}
-          default-ref: ""
-          # Only match studio release tags (v0.1.0-beta etc.), not llama.cpp builds (b8508)
-          tag-pattern: "^v"
-          resolve-master-to-commit: "false"
+          manual-version: ${{ inputs.UNSLOTH_VERSION }}
 
       - name: Determine if build should run
         id: decision
         run: |
           if [[ "${{ steps.secrets.outputs.available }}" == "true" && "${{ steps.release-check.outputs.new-release }}" == "true" ]]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
-            echo "✓ Building ref: ${{ steps.release-check.outputs.resolved-ref }}"
+            echo "✓ Building unsloth ${{ steps.release-check.outputs.resolved-version }}"
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
           fi
@@ -133,7 +128,7 @@ jobs:
 
           IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
           if [ -z "$IMAGE_TAG_BASE" ]; then
-            IMAGE_TAG_BASE="${{ needs.preflight.outputs.unsloth-ref }}"
+            IMAGE_TAG_BASE="${{ needs.preflight.outputs.unsloth-version }}"
           fi
 
           DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || 'unsloth-studio' }}"
@@ -164,6 +159,7 @@ jobs:
           docker buildx build \
             --platform "$platforms" \
             --build-arg PYTORCH_BASE=${{ matrix.base_image }} \
+            --build-arg UNSLOTH_VERSION=${{ needs.preflight.outputs.unsloth-version }} \
             -t ${{ env.FULL_IMAGE }} \
             . --push
 
@@ -214,7 +210,7 @@ jobs:
     with:
       build-result: ${{ needs.build.result }}
       image-name: "Unsloth Studio"
-      image-ref: ${{ needs.preflight.outputs.unsloth-ref }}
+      image-ref: ${{ needs.preflight.outputs.unsloth-version }}
       image-tags: ${{ needs.collect-tags.outputs.all-tags }}
       trigger: ${{ github.event_name }}
       run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -23,12 +23,14 @@ RUN \
 # Install unsloth, symlink the studio venv to /venv/main so setup.sh installs
 # everything into our existing venv (avoids a duplicate torch install), then
 # run studio setup for frontend build + llama.cpp + all python deps.
+ARG UNSLOTH_VERSION=""
 RUN \
     set -euo pipefail && \
     . /opt/nvm/nvm.sh && \
     . /venv/main/bin/activate && \
     torch_version_pre="$(python -c 'import torch; print(torch.__version__)')" && \
-    uv pip install --no-cache-dir --torch-backend=cu128 unsloth && \
+    unsloth_spec="unsloth${UNSLOTH_VERSION:+==${UNSLOTH_VERSION}}" && \
+    uv pip install --no-cache-dir --torch-backend=cu128 "$unsloth_spec" && \
     # Store unsloth data under /opt so it survives volume mounts over /root
     mkdir -p /opt/workspace-internal/unsloth/studio && \
     ln -sf /opt/workspace-internal/unsloth /root/.unsloth && \

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -23,7 +23,7 @@ RUN \
 # Install unsloth, symlink the studio venv to /venv/main so setup.sh installs
 # everything into our existing venv (avoids a duplicate torch install), then
 # run studio setup for frontend build + llama.cpp + all python deps.
-ARG UNSLOTH_VERSION=""
+ARG UNSLOTH_VERSION=
 RUN \
     set -euo pipefail && \
     . /opt/nvm/nvm.sh && \


### PR DESCRIPTION
## Summary
- Unsloth ships to PyPI more frequently than it cuts GitHub releases, so the old GitHub-release gate kept the scheduled builder idle through most of the real release cadence.
- New `.github/actions/check-pypi-release` composite action queries `pypi.org/pypi/{package}/json`, picks the most-recently-uploaded non-yanked release (with optional `version-pattern` and `include-prereleases` filters), and gates scheduled runs on `age-threshold-seconds`.
- `build-unsloth-studio.yml` now uses this action; `UNSLOTH_REF` input / `unsloth-ref` output renamed to the PyPI-accurate `UNSLOTH_VERSION` / `unsloth-version`, and the resolved version flows through as a `--build-arg` so the Dockerfile installs `unsloth==X.Y.Z` — no more drift between image tag and installed package.
- Dockerfile's build arg defaults to empty, so local `docker build` keeps its unpinned-latest behavior.

## Test plan
- [x] Manual `workflow_dispatch` with empty `UNSLOTH_VERSION` — preflight resolves latest PyPI version, build tag matches installed package.
- [ ] Manual `workflow_dispatch` with an explicit older `UNSLOTH_VERSION` (e.g. `2026.4.6`) — builds and tags with that version.
- [ ] Let a scheduled run trigger after a fresh PyPI release — preflight gates `should-run=true`.
- [ ] Wait past the 12h threshold with no new release — scheduled run no-ops.