### PR TITLE
linux-desktop: fix screen resize on arm64 (Selkies-less arches)

### DIFF
--- a/derivatives/linux-desktop/ROOT/opt/supervisor-scripts/x-server.sh
+++ b/derivatives/linux-desktop/ROOT/opt/supervisor-scripts/x-server.sh
@@ -23,9 +23,33 @@ while [[ ! -S $socket ]]; do
     sleep 1
 done
 
+# Apply the requested WIDTHxHEIGHT to the Xvfb screen with xrandr. Used as a
+# fallback where Selkies' own selkies-gstreamer-resize is unavailable: Selkies
+# ships amd64-only release artifacts, so on other arches (arm64/sbsa) that
+# helper is absent and the desktop would otherwise stay at Xvfb's full
+# 8192x4096 startup framebuffer.
+function resizeWithXrandr() {
+    local res="$1"
+    local w="${res%x*}" h="${res#*x}" output mode line
+    output="$(xrandr --query | awk '/ connected/{print $1; exit}')"
+    output="${output:-screen}"
+    mode="${w}x${h}"
+    if ! xrandr --query | grep -qw "${mode}"; then
+        line="$(cvt "${w}" "${h}" 60 | sed -n 's/^Modeline //p' | cut -d' ' -f2-)"
+        xrandr --newmode "${mode}" ${line}
+        xrandr --addmode "${output}" "${mode}"
+    fi
+    xrandr --output "${output}" --mode "${mode}"
+}
+
 function delayedResize() {
     sleep 15
-    /usr/local/bin/selkies-gstreamer-resize "${DISPLAY_SIZEW}x${DISPLAY_SIZEH}"
+    local target="${DISPLAY_SIZEW}x${DISPLAY_SIZEH}"
+    if [[ -x /usr/local/bin/selkies-gstreamer-resize ]]; then
+        /usr/local/bin/selkies-gstreamer-resize "${target}"
+    else
+        resizeWithXrandr "${target}"
+    fi
 }
 
 echo "Starting Xvfb..."


### PR DESCRIPTION
## Problem

On arm64 the linux-desktop image never resizes the screen — the desktop stays at Xvfb's full **8192x4096** startup framebuffer instead of the requested `DISPLAY_SIZEW`x`DISPLAY_SIZEH`.

`x-server.sh`'s `delayedResize()` applies the resolution via Selkies' `selkies-gstreamer-resize`, but Selkies ships **amd64-only** release artifacts and is skipped on arm64/sbsa (the Dockerfile drops the install and the supervisor program there). The resize helper is therefore absent, and the call fails:

```
/opt/supervisor-scripts/x-server.sh: line 28: /usr/local/bin/selkies-gstreamer-resize: No such file or directory
```

## Fix

Add an xrandr fallback in `delayedResize()`:
- If `/usr/local/bin/selkies-gstreamer-resize` exists (amd64) — use it, unchanged.
- Otherwise — derive a CVT modeline and apply `WIDTHxHEIGHT` directly with `xrandr` (`--newmode`/`--addmode`/`--output ... --mode`).

The fallback runs in the same user/`DISPLAY` context as the existing call (supervisor runs `x-server.sh` as `user` with the desktop `DISPLAY`), so no extra X-auth handling is needed. `xrandr` and `cvt` are already present on both arches.

## Verification

On a live arm64 instance:
- Before: `current 8192 x 4096`, log shows the missing-binary error.
- After deploying the script and `supervisorctl restart x-server`: desktop comes up at `1920x1080` (`current 1920 x 1080`, mode `1920x1080*`), no error in the log.

## Follow-up (not in this PR)

`aio-studio`'s `desktop.sh` has the same gap — its resize loop sits inside the `selkies-installed` branch, so it's also skipped on arm64. Worth a separate fix.