### PR TITLE
Entrypoint-mode Jupyter, tunnel/scheme, and Open Button fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The default boot script (`/opt/instance-tools/bin/boot_default.sh`) accepts thes
 | `--sync-environment` | Sync Python/Conda environments to workspace volume for persistence |
 | `--sync-home` | Sync home directories to workspace |
 | `--jupyter-override` | Force Jupyter to start even in non-Jupyter launch modes |
+| `--no-force-jupyter` | Don't re-add Jupyter to the portal config in entrypoint mode (no `/.launch`) |
 
 **Example** (in Docker run command or template):
 ```bash

--- a/ROOT/etc/vast_boot.d/10-prep-env.sh
+++ b/ROOT/etc/vast_boot.d/10-prep-env.sh
@@ -13,6 +13,14 @@ if [[ -z "${VAST_TCP_PORT_8080}" ]] || { [[ -f /.launch ]] && ! grep -qi jupyter
     PORTAL_CONFIG=$(echo "$PORTAL_CONFIG" | tr '|' '\n' | grep -vi jupyter | tr '\n' '|' | sed 's/|$//')
 fi
 
+# In entrypoint mode (no /.launch) the Vast controller strips Jupyter from
+# PORTAL_CONFIG. Jupyter is a core service of our images and was never meant to
+# be removed, so re-add it unless explicitly disabled (--no-force-jupyter) or
+# there is no port 8080 to serve it on.
+if [[ "${FORCE_JUPYTER,,}" != "false" ]] && [[ ! -f /.launch ]] && [[ -n "${VAST_TCP_PORT_8080}" ]] && ! grep -qi jupyter <<< "$PORTAL_CONFIG"; then
+    PORTAL_CONFIG="${PORTAL_CONFIG:+${PORTAL_CONFIG}|}localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+fi
+
 # Ensure correct port mappings for Jupyter when running in Jupyter launch mode
 if [[ -f /.launch ]] && grep -qi jupyter /.launch && [[ "${JUPYTER_OVERRIDE,,}" != "true" ]]; then
     PORTAL_CONFIG="$(echo "$PORTAL_CONFIG" | sed 's#localhost:8080:18080#localhost:8080:8080#g')"

--- a/ROOT/opt/instance-tools/bin/boot_default.sh
+++ b/ROOT/opt/instance-tools/bin/boot_default.sh
@@ -53,6 +53,10 @@ main() {
                 export JUPYTER_OVERRIDE=true
                 shift
                 ;;
+            --no-force-jupyter)
+                export FORCE_JUPYTER=false
+                shift
+                ;;
             *)
                 echo "Warning: Unknown flag: $1" >&2
                 shift

--- a/portal-aio/caddy_manager/caddy_config_manager.py
+++ b/portal-aio/caddy_manager/caddy_config_manager.py
@@ -123,35 +123,40 @@ def generate_caddyfile(config):
     # Build token matchers - always use CEL expressions for safety.
     # Simple query/header_regexp matchers break with regex-special chars in passwords (e.g. * + .)
     if web_password == open_button_token:
-        token_auth_matcher = f'''(token_auth_matcher) {{
-        @token_auth {{
-            expression `{{http.request.uri.query.token}} == "{cel_web_password}"`
-        }}
-    }}'''
-        cookie_matcher = f'''(has_valid_auth_cookie_matcher) {{
-        @has_valid_auth_cookie {{
-            expression `{{http.request.header.Cookie}}.contains("{caddy_identifier}_auth_token={cel_web_password}")`
-        }}
-    }}'''
-        bearer_matcher = f'''(has_valid_bearer_token_matcher) {{
-        @has_valid_bearer_token {{
-            expression `{{http.request.header.Authorization}} == "Bearer {cel_web_password}"`
-        }}
-    }}'''
+        token_cel = f'{{http.request.uri.query.token}} == "{cel_web_password}"'
+        cookie_cel = f'{{http.request.header.Cookie}}.contains("{caddy_identifier}_auth_token={cel_web_password}")'
+        bearer_cel = f'{{http.request.header.Authorization}} == "Bearer {cel_web_password}"'
     else:
-        token_auth_matcher = f'''(token_auth_matcher) {{
+        token_cel = f'{{http.request.uri.query.token}} == "{cel_web_password}" || {{http.request.uri.query.token}} == "{cel_open_button_token}"'
+        cookie_cel = f'{{http.request.header.Cookie}}.contains("{caddy_identifier}_auth_token={cel_web_password}") || {{http.request.header.Cookie}}.contains("{caddy_identifier}_auth_token={cel_open_button_token}")'
+        bearer_cel = f'{{http.request.header.Authorization}} == "Bearer {cel_web_password}" || {{http.request.header.Authorization}} == "Bearer {cel_open_button_token}"'
+
+    # A valid ?token= request is treated as an interactive browser navigation
+    # when it asks for HTML (sent on both http and https) or carries a top-level
+    # fetch marker (secure-context only). The Open Button probe is axios
+    # (Accept: application/json, text/plain, */* — no text/html, no Sec-Fetch),
+    # so it never matches here and falls through to the cookie-less token route,
+    # which serves content directly instead of relying on a redirect + cookie.
+    browser_nav_cel = '{http.request.header.Accept}.contains("text/html") || {http.request.header.Sec-Fetch-Dest} == "document"'
+
+    token_auth_matcher = f'''(token_auth_matcher) {{
         @token_auth {{
-            expression `{{http.request.uri.query.token}} == "{cel_web_password}" || {{http.request.uri.query.token}} == "{cel_open_button_token}"`
+            expression `{token_cel}`
         }}
     }}'''
-        cookie_matcher = f'''(has_valid_auth_cookie_matcher) {{
+    token_auth_browser_matcher = f'''(token_auth_browser_matcher) {{
+        @token_auth_browser {{
+            expression `({token_cel}) && ({browser_nav_cel})`
+        }}
+    }}'''
+    cookie_matcher = f'''(has_valid_auth_cookie_matcher) {{
         @has_valid_auth_cookie {{
-            expression `{{http.request.header.Cookie}}.contains("{caddy_identifier}_auth_token={cel_web_password}") || {{http.request.header.Cookie}}.contains("{caddy_identifier}_auth_token={cel_open_button_token}")`
+            expression `{cookie_cel}`
         }}
     }}'''
-        bearer_matcher = f'''(has_valid_bearer_token_matcher) {{
+    bearer_matcher = f'''(has_valid_bearer_token_matcher) {{
         @has_valid_bearer_token {{
-            expression `{{http.request.header.Authorization}} == "Bearer {cel_web_password}" || {{http.request.header.Authorization}} == "Bearer {cel_open_button_token}"`
+            expression `{bearer_cel}`
         }}
     }}'''
 
@@ -195,6 +200,8 @@ def generate_caddyfile(config):
     }}
 
     {token_auth_matcher}
+
+    {token_auth_browser_matcher}
 
     {cookie_matcher}
 
@@ -332,14 +339,24 @@ def generate_auth_config(caddy_identifier, username, password, open_button_token
         }}
     }}
 
+    import token_auth_browser_matcher
     import token_auth_matcher
     import has_valid_auth_cookie_matcher
     import has_valid_bearer_token_matcher
 
-    route @token_auth {{
+    route @token_auth_browser {{
         header Set-Cookie "{caddy_identifier}_auth_token={safe_open_button_token}; Path=/; Max-Age=604800; HttpOnly; SameSite=lax"
         uri query -token
         redir * {{uri}} 302
+    }}
+
+    route @token_auth {{
+        header Set-Cookie "{caddy_identifier}_auth_token={safe_open_button_token}; Path=/; Max-Age=604800; HttpOnly; SameSite=lax"
+        uri query -token
+        handle {{
+            {cors_block}
+            {proxy_block}
+        }}
     }}
 
     route @has_valid_auth_cookie {{

--- a/portal-aio/portal/portal.py
+++ b/portal-aio/portal/portal.py
@@ -145,11 +145,23 @@ def load_config() -> dict:
         return hydrate_applications(config_applications)
 
 def hydrate_applications(applications: dict) -> dict:
+    # External ports that Caddy actually proxies (internal port differs from
+    # external). For these Caddy owns the listener and its scheme follows
+    # ENABLE_HTTPS. Must stay in sync with the tunnel manager's hydration so
+    # target_url values match for tunnel lookups.
+    proxied_external_ports = {
+        app["external_port"]
+        for app in applications.values()
+        if app["external_port"] != app["internal_port"]
+    }
     for app_name, app in applications.items():
         hostname = app["hostname"]
         external_port = app["external_port"]
         internal_port = app["internal_port"]
-        if external_port == internal_port and internal_port == 8080:
+        # A straight-through :8080 entry is direct TLS (launch-mode Jupyter)
+        # only when nothing else proxies :8080; in supervisor mode Caddy owns
+        # the :8080 listener and the scheme follows ENABLE_HTTPS.
+        if external_port == internal_port and internal_port == 8080 and 8080 not in proxied_external_ports:
             scheme = "https"
         else:
             scheme = get_scheme()

--- a/portal-aio/tunnel_manager/tunnel_manager.py
+++ b/portal-aio/tunnel_manager/tunnel_manager.py
@@ -479,10 +479,11 @@ async def _create_default_tunnels():
         # app proxied from :18080 plus a :8080->:8080 entry that exists purely
         # as a frontend alias (the terminal). Caddy collapses these into a
         # single :8080 listener, so a second tunnel for the same external port
-        # is redundant — and because the alias entry carries a hard-coded https
-        # scheme (see hydrate_applications) it would point at a listener that
-        # isn't there. Prefer the proxied entry (internal_port != external_port)
-        # so the tunnel's scheme matches what Caddy actually serves.
+        # is redundant. hydrate_applications already gives both entries the same
+        # scheme (so they share a target_url), but gating on the external port
+        # guarantees a single tunnel regardless of any future scheme divergence.
+        # Prefer the proxied entry (internal_port != external_port) so the
+        # surviving tunnel's scheme matches what Caddy actually serves.
         selected = {}  # external_port -> app_name
         for app_name, app_config in config.items():
             ext = app_config['external_port']

--- a/portal-aio/tunnel_manager/tunnel_manager.py
+++ b/portal-aio/tunnel_manager/tunnel_manager.py
@@ -68,6 +68,21 @@ def hydrate_applications(applications):
         applications[app_name]["target_url"] = f'{scheme}://{app["hostname"]}:{app["external_port"]}'
     return applications
 
+def get_scheme_for_external_port(port: int) -> str:
+    """Scheme actually served on a given external port.
+
+    Derived from the hydrated portal config so it stays consistent with the
+    tunnel target_urls (and with hydrate_applications' launch-mode handling):
+    a straight-through :8080 entry is direct TLS only when nothing else proxies
+    :8080 (launch-mode Jupyter); in supervisor mode Caddy owns the listener and
+    the scheme follows ENABLE_HTTPS. Falls back to get_scheme() for ports that
+    aren't in the portal config.
+    """
+    for app in load_config().values():
+        if app["external_port"] == port:
+            return urlparse(app["target_url"]).scheme
+    return get_scheme()
+
 # Function to fetch the public IP address
 def get_public_ip():
     # We should have this from the first request after clicking the Open button - Use the less reliable $PUBLIC_IPADDR otherwise
@@ -99,10 +114,10 @@ def get_port_mapping(port: int):
     # Fetch the public IP
     public_ip = get_public_ip()
 
-    if os.environ.get("ENABLE_HTTPS", "false").lower() == "true" or port == 8080:
-        scheme = "https://"
-    else:
-        scheme = "http://"
+    # Match the scheme Caddy/the service actually serves on this external port
+    # rather than hard-coding https for :8080 (which is only correct in
+    # launch mode, not when Caddy serves :8080 over http in supervisor mode).
+    scheme = get_scheme_for_external_port(port)
 
     # Fetch the environment variable dynamically
     env_var_name = f"VAST_TCP_PORT_{port}"
@@ -112,7 +127,7 @@ def get_port_mapping(port: int):
         raise HTTPException(status_code=404, detail=f"Environment variable {env_var_name} not found")
 
     # Return the {PUBLIC_IP}:{PORT_VALUE}
-    return {"result": f"{scheme}{public_ip}:{port_value}"}
+    return {"result": f"{scheme}://{public_ip}:{port_value}"}
 
 class QuickTunnel:
     def __init__(self, target_url: str):

--- a/portal-aio/tunnel_manager/tunnel_manager.py
+++ b/portal-aio/tunnel_manager/tunnel_manager.py
@@ -39,8 +39,29 @@ def load_config():
     return {}
 
 def hydrate_applications(applications):
+    # External ports that Caddy actually proxies — an entry whose internal port
+    # differs from its external port. For these, Caddy owns the listener and its
+    # scheme follows ENABLE_HTTPS.
+    proxied_external_ports = {
+        app["external_port"]
+        for app in applications.values()
+        if app["external_port"] != app["internal_port"]
+    }
     for app_name, app in applications.items():
-        if app["external_port"] == app["internal_port"] and app["internal_port"] == 8080:
+        # A straight-through :8080 entry (external == internal == 8080) is served
+        # over TLS directly by Vast launch-mode Jupyter — BUT only when nothing
+        # else is proxying :8080. In supervisor mode :8080 is the proxied Jupyter
+        # entry (8080->18080) plus a :8080->:8080 frontend alias for the terminal;
+        # there Caddy owns the listener, so the alias must follow ENABLE_HTTPS too,
+        # otherwise its target_url would point https at an http listener (and
+        # split into a second, broken tunnel). Detecting the proxy entry lets us
+        # tell the two modes apart from the config shape alone, which also covers
+        # the --jupyter-override case (proxied :8080 even though /.launch exists).
+        if (
+            app["external_port"] == app["internal_port"]
+            and app["internal_port"] == 8080
+            and 8080 not in proxied_external_ports
+        ):
             scheme = "https"
         else:
             scheme = get_scheme()
@@ -452,11 +473,29 @@ async def _create_default_tunnels():
     """
     try:
         config = load_config()
-        unique_targets = {}
+
+        # Only one tunnel per external port. Several portal entries can share
+        # an external port: supervisor-managed Jupyter exposes :8080 for the
+        # app proxied from :18080 plus a :8080->:8080 entry that exists purely
+        # as a frontend alias (the terminal). Caddy collapses these into a
+        # single :8080 listener, so a second tunnel for the same external port
+        # is redundant — and because the alias entry carries a hard-coded https
+        # scheme (see hydrate_applications) it would point at a listener that
+        # isn't there. Prefer the proxied entry (internal_port != external_port)
+        # so the tunnel's scheme matches what Caddy actually serves.
+        selected = {}  # external_port -> app_name
         for app_name, app_config in config.items():
-            target_url = app_config['target_url']
-            if target_url not in unique_targets:
-                unique_targets[target_url] = app_name
+            ext = app_config['external_port']
+            prev = selected.get(ext)
+            if prev is None or (
+                config[prev]['internal_port'] == ext
+                and app_config['internal_port'] != ext
+            ):
+                selected[ext] = app_name
+
+        unique_targets = {}  # target_url -> app_name
+        for app_name in selected.values():
+            unique_targets[config[app_name]['target_url']] = app_name
 
         # Create tunnels sequentially with a small delay between each
         # to avoid hitting Cloudflare's rate limiter on quick tunnel


### PR DESCRIPTION
## Summary

A set of related fixes for running the images in **entrypoint mode** (no `/.launch`), plus the tunnel/scheme and Open Button issues that surfaced alongside them. Verified on a rebuilt image.

### 1. Re-add Jupyter to `PORTAL_CONFIG` in entrypoint mode
In entrypoint mode the Vast controller strips Jupyter entries from `PORTAL_CONFIG` independently of our image. Jupyter is a core service and was never meant to be removed. `10-prep-env.sh` now re-adds both canonical entries on boot:
```
localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal
```
...unless disabled or there is no port 8080. New `--no-force-jupyter` entrypoint flag (`FORCE_JUPYTER=false`) opts out. Guarded so it never duplicates an existing entry; runs after derivative `05-*-env.sh` defaults.

### 2. Fix duplicate Cloudflare tunnel for external port 8080
`hydrate_applications` hard-coded `https` for the straight-through `:8080` terminal alias while the proxied Jupyter entry used `http`, so the two produced different `target_url`s, slipped past the dedup, and created a second tunnel pointing `https` at an `http` listener. Now: a straight-through `:8080` entry is treated as direct TLS only when nothing else proxies `:8080` (distinguishes launch mode from supervisor mode by config shape, also covers `--jupyter-override`); and `_create_default_tunnels` gates dedup on external port, preferring the proxied entry.

### 3. Fix direct-IP URL scheme for `:8080` in supervisor mode
`/get-direct-url/{port}` hard-coded `https` for port 8080, so the portal showed an `https` direct link even with `ENABLE_HTTPS` unset (Caddy serves `:8080` over `http` in supervisor mode). Now derives the scheme from the hydrated config (`get_scheme_for_external_port`): `http` unless `ENABLE_HTTPS` in supervisor mode, still `https` in launch mode. `portal.py`'s copy of `hydrate_applications` was synced to match so the frontend's `quick_tunnels[target_url]` lookup doesn't miss.

### 4. Fix Open Button probe 401 (entrypoint mode)
The Vast Open Button probe (**axios**, server-side, no cookie jar) hits `:1111` with `?token=OPEN_BUTTON_TOKEN`. The `@token_auth` route set a cookie and `302`'d to a clean URL, relying on the client to replay the cookie — which the probe doesn't, so the followed `GET /` fell through to `basic_auth` and returned `401`. Token-auth handling is now split by client type:
- **`@token_auth_browser`** — a browser navigation (`Accept: text/html`, or `Sec-Fetch-Dest: document` on secure origins) keeps the cookie + `302` redirect, so the token stays out of the URL bar/history.
- **`@token_auth`** — any other valid-token client (the axios probe, curl, monitors) sets the cookie **and serves the proxied content directly with `200`**, so success no longer depends on a cookie round-trip.

`Accept`-based detection works on both http and https origins (`Sec-Fetch-*` is only sent to secure contexts, so it can't be the sole discriminator for http direct-IP access).

## Behaviour matrix (verified)

| Mode | `:8080` scheme | Tunnels | `/get-direct-url/8080` |
|---|---|---|---|
| Supervisor, HTTPS off | `http` | 1 | `http` |
| Supervisor, HTTPS on | `https` | 1 | `https` |
| Launch mode (vast direct TLS) | `https` | 1 | `https` |
| `--jupyter-override` + `/.launch` | `http` | 1 | `http` |

## Security review
Ran a focused security review of the full branch diff (auth/Caddy refactor in particular): **no findings**. Both new token routes still require a valid token (`@token_auth_browser` ANDs the token check with the browser signal, making it strictly narrower; `@token_auth` is identical to the prior matcher). Missing `Accept`/`Sec-Fetch` headers evaluate false and fall through to the token-required route — no unauthenticated path. Token escaping (`cel_escape`/`caddy_quote_escape`) and `HttpOnly` cookies preserved; `uri query -token` still strips the token before proxying upstream.

## Files changed
- `ROOT/etc/vast_boot.d/10-prep-env.sh` — re-add Jupyter in entrypoint mode
- `ROOT/opt/instance-tools/bin/boot_default.sh` — `--no-force-jupyter` flag
- `README.md` — document the flag
- `portal-aio/tunnel_manager/tunnel_manager.py` — scheme detection, direct-URL scheme, external-port tunnel gating
- `portal-aio/portal/portal.py` — sync hydrate scheme with tunnel manager
- `portal-aio/caddy_manager/caddy_config_manager.py` — browser/non-browser token-auth split

## Testing
Boot scripts pass `bash -n`; Python modules parse clean; generated Caddyfile rendered and validated structurally (single- and dual-token cases). Confirmed working end-to-end on a rebuilt image: Open Button succeeds, no duplicate tunnel, correct direct-URL scheme.

## Test template
Ready-to-launch Vast template for testing this image: https://cloud.vast.ai?ref_id=145102&template_id=d36126dad51351d6085840d8fea501ba
