### PR TITLE
base-image: native arm builds, crane merge/promotion, latest CUDA patches

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -74,10 +74,11 @@ jobs:
             "cuda-12.4-22|nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04|cuda-12.4.1-cudnn-devel-ubuntu22.04|linux/amd64,linux/arm64|3.10"
             "cuda-12.6-24|nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04|cuda-12.6.3-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
             "cuda-12.8-24|nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04|cuda-12.8.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-12.9-24|nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04|cuda-12.9.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.0.2-24|nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04|cuda-13.0.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.1.1-24|nvidia/cuda:13.1.1-cudnn-devel-ubuntu24.04|cuda-13.1.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.2.0-24|nvidia/cuda:13.2.0-cudnn-devel-ubuntu24.04|cuda-13.2.0-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-12.9-24|nvidia/cuda:12.9.2-cudnn-devel-ubuntu24.04|cuda-12.9.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.0-24|nvidia/cuda:13.0.3-cudnn-devel-ubuntu24.04|cuda-13.0.3-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.1-24|nvidia/cuda:13.1.2-cudnn-devel-ubuntu24.04|cuda-13.1.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.2-24|nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04|cuda-13.2.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.3-24|nvidia/cuda:13.3.0-cudnn-devel-ubuntu24.04|cuda-13.3.0-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
           )
 
           BUILD_MATRIX="[]"
@@ -102,14 +103,21 @@ jobs:
             IFS=',' read -ra ARCH_LIST <<< "$arches"
             for arch in "${ARCH_LIST[@]}"; do
               arch_suffix="${arch#linux/}"
+              # Native runner per arch — no QEMU. arm64 builds on arm hardware.
+              if [[ "$arch" == "linux/arm64" ]]; then
+                runs_on="ubuntu-24.04-arm"
+              else
+                runs_on="ubuntu-latest"
+              fi
               BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq -c \
                 --arg key "$key" \
                 --arg base_image "$base_image" \
                 --arg tag_template "$tag_template" \
                 --arg arch "$arch" \
                 --arg arch_suffix "$arch_suffix" \
+                --arg runs_on "$runs_on" \
                 --arg default_python "$default_python" \
-                '. + [{"config_key": $key, "base_image": $base_image, "tag_template": $tag_template, "arch": $arch, "arch_suffix": $arch_suffix, "default_python": $default_python}]')
+                '. + [{"config_key": $key, "base_image": $base_image, "tag_template": $tag_template, "arch": $arch, "arch_suffix": $arch_suffix, "runs_on": $runs_on, "default_python": $default_python}]')
             done
           done
 
@@ -136,13 +144,20 @@ jobs:
 
             for arch in "linux/amd64" "linux/arm64"; do
               arch_suffix="${arch#linux/}"
+              # Native runner per arch — no QEMU. arm64 builds on arm hardware.
+              if [[ "$arch" == "linux/arm64" ]]; then
+                runs_on="ubuntu-24.04-arm"
+              else
+                runs_on="ubuntu-latest"
+              fi
               MINI_BUILD_MATRIX=$(echo "$MINI_BUILD_MATRIX" | jq -c \
                 --arg key "$key" \
                 --arg mini_tag "$mini_tag" \
                 --arg cuda_versions "$cuda_versions" \
                 --arg arch "$arch" \
                 --arg arch_suffix "$arch_suffix" \
-                '. + [{"config_key": $key, "mini_tag": $mini_tag, "cuda_versions": $cuda_versions, "arch": $arch, "arch_suffix": $arch_suffix}]')
+                --arg runs_on "$runs_on" \
+                '. + [{"config_key": $key, "mini_tag": $mini_tag, "cuda_versions": $cuda_versions, "arch": $arch, "arch_suffix": $arch_suffix, "runs_on": $runs_on}]')
             done
           done
 
@@ -176,7 +191,7 @@ jobs:
   build:
     needs: generate-matrix
     if: ${{ !inputs.DRY_RUN }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     permissions:
       contents: read
     strategy:
@@ -189,9 +204,6 @@ jobs:
 
       - name: Maximize build space
         uses: ./.github/actions/maximize-build-space
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -258,8 +270,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.merge-matrix) }}
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
 
       - name: Docker Hub login
         uses: docker/login-action@v3
@@ -284,20 +296,24 @@ jobs:
             AMD64_TAG="${FINAL_TAG}-amd64"
             ARM64_TAG="${FINAL_TAG}-arm64"
 
