### PR TITLE
Fix vLLM/SGLang build matrices and SGLang supervisor stop

### DIFF
--- a/.github/workflows/build-sglang.yml
+++ b/.github/workflows/build-sglang.yml
@@ -93,23 +93,34 @@ jobs:
           echo "Available variants: $VARIANTS"
 
           # Convert variant tags to build matrix.
-          # Upstream tag scheme (v0.5.10+): multi-arch manifests, no -amd64 suffix.
-          #   <ver>           -> default CUDA 12.9
-          #   <ver>-cu130     -> CUDA 13.0
-          # Exclude rocm/xeon/cann/runtime variants and unrelated post/rc siblings
-          # by exact-matching ^<VERSION>(-cu[0-9]+)?$.
+          # Upstream tag scheme (v0.5.11+): multi-arch manifests, no -amd64 suffix.
+          # SGLang flipped the default CUDA from 12.9 to 13.0 in v0.5.11, so
+          # the bare <ver> tag now IS the CUDA 13.0 image (and is published
+          # alongside an explicit -cu130 alias). Prefer explicit -cuNNN
+          # suffixes; treat the bare $VERSION tag as CUDA 13.0 only when no
+          # -cu130 variant exists, so releases that ship both don't produce
+          # a duplicate CUDA 13.0 build (and the bare doesn't get mistagged
+          # as 12.9, clobbering the real -cu129 image at push time).
+          # Exclude rocm/xeon/cann/runtime variants by exact-matching
+          # ^<VERSION>(-cu[0-9]+)?$.
           MATRIX=$(echo "$VARIANTS" | jq -c --arg ver "$VERSION" '
             map(select(test("^" + $ver + "(-cu[0-9]+)?$")))
+            | . as $variants
+            | ($variants | any(endswith("-cu130"))) as $has_cu130
+            | $variants
             | map(
                 . as $tag
-                | (if $tag | test("-cu[0-9]+$")
-                   then ($tag | capture("-cu(?<raw>[0-9]+)$") | .raw)
-                   else "129"
-                   end) as $cu
-                | {
-                    tag: $tag,
-                    cuda: ($cu[0:($cu | length) - 1] + "." + $cu[($cu | length) - 1:])
-                  }
+                | if $tag | endswith("-cu130") then
+                    {tag: $tag, cuda: "13.0"}
+                  elif $tag | endswith("-cu129") then
+                    {tag: $tag, cuda: "12.9"}
+                  elif $tag | endswith("-cu128") then
+                    {tag: $tag, cuda: "12.8"}
+                  elif $tag == $ver and ($has_cu130 | not) then
+                    {tag: $tag, cuda: "13.0"}
+                  else
+                    empty
+                  end
               )
           ')
 

--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -91,17 +91,21 @@ jobs:
           echo "Available variants: $VARIANTS"
           
           # Convert variant tags to build matrix.
-          # Key off explicit -cuNNN suffix only — the unsuffixed base tag's
-          # CUDA version tracks whatever vLLM currently defaults to (was 12.9,
-          # now 13.0), so relying on it produces mistagged images and
-          # duplicates whichever -cuNNN variant matches the current default.
-          MATRIX=$(echo "$VARIANTS" | jq -c '
+          # Prefer explicit -cuNNN suffixes. As of v0.20.1 vLLM stopped
+          # publishing -cu130 entirely, so the unsuffixed base tag now IS
+          # the CUDA 13.0 image. Treat the bare $VERSION tag as CUDA 13.0
+          # only when no explicit -cu130 variant exists, so older releases
+          # that still ship both don't produce duplicate CUDA 13.0 builds.
+          MATRIX=$(echo "$VARIANTS" | jq -c --arg version "$VERSION" '
             map(
               # Skip arch-specific tags (we use multi-arch builds)
               select(test("-(x86_64|aarch64)") | not)
               # Skip ubuntu2404 (and any other non-CUDA) variants
               | select(test("-ubuntu") | not)
             )
+            | . as $variants
+            | ($variants | any(endswith("-cu130"))) as $has_cu130
+            | $variants
             | map(
               if endswith("-cu130") then
                 {tag: ., cuda: "13.0"}
@@ -109,6 +113,8 @@ jobs:
                 {tag: ., cuda: "12.9"}
               elif endswith("-cu128") then
                 {tag: ., cuda: "12.8"}
+              elif . == $version and ($has_cu130 | not) then
+                {tag: ., cuda: "13.0"}
               else
                 empty
               end

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/ROOT/opt/supervisor-scripts/ai-toolkit.sh
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/ROOT/opt/supervisor-scripts/ai-toolkit.sh
@@ -13,4 +13,15 @@ echo "Starting AI Toolkit"
 
 cd "${WORKSPACE}/ai-toolkit/ui"
 
+# AI Toolkit's Node worker spawns run.py training jobs in a new session
+# (start_new_session=True), so they detach from the process group and
+# survive supervisor stop. Override the cleanup trap to kill them by pattern.
+cleanup_ai_toolkit() {
+    echo "Stopping AI Toolkit and training jobs..."
+    pkill -TERM -f "ai-toolkit/run\.py" 2>/dev/null
+    sleep 2
+    pkill -KILL -f "ai-toolkit/run\.py" 2>/dev/null
+}
+trap cleanup_ai_toolkit EXIT INT TERM
+
 pty ${AI_TOOLKIT_START_CMD:-npm run start} 2>&1

--- a/external/sglang/ROOT/opt/supervisor-scripts/sglang.sh
+++ b/external/sglang/ROOT/opt/supervisor-scripts/sglang.sh
@@ -34,5 +34,23 @@ fi
 
 # Force Caches to be written in workspace (vols)
 export HOME=${WORKSPACE}
+
+# unbuffer (used by `pty`) setsids its leaf into a new session, so killasgroup
+# can't reach the running sglang. The kernel's PTY hangup that normally kills
+# such a leaf when its master dies also doesn't kill sglang, because sglang
+# serve installs a SIGHUP handler that swallows the signal. Override the
+# generic cleanup trap to kill the orphaned sglang directly by command pattern
+# (mirrors the approach used in aio-studio's ai-toolkit.sh for run.py).
+cleanup_sglang() {
+    echo "Stopping sglang..."
+    pkill -TERM -f 'sglang serve' 2>/dev/null
+    for _ in {1..50}; do
+        pgrep -f 'sglang serve' >/dev/null 2>&1 || break
+        sleep 0.1
+    done
+    pkill -KILL -f 'sglang serve' 2>/dev/null
+}
+trap cleanup_sglang EXIT INT TERM
+
 # Read complex args from /etc/sglang-args.conf if env vars were unsuitable
 eval "pty sglang serve --model-path "${SGLANG_MODEL:-}" ${SGLANG_ARGS:-} ${AUTO_PARALLEL_ARGS} $([[ -f /etc/sglang-args.conf ]] && cat /etc/sglang-args.conf)" 2>&1


### PR DESCRIPTION
Three fixes — two CI build-matrix corrections, one runtime supervisor fix.

## vLLM build matrix (build-vllm.yml)
- vLLM stopped publishing the `-cu130` variant in v0.20.1; the unsuffixed base tag (e.g. `v0.20.1`) is now the CUDA 13.0 image.
- The build matrix only matched explicit `-cuNNN` suffixes, so it silently skipped the CUDA 13.0 build and produced only the `-cu129` (CUDA 12.9) image.
- Map the bare `$VERSION` tag to CUDA 13.0 when no explicit `-cu130` variant is present, so older releases that still ship both (e.g. v0.20.0) don't produce a duplicate CUDA 13.0 build.

## SGLang build matrix (build-sglang.yml)
- SGLang flipped the default CUDA from 12.9 to 13.0 in v0.5.11. The bare `<ver>` tag is now CUDA 13.0, published alongside an explicit `-cu130` alias.
- The matrix still treated any non-suffixed tag as CUDA 12.9, producing **three** entries for v0.5.11: `-cu129` (12.9), `-cu130` (13.0), and the bare tag mislabelled as 12.9.
- Worse, the mislabelled bare entry shared its output tag (`...-cuda-12.9`) with the real `-cu129` build and clobbered it on push - so the published "CUDA 12.9" image was actually CUDA 13.
- Mirror the vLLM fix: prefer explicit `-cuNNN` suffixes; only treat the bare `$VERSION` tag as CUDA 13.0 when no `-cu130` variant exists.

## SGLang supervisor stop (sglang.sh)
- `supervisorctl stop sglang` was leaving the python sglang serve process running. Two factors compound the failure:
  1. The `pty` wrapper uses `unbuffer -p`, which setsids its leaf into a new session/PGID. supervisor's `killasgroup=true` only signals the wrapper's PGID, so SIGTERM never reaches sglang.
  2. sglang serve installs a SIGHUP handler that swallows the signal, so the kernel's PTY hangup that normally kills the leaf when its master dies (the mechanism that makes other pty-wrapped services stop cleanly) doesn't kill sglang either.
- Mirror the approach used in aio-studio's `ai-toolkit.sh` for detached `run.py` training jobs: keep the pty wrapper for line-buffered TTY output in the portal UI, and override the generic cleanup trap with a sglang-specific one that `pkill`s `sglang serve` by command pattern when the wrapper receives SIGTERM.

## Test plan
- [x] Verified vLLM jq logic locally against v0.20.1 (new shape) -> `[{cu129->12.9}, {bare->13.0}]`.
- [x] Verified vLLM jq logic locally against v0.20.0 (old shape, both bare and `-cu130` present) -> `[{cu129->12.9}, {cu130->13.0}]`; bare correctly skipped, no duplicate.
- [x] Verified SGLang jq logic locally against v0.5.11 -> `[{cu129->12.9}, {cu130->13.0}]` (was 3 entries before).
- [x] Verified SGLang jq logic locally against v0.5.10.post1 -> `[{cu130->13.0}]` (only `-cu130` exists upstream; bare correctly deduped).
- [x] Verified the sglang stop fix on a live host: confirmed PID-2522-style orphaning before the change, and `supervisorctl stop sglang` now returns in <1s with no surviving sglang processes after the change.
- [ ] Trigger `Build vLLM Image` and `Build SGLang Image` via `workflow_dispatch` (no inputs) once merged and confirm both `-cuda-12.9` and `-cuda-13.0` images are pushed for each.
