### PR TITLE
Add Build FluxGym Image workflow stub

### DIFF
--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -1,0 +1,19 @@
+# Stub so "Build FluxGym Image" is registered on the default branch and can be
+# dispatched against the fluxgym-docker-image feature branch via:
+#   gh workflow run "Build FluxGym Image" --ref fluxgym-docker-image
+# Replaced with the full workflow when PR #153 merges.
+
+name: Build FluxGym Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub notice
+        run: |
+          echo "This is a stub of Build FluxGym Image on the default branch."
+          echo "The real workflow lives on the fluxgym-docker-image branch until its PR merges."
+          echo "Re-run this workflow with --ref fluxgym-docker-image to build against the branch."


### PR DESCRIPTION
## Summary
- Registers "Build FluxGym Image" on the default branch so it can be dispatched against the `fluxgym-docker-image` feature branch before PR #153 merges.
- Mirrors the pattern used for the Wan2GP and Whisper stubs (replaced with the full workflow when the feature PR merges).

## Test plan
- [ ] Stub run via `gh workflow run "Build FluxGym Image" --ref fluxgym-docker-image` succeeds against the feature branch