-            EXTRA_TAGS=""
-            if [[ "$py_version" == "$DEFAULT_PYTHON" ]]; then
-              ALIAS_TAG="${NAMESPACE}/base-image:${TAG_TEMPLATE}-${BUILD_DATE}"
-              EXTRA_TAGS="-t ${ALIAS_TAG}"
-              echo "$ALIAS_TAG" >> built-tags/tags.txt
-            fi
-
             echo "=== Merging manifest: ${FINAL_TAG} ==="
-            docker buildx imagetools create \
-              -t "${FINAL_TAG}" \
-              ${EXTRA_TAGS} \
-              "${AMD64_TAG}" "${ARM64_TAG}"
+            # --docker-empty-base forces a fresh scratch index so re-runs are
+            # idempotent (no duplicate platform entries accumulating on the tag).
+            crane index append \
+              --docker-empty-base \
+              --tag "${FINAL_TAG}" \
+              --manifest "${AMD64_TAG}" \
+              --manifest "${ARM64_TAG}"
 
             echo "$FINAL_TAG" >> built-tags/tags.txt
+
+            if [[ "$py_version" == "$DEFAULT_PYTHON" ]]; then
+              ALIAS_TAG="${NAMESPACE}/base-image:${TAG_TEMPLATE}-${BUILD_DATE}"
+              echo "=== Aliasing ${FINAL_TAG} -> ${ALIAS_TAG} ==="
+              # crane copy cross-mounts blobs registry-side (no host streaming).
+              crane copy "${FINAL_TAG}" "${ALIAS_TAG}"
+              echo "$ALIAS_TAG" >> built-tags/tags.txt
+            fi
           done
 
       - name: Upload manifest tags
@@ -310,7 +326,7 @@ jobs:
   build-mini:
     needs: [generate-matrix, merge-manifests]
     if: ${{ !inputs.DRY_RUN }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     permissions:
       contents: read
     strategy:
@@ -322,9 +338,6 @@ jobs:
 
       - name: Maximize build space
         uses: ./.github/actions/maximize-build-space
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -381,8 +394,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.mini-merge-matrix) }}
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
 
       - name: Docker Hub login
         uses: docker/login-action@v3
@@ -407,9 +420,11 @@ jobs:
             ARM64_TAG="${FINAL_TAG}-arm64"
 
             echo "=== Merging mini manifest: ${FINAL_TAG} ==="
-            docker buildx imagetools create \
-              -t "${FINAL_TAG}" \
-              "${AMD64_TAG}" "${ARM64_TAG}"
+            crane index append \
+              --docker-empty-base \
+              --tag "${FINAL_TAG}" \
+              --manifest "${AMD64_TAG}" \
+              --manifest "${ARM64_TAG}"
 
             echo "$FINAL_TAG" >> built-tags/tags.txt
           done

--- a/.github/workflows/extend-base-image.yml
+++ b/.github/workflows/extend-base-image.yml
@@ -60,10 +60,11 @@ jobs:
             "cuda-12.4-22|cuda-12.4.1-cudnn-devel-ubuntu22.04|linux/amd64,linux/arm64|3.10"
             "cuda-12.6-24|cuda-12.6.3-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
             "cuda-12.8-24|cuda-12.8.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-12.9-24|cuda-12.9.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.0.2-24|cuda-13.0.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.1.1-24|cuda-13.1.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.2.0-24|cuda-13.2.0-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-12.9-24|cuda-12.9.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.0-24|cuda-13.0.3-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.1-24|cuda-13.1.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.2-24|cuda-13.2.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.3-24|cuda-13.3.0-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
           )
 
           BUILD_MATRIX="[]"
@@ -85,13 +86,20 @@ jobs:
             IFS=',' read -ra ARCH_LIST <<< "$arches"
             for arch in "${ARCH_LIST[@]}"; do
               arch_suffix="${arch#linux/}"
+              # Native runner per arch — no QEMU. arm64 builds on arm hardware.
+              if [[ "$arch" == "linux/arm64" ]]; then
+                runs_on="ubuntu-24.04-arm"
+              else
+                runs_on="ubuntu-latest"
+              fi
               BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq -c \
                 --arg key "$key" \
                 --arg tag_template "$tag_template" \
                 --arg arch "$arch" \
                 --arg arch_suffix "$arch_suffix" \
+                --arg runs_on "$runs_on" \
                 --arg default_python "$default_python" \
