### PR TITLE
Fix vLLM CUDA tag mapping after default bump to 13.0

### DIFF
--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -90,18 +90,23 @@ jobs:
           VARIANTS=$(cat /tmp/variants.json)
           echo "Available variants: $VARIANTS"
           
-          # Convert variant tags to build matrix
-          # Base tag (v0.14.0) is CUDA 12.9, -cu130 is CUDA 13.0
-          MATRIX=$(echo "$VARIANTS" | jq -c --arg ver "$VERSION" '
+          # Convert variant tags to build matrix.
+          # Key off explicit -cuNNN suffix only — the unsuffixed base tag's
+          # CUDA version tracks whatever vLLM currently defaults to (was 12.9,
+          # now 13.0), so relying on it produces mistagged images and
+          # duplicates whichever -cuNNN variant matches the current default.
+          MATRIX=$(echo "$VARIANTS" | jq -c '
             map(
               # Skip arch-specific tags (we use multi-arch builds)
               select(test("-(x86_64|aarch64)") | not)
+              # Skip ubuntu2404 (and any other non-CUDA) variants
+              | select(test("-ubuntu") | not)
             )
             | map(
-              if . == $ver then
-                {tag: ., cuda: "12.9"}
-              elif endswith("-cu130") then
+              if endswith("-cu130") then
                 {tag: ., cuda: "13.0"}
+              elif endswith("-cu129") then
+                {tag: ., cuda: "12.9"}
               elif endswith("-cu128") then
                 {tag: ., cuda: "12.8"}
               else


### PR DESCRIPTION
## Summary
- vLLM moved its default CUDA from 12.9 to 13.0, so the unsuffixed base tag (e.g. `v0.20.0`) now means CUDA 13.0. The build matrix still mapped the bare tag to `12.9`, producing a mistagged image, rebuilding `-cu130` as a content-identical duplicate, and silently dropping `-cu129`.
- Key the matrix off the explicit `-cuNNN` suffix only (and ignore the new `-ubuntu2404` variants). One correctly tagged image per CUDA version, robust to future default bumps.
- `build-vllm-omni.yml` intentionally left untouched — vllm-omni does not publish `-cuNNN` variants, and the same change there would empty the matrix. Will be addressed separately.

## Validation
Running the new jq pipeline against the live `vllm/vllm-openai` tag list for `v0.20.0` produces:

```
[{"tag":"v0.20.0-cu129","cuda":"12.9"},{"tag":"v0.20.0-cu130","cuda":"13.0"}]
```

No duplicate CUDA-13 build, `-cu129` correctly picked up, bare/`-ubuntu2404`/arch-specific tags filtered out.

## Test plan
- [x] Manual `workflow_dispatch` of Build vLLM Image against latest release; confirm two images are pushed (`...-cuda-12.9` and `...-cuda-13.0`) with no duplicate tags.
- [x] Spot-check that the resulting `-cuda-13.0` image actually ships CUDA 13.0 and `-cuda-12.9` ships CUDA 12.9.