### PR TITLE
Fix llama.cpp SIGILL on Unsloth Studio images

### DIFF
--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -39,6 +39,12 @@ RUN \
     # Patch install_python_stack.py to use cu128 torch backend instead of auto-detection
     find /venv/main/lib -name 'install_python_stack.py' -path '*/studio/*' \
         -exec sed -i 's|--torch-backend=auto|--torch-backend=cu128|' {} + && \
+    # Patch setup.sh to build llama.cpp with portable CPU dispatch instead of -march=native.
+    # Without this, the build host's AVX-512 leaks into libggml-cpu.so and SIGILLs on
+    # any runtime CPU lacking AVX-512 (e.g. Zen 2). GGML_CPU_ALL_VARIANTS produces
+    # per-microarch backends selected at runtime.
+    find /venv/main/lib -name 'setup.sh' -path '*/studio/*' \
+        -exec sed -i 's|-DGGML_NATIVE=ON|-DGGML_NATIVE=OFF -DGGML_CPU_ALL_VARIANTS=ON -DGGML_BACKEND_DL=ON -DBUILD_SHARED_LIBS=ON|' {} + && \
     # Skip prebuilt llama.cpp (needs nvidia-smi), go straight to source build
     export UNSLOTH_LLAMA_FORCE_COMPILE=1 && \
     export SKIP_STUDIO_BASE=1 && \


### PR DESCRIPTION
## Summary

- The studio's bundled `setup.sh` hardcodes `cmake … -DGGML_NATIVE=ON`, which adds `-march=native` and bakes the build host's instruction set into `libggml-cpu.so`. On runtime CPUs without AVX-512 (e.g. EPYC 7642 / Zen 2), `llama-server` raises SIGILL the moment it touches the CPU backend, so any GGUF load fails with exit 132 (Python `-4`).
- Patch `setup.sh` during the image build to swap `-DGGML_NATIVE=ON` for `-DGGML_NATIVE=OFF -DGGML_CPU_ALL_VARIANTS=ON -DGGML_BACKEND_DL=ON -DBUILD_SHARED_LIBS=ON`. llama.cpp then emits per-microarch backends (`libggml-cpu-{haswell,zen4,skylakex,…}.so`) and selects one at runtime via CPU feature detection — same approach as the previously-working images.

## Test plan

- [x] Reproduced `Illegal instruction` (exit 132) on a Zen 2 instance running the current image.
- [x] Confirmed the bad `libggml-cpu.so` contained AVX-512 ops (`vpermt2w`, `vmovdqu64 %zmm…`).
- [x] Confirmed `CMakeCache.txt` had `GGML_NATIVE=ON`, `GGML_CPU_ALL_VARIANTS=OFF`.
- [x] Rebuilt llama.cpp on the same instance with the new flags; per-microarch backends produced; dispatcher selected `libggml-cpu-haswell.so`; `gemma-4-E2B-it-UD-Q4_K_XL.gguf` loaded with `-ngl 0` cleanly, no SIGILL.
- [x] Verify a fresh CI build of the unsloth-studio image picks up the patch and ships per-microarch backends.