-                '. + [{"config_key": $key, "tag_template": $tag_template, "arch": $arch, "arch_suffix": $arch_suffix, "default_python": $default_python}]')
+                '. + [{"config_key": $key, "tag_template": $tag_template, "arch": $arch, "arch_suffix": $arch_suffix, "runs_on": $runs_on, "default_python": $default_python}]')
             done
           done
 
@@ -118,12 +126,19 @@ jobs:
 
             for arch in "linux/amd64" "linux/arm64"; do
               arch_suffix="${arch#linux/}"
+              # Native runner per arch — no QEMU. arm64 builds on arm hardware.
+              if [[ "$arch" == "linux/arm64" ]]; then
+                runs_on="ubuntu-24.04-arm"
+              else
+                runs_on="ubuntu-latest"
+              fi
               MINI_BUILD_MATRIX=$(echo "$MINI_BUILD_MATRIX" | jq -c \
                 --arg key "$key" \
                 --arg mini_tag "$mini_tag" \
                 --arg arch "$arch" \
                 --arg arch_suffix "$arch_suffix" \
-                '. + [{"config_key": $key, "mini_tag": $mini_tag, "arch": $arch, "arch_suffix": $arch_suffix}]')
+                --arg runs_on "$runs_on" \
+                '. + [{"config_key": $key, "mini_tag": $mini_tag, "arch": $arch, "arch_suffix": $arch_suffix, "runs_on": $runs_on}]')
             done
           done
 
@@ -155,7 +170,7 @@ jobs:
   extend:
     needs: generate-matrix
     if: ${{ !inputs.DRY_RUN }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     permissions:
       contents: read
     strategy:
@@ -165,9 +180,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -234,8 +246,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.merge-matrix) }}
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
 
       - name: Docker Hub login
         uses: docker/login-action@v3
@@ -260,20 +272,24 @@ jobs:
             AMD64_TAG="${FINAL_TAG}-amd64"
             ARM64_TAG="${FINAL_TAG}-arm64"
 
-            EXTRA_TAGS=""
-            if [[ "$py_version" == "$DEFAULT_PYTHON" ]]; then
-              ALIAS_TAG="${NAMESPACE}/base-image:${TAG_TEMPLATE}-${BUILD_DATE}"
-              EXTRA_TAGS="-t ${ALIAS_TAG}"
-              echo "$ALIAS_TAG" >> built-tags/tags.txt
-            fi
-
             echo "=== Merging manifest: ${FINAL_TAG} ==="
-            docker buildx imagetools create \
-              -t "${FINAL_TAG}" \
-              ${EXTRA_TAGS} \
-              "${AMD64_TAG}" "${ARM64_TAG}"
+            # --docker-empty-base forces a fresh scratch index so re-runs are
+            # idempotent (no duplicate platform entries accumulating on the tag).
+            crane index append \
+              --docker-empty-base \
+              --tag "${FINAL_TAG}" \
+              --manifest "${AMD64_TAG}" \
+              --manifest "${ARM64_TAG}"
 
             echo "$FINAL_TAG" >> built-tags/tags.txt
+
+            if [[ "$py_version" == "$DEFAULT_PYTHON" ]]; then
+              ALIAS_TAG="${NAMESPACE}/base-image:${TAG_TEMPLATE}-${BUILD_DATE}"
+              echo "=== Aliasing ${FINAL_TAG} -> ${ALIAS_TAG} ==="
+              # crane copy cross-mounts blobs registry-side (no host streaming).
+              crane copy "${FINAL_TAG}" "${ALIAS_TAG}"
+              echo "$ALIAS_TAG" >> built-tags/tags.txt
+            fi
           done
 
       - name: Upload manifest tags
@@ -286,7 +302,7 @@ jobs:
   extend-mini:
     needs: [generate-matrix]
     if: ${{ !inputs.DRY_RUN }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     permissions:
       contents: read
     strategy:
@@ -295,9 +311,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -355,8 +368,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.mini-merge-matrix) }}
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
 
       - name: Docker Hub login
         uses: docker/login-action@v3
@@ -381,9 +394,11 @@ jobs:
             ARM64_TAG="${FINAL_TAG}-arm64"
 
             echo "=== Merging mini manifest: ${FINAL_TAG} ==="
-            docker buildx imagetools create \
-              -t "${FINAL_TAG}" \
-              "${AMD64_TAG}" "${ARM64_TAG}"
+            crane index append \
+              --docker-empty-base \
+              --tag "${FINAL_TAG}" \
+              --manifest "${AMD64_TAG}" \
+              --manifest "${ARM64_TAG}"
 
             echo "$FINAL_TAG" >> built-tags/tags.txt
           done

