### PR TITLE
Bump portal-aio deps to clear Dependabot alerts

### DIFF
--- a/portal-aio/requirements.txt
+++ b/portal-aio/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==24.1.0
 aiohappyeyeballs==2.5.0
-aiohttp==3.13.3
+aiohttp==3.13.4
 aiosignal==1.4.0
 annotated-doc==0.0.3
 annotated-types==0.7.0
@@ -32,11 +32,11 @@ propcache==0.2.0
 psutil==6.1.1
 pydantic==2.9.2
 pydantic_core==2.23.4
-Pygments==2.18.0
-python-dotenv==1.0.1
-python-multipart==0.0.22
+Pygments==2.20.0
+python-dotenv==1.2.2
+python-multipart==0.0.26
 PyYAML==6.0.2
-requests==2.32.4
+requests==2.33.0
 rich==13.9.2
 shellingham==1.5.4
 shortuuid==1.0.13


### PR DESCRIPTION
## Summary
- Bumps 5 packages in `portal-aio/requirements.txt` to clear all 14 open Dependabot alerts
- `aiohttp` 3.13.3 → 3.13.4 (9 alerts: Host header dupe, header injection, cross-origin header leak, multipart DoS, response splitting, size bypass, UNC SSRF, CRLF injection, DNS cache DoS, trailer headers)
- `Pygments` 2.18.0 → 2.20.0 (GUID regex ReDoS)
- `python-dotenv` 1.0.1 → 1.2.2 (symlink arbitrary file overwrite)
- `python-multipart` 0.0.22 → 0.0.26 (preamble/epilogue DoS)
- `requests` 2.32.4 → 2.33.0 (insecure temp file reuse in `extract_zipped_paths`)

## Test plan
- [ ] CI builds pass