--- a/.github/workflows/promote-base-image.yml
+++ b/.github/workflows/promote-base-image.yml
@@ -54,10 +54,11 @@ jobs:
             "cuda-12.4-22|cuda-12.4.1-cudnn-devel-ubuntu22.04|3.10"
             "cuda-12.6-24|cuda-12.6.3-cudnn-devel-ubuntu24.04|3.12"
             "cuda-12.8-24|cuda-12.8.1-cudnn-devel-ubuntu24.04|3.12"
-            "cuda-12.9-24|cuda-12.9.1-cudnn-devel-ubuntu24.04|3.12"
-            "cuda-13.0.2-24|cuda-13.0.2-cudnn-devel-ubuntu24.04|3.12"
-            "cuda-13.1.1-24|cuda-13.1.1-cudnn-devel-ubuntu24.04|3.12"
-            "cuda-13.2.0-24|cuda-13.2.0-cudnn-devel-ubuntu24.04|3.12"
+            "cuda-12.9-24|cuda-12.9.2-cudnn-devel-ubuntu24.04|3.12"
+            "cuda-13.0-24|cuda-13.0.3-cudnn-devel-ubuntu24.04|3.12"
+            "cuda-13.1-24|cuda-13.1.2-cudnn-devel-ubuntu24.04|3.12"
+            "cuda-13.2-24|cuda-13.2.1-cudnn-devel-ubuntu24.04|3.12"
+            "cuda-13.3-24|cuda-13.3.0-cudnn-devel-ubuntu24.04|3.12"
           )
 
           CONFIGS_JSON="[]"
@@ -123,8 +124,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
 
       - name: Docker Hub login
         uses: docker/login-action@v3
@@ -157,7 +158,7 @@ jobs:
             for py_version in "${PYTHON_VERSIONS[@]}"; do
               py_tag="${py_version//.}"
               SOURCE="${NAMESPACE_STAGING}/base-image:${tag_template}-py${py_tag}-${STAGING_DATE}"
-              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+              if crane digest "$SOURCE" >/dev/null 2>&1; then
                 echo "  ok: $SOURCE"
               else
                 echo "  MISSING: $SOURCE"
@@ -171,7 +172,7 @@ jobs:
             for py_version in "${MINI_PYTHON_VERSIONS[@]}"; do
               py_tag="${py_version//.}"
               SOURCE="${NAMESPACE_STAGING}/base-image:${mini_tag}-py${py_tag}-${STAGING_DATE}"
-              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+              if crane digest "$SOURCE" >/dev/null 2>&1; then
                 echo "  ok: $SOURCE"
               else
                 echo "  MISSING: $SOURCE"
@@ -199,7 +200,7 @@ jobs:
             at_cuda_ver=$(echo "$at_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
             [[ -z "$at_cuda_ver" ]] && continue
             AUTO_TAG_REF="${NAMESPACE_PROD}/base-image:cuda-${at_cuda_ver}-auto"
-            if digest=$(docker buildx imagetools inspect "$AUTO_TAG_REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+            if digest=$(crane digest "$AUTO_TAG_REF" 2>/dev/null); then
               AUTO_TARGET_PRE[$at_cuda_ver]="${NAMESPACE_PROD}/base-image@${digest}"
               echo "Captured existing auto tag: cuda-${at_cuda_ver}-auto @ ${digest}"
             else
@@ -224,21 +225,18 @@ jobs:
               SOURCE="${NAMESPACE_STAGING}/base-image:${tag_template}-py${py_tag}-${STAGING_DATE}"
               DATED_TAG="${NAMESPACE_PROD}/base-image:${tag_template}-py${py_tag}-${STAGING_DATE}"
 
-              EXTRA_TAGS=""
+              echo "Promoting: ${SOURCE} -> ${DATED_TAG}"
+              # crane copy cross-mounts blobs registry-side (no host streaming).
+              crane copy "${SOURCE}" "${DATED_TAG}"
+              echo "$DATED_TAG" >> built-tags/tags.txt
+
               if [[ "$py_version" == "$default_python" ]]; then
                 # Default python alias (no -pyXXX, but keeps date)
                 DATED_ALIAS="${NAMESPACE_PROD}/base-image:${tag_template}-${STAGING_DATE}"
-                EXTRA_TAGS="--tag ${DATED_ALIAS}"
+                echo "Aliasing: ${SOURCE} -> ${DATED_ALIAS}"
+                crane copy "${SOURCE}" "${DATED_ALIAS}"
                 echo "$DATED_ALIAS" >> built-tags/tags.txt
               fi
-
-              echo "Promoting: ${SOURCE} -> ${DATED_TAG}"
-              docker buildx imagetools create \
-                --tag "${DATED_TAG}" \
-                ${EXTRA_TAGS} \
-                "${SOURCE}"
-
-              echo "$DATED_TAG" >> built-tags/tags.txt
             done
           done
 
@@ -258,9 +256,7 @@ jobs:
               DATED_TAG="${NAMESPACE_PROD}/base-image:${mini_tag}-py${py_tag}-${STAGING_DATE}"
 
               echo "Promoting mini: ${SOURCE} -> ${DATED_TAG}"
-              docker buildx imagetools create \
-                --tag "${DATED_TAG}" \
-                "${SOURCE}"
+              crane copy "${SOURCE}" "${DATED_TAG}"
 
               echo "$DATED_TAG" >> built-tags/tags.txt
             done
@@ -304,7 +300,7 @@ jobs:
           declare -A FINAL_DIGEST
           for cuda_ver in "${!AUTO_TARGET_FINAL[@]}"; do
             ref="${AUTO_TARGET_FINAL[$cuda_ver]}"
-            if d=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+            if d=$(crane digest "$ref" 2>/dev/null); then
               FINAL_DIGEST[$cuda_ver]="$d"
             else
               echo "WARN: could not resolve digest for ${ref}; cuda-${cuda_ver}-auto will be skipped in the dance"
@@ -352,15 +348,15 @@ jobs:
               # correctness does not depend on the dance being
               # possible — only the tag-order optimisation is lost.
               echo "WARN: no distinct anchor for ${AUTO_TAG_REF}; falling back to direct update (tag order will not advance)"
-              docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${TARGET_REF}"
+              crane copy "${TARGET_REF}" "${AUTO_TAG_REF}"
               echo "$AUTO_TAG_REF" >> built-tags/tags.txt
               continue
             fi
 
             echo "  Phase A: ${AUTO_TAG_REF} -> anchor ${anchor_ref}"
-            docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${anchor_ref}"
+            crane copy "${anchor_ref}" "${AUTO_TAG_REF}"
             echo "  Phase B: ${AUTO_TAG_REF} -> ${TARGET_REF}"
-            docker buildx imagetools create --tag "${AUTO_TAG_REF}" "${TARGET_REF}"
+            crane copy "${TARGET_REF}" "${AUTO_TAG_REF}"
             echo "$AUTO_TAG_REF" >> built-tags/tags.txt
           done
 
@@ -408,8 +404,8 @@ jobs:
     if: ${{ inputs.DRY_RUN }}
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
 
       - name: Docker Hub login
         uses: docker/login-action@v3
@@ -445,7 +441,7 @@ jobs:
             for py_version in "${PYTHON_VERSIONS[@]}"; do
               py_tag="${py_version//.}"
               SOURCE="${NAMESPACE_STAGING}/base-image:${tag_template}-py${py_tag}-${STAGING_DATE}"
-              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+              if crane digest "$SOURCE" >/dev/null 2>&1; then
                 echo "  ok: $SOURCE"
               else
                 echo "  MISSING: $SOURCE"
@@ -459,7 +455,7 @@ jobs:
             for py_version in "${MINI_PYTHON_VERSIONS[@]}"; do
               py_tag="${py_version//.}"
               SOURCE="${NAMESPACE_STAGING}/base-image:${mini_tag}-py${py_tag}-${STAGING_DATE}"
-              if docker buildx imagetools inspect "$SOURCE" --format '{{.Manifest.Digest}}' >/dev/null 2>&1; then
+              if crane digest "$SOURCE" >/dev/null 2>&1; then
                 echo "  ok: $SOURCE"
               else
                 echo "  MISSING: $SOURCE"
@@ -523,7 +519,7 @@ jobs:
             at_cuda_ver=$(echo "$at_template" | sed -n 's/^cuda-\([0-9.]*\)-.*/\1/p')
             [[ -z "$at_cuda_ver" ]] && continue
             AUTO_TAG_REF="${NAMESPACE_PROD}/base-image:cuda-${at_cuda_ver}-auto"
-            if digest=$(docker buildx imagetools inspect "$AUTO_TAG_REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+            if digest=$(crane digest "$AUTO_TAG_REF" 2>/dev/null); then
               AUTO_TARGET_PRE[$at_cuda_ver]="${NAMESPACE_PROD}/base-image@${digest}"
             fi
           done
@@ -555,7 +551,7 @@ jobs:
             [[ -z "$cuda_ver" ]] && continue
             dp_tag="${default_python//.}"
             staging_ref="${NAMESPACE_STAGING}/base-image:${tag_template}-py${dp_tag}-${STAGING_DATE}"
-            if d=$(docker buildx imagetools inspect "$staging_ref" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+            if d=$(crane digest "$staging_ref" 2>/dev/null); then
               FINAL_DIGEST[$cuda_ver]="$d"
             else
               echo "WARN: could not resolve staging source ${staging_ref}"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We build multiple variants to support different hardware and Python requirements
 | Type | Base Image | Ubuntu | Notes |
 |------|-----------|--------|-------|
 | **Stock** | `ubuntu:22.04`, `ubuntu:24.04` | 22.04, 24.04 | No CUDA/ROCm libraries, but NVIDIA drivers are still loaded at runtime |
-| **NVIDIA CUDA** | `nvidia/cuda:*-cudnn-devel-ubuntu*` | 22.04, 24.04 | Full CUDA toolkit + cuDNN (11.8, 12.1, 12.4, 12.6, 12.8, 12.9, 13.0.1, 13.0.2) |
+| **NVIDIA CUDA** | `nvidia/cuda:*-cudnn-devel-ubuntu*` | 22.04, 24.04 | Full CUDA toolkit + cuDNN (11.8, 12.1, 12.4, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3 — latest patch per minor) |
 | **AMD ROCm** | `rocm/dev-ubuntu-*:6.2.4-complete` | 22.04, 24.04 | Complete ROCm 6.2.4 development environment |
 
 **Note:** Stock images can still access NVIDIA GPUs—they simply don't include the heavier CUDA development libraries. Use these when you want a lighter image and will install specific CUDA components yourself.


### PR DESCRIPTION
Modernises the three base-image workflows (build, promote, extend) to the native-runner + crane pattern already established for the comfyui and other derivative builds, and refreshes the CUDA matrix to the latest patch per minor.

## Native arm builds (no QEMU)
- `build` / `build-mini` (build-base-image), `extend` / `extend-mini` (extend-base-image) now select a runner per matrix entry via a `runs_on` field added in `generate-matrix`: `ubuntu-24.04-arm` for arm64, `ubuntu-latest` for amd64.
- `docker/setup-qemu-action` removed everywhere. arm64 now builds on arm hardware instead of emulation.

## Crane for index assembly + promotion
- `merge-manifests` / `merge-mini-manifests` (build + extend) assemble the multi-arch index with `crane index append --docker-empty-base` (+ `crane copy` for the default-python alias) instead of `docker buildx imagetools create` — blobs cross-mount registry-side.
- `promote-base-image`: every retag (dated, alias, mini, and the auto-tag ordering dance) uses `crane copy`; digest lookups use `crane digest`; `setup-buildx` → `setup-crane`. Pre-flight checks and the auto-tag dance logic are unchanged.

## CUDA matrix — latest patch per minor
Applied to build, promote, extend, and the README list. Each verified to ship both arm64 and amd64 on Docker Hub:
- `12.9.1 → 12.9.2`
- `13.0.2 → 13.0.3`
- `13.1.1 → 13.1.2`
- `13.2.0 → 13.2.1`
- add new minor `13.3.0`
- 13.x config keys normalised to minor-only (`cuda-13.0-24` etc.)

## Validation
- All three workflows parse as YAML.
- Matrix-generation bash simulated: arm64 entries route to the arm runner, new configs produce valid JSON.
- No `setup-qemu` / `imagetools` references remain; the only `setup-buildx` steps left are where `docker buildx build` actually runs.

## Out of scope (flagged, not changed)
Downstream consumers still pin the pre-bump tags and will keep building against the superseded patches until updated separately:
- PyTorch derivative: `build/promote/extend-pytorch`, `derivatives/pytorch/build-many*.sh`, pytorch README (`12.9.1-cudnn-devel`, `13.0.2-cudnn-devel`, `cuda-12.9.1-auto`, `cuda-13.0.2-auto`).
- `derivatives/linux-desktop` Dockerfile + README (`cuda-12.9.1-cudnn-devel-ubuntu24.04-py312`).
- Legacy local `build.sh`.