### PR TITLE
desktop: fix/defend screen resize on Selkies-less arches (arm64)

### DIFF
--- a/derivatives/linux-desktop/ROOT/opt/supervisor-scripts/x-server.sh
+++ b/derivatives/linux-desktop/ROOT/opt/supervisor-scripts/x-server.sh
@@ -23,9 +23,33 @@ while [[ ! -S $socket ]]; do
     sleep 1
 done
 
+# Apply the requested WIDTHxHEIGHT to the Xvfb screen with xrandr. Used as a
+# fallback where Selkies' own selkies-gstreamer-resize is unavailable: Selkies
+# ships amd64-only release artifacts, so on other arches (arm64/sbsa) that
+# helper is absent and the desktop would otherwise stay at Xvfb's full
+# 8192x4096 startup framebuffer.
+function resizeWithXrandr() {
+    local res="$1"
+    local w="${res%x*}" h="${res#*x}" output mode line
+    output="$(xrandr --query | awk '/ connected/{print $1; exit}')"
+    output="${output:-screen}"
+    mode="${w}x${h}"
+    if ! xrandr --query | grep -qw "${mode}"; then
+        line="$(cvt "${w}" "${h}" 60 | sed -n 's/^Modeline //p' | cut -d' ' -f2-)"
+        xrandr --newmode "${mode}" ${line}
+        xrandr --addmode "${output}" "${mode}"
+    fi
+    xrandr --output "${output}" --mode "${mode}"
+}
+
 function delayedResize() {
     sleep 15
-    /usr/local/bin/selkies-gstreamer-resize "${DISPLAY_SIZEW}x${DISPLAY_SIZEH}"
+    local target="${DISPLAY_SIZEW}x${DISPLAY_SIZEH}"
+    if [[ -x /usr/local/bin/selkies-gstreamer-resize ]]; then
+        /usr/local/bin/selkies-gstreamer-resize "${target}"
+    else
+        resizeWithXrandr "${target}"
+    fi
 }
 
 echo "Starting Xvfb..."

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT_BASE/opt/supervisor-scripts/desktop.sh
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT_BASE/opt/supervisor-scripts/desktop.sh
@@ -62,6 +62,29 @@ wait_file() {
     log "$label ready"
 }
 
+# Apply WIDTHxHEIGHT to the Xvfb screen (run as 'user' on the desktop DISPLAY).
+# Prefer Selkies' resize helper when present; otherwise fall back to a direct
+# xrandr resize. Selkies ships amd64-only release artifacts, so on arches that
+# lack it (e.g. aarch64/sbsa) this keeps the desktop from staying at Xvfb's
+# full 8192x4096 startup framebuffer.
+resize_display() {
+    local target="$1"
+    if [[ -x /usr/local/bin/selkies-gstreamer-resize ]]; then
+        DISPLAY="${DISPLAY}" runuser -u user -- /usr/local/bin/selkies-gstreamer-resize "${target}" >/dev/null 2>&1
+        return
+    fi
+    DISPLAY="${DISPLAY}" runuser -u user -- bash -c '
+        target="$1"; w="${target%x*}"; h="${target#*x}"; mode="${w}x${h}"
+        output="$(xrandr --query | awk "/ connected/ {print \$1; exit}")"
+        output="${output:-screen}"
+        if ! xrandr --query | grep -qw "$mode"; then
+            line="$(cvt "$w" "$h" 60 | sed -n "s/^Modeline //p" | cut -d" " -f2-)"
+            xrandr --newmode "$mode" $line && xrandr --addmode "$output" "$mode"
+        fi
+        xrandr --output "$output" --mode "$mode"
+    ' _ "${target}" >/dev/null 2>&1
+}
+
 # --- Cleanup ---
 cleanup_desktop() {
     log "Shutting down desktop stack..."
@@ -229,25 +252,27 @@ if command -v selkies-gstreamer >/dev/null 2>&1; then
         --turn_protocol="${TURN_PROTOCOL}" \
         --turn_username="${TURN_USERNAME}" \
         --turn_password="${TURN_PASSWORD}"
-
-    # --- Persistent display resize ---
-    # Selkies resets the display resolution when its pipeline (re)initializes.
-    # This background loop monitors and re-applies the target resolution.
-    (
-        TARGET="${DISPLAY_SIZEW}x${DISPLAY_SIZEH}"
-        while true; do
-            CURRENT=$(DISPLAY=${DISPLAY} runuser -u user -- xrandr 2>/dev/null | grep '\*' | awk '{print $1}')
-            if [[ "$CURRENT" != "$TARGET" ]]; then
-                DISPLAY=${DISPLAY} runuser -u user -- /usr/local/bin/selkies-gstreamer-resize "$TARGET" >/dev/null 2>&1 \
-                    && echo "[desktop] Display resized to $TARGET"
-            fi
-            sleep 5
-        done
-    ) &
-    PIDS+=($!)
 else
     log "Selkies not installed (arch=$(uname -m)); skipping Selkies + TURN. VNC remains available."
 fi
+
+# --- Persistent display resize ---
+# Xvfb starts at its full 8192x4096 framebuffer, so the target resolution must
+# be applied after start. Selkies (when present) also resets the resolution
+# when its pipeline (re)initializes, so this background loop monitors and
+# re-applies. Runs on all arches; resize_display falls back to xrandr where
+# Selkies' own resize helper is unavailable.
+(
+    TARGET="${DISPLAY_SIZEW}x${DISPLAY_SIZEH}"
+    while true; do
+        CURRENT=$(DISPLAY=${DISPLAY} runuser -u user -- xrandr 2>/dev/null | grep '\*' | awk '{print $1}')
+        if [[ "$CURRENT" != "$TARGET" ]]; then
+            resize_display "$TARGET" && echo "[desktop] Display resized to $TARGET"
+        fi
+        sleep 5
+    done
+) &
+PIDS+=($!)
 
 # --- All services started ---
 log "=========================================="


### PR DESCRIPTION
Fixes the desktop screen resize on arm64, where Selkies is unavailable. Combines two related changes (previously #169 + #170) into one PR.

## Problem

Both the `linux-desktop` and `aio-studio` desktops apply the target resolution via Selkies' `selkies-gstreamer-resize`. Selkies ships **amd64-only** release artifacts and is skipped on arm64/sbsa, so that helper is absent there and the resize never happens — the desktop stays at Xvfb's full **8192x4096** startup framebuffer.

- **linux-desktop** — live bug on arm64. `x-server.sh` logged `selkies-gstreamer-resize: No such file or directory`.
- **aio-studio** — amd64-only today, so defensive: its resize loop sat *inside* the `command -v selkies-gstreamer` branch and would be skipped entirely on a future Selkies-less arch.

## Fix

Add an xrandr fallback in both scripts: use `selkies-gstreamer-resize` when present (amd64, unchanged), otherwise derive a CVT modeline and apply `WIDTHxHEIGHT` directly with `xrandr` (`--newmode`/`--addmode`/`--output ... --mode`). The fallback names the mode `WxH` so aio-studio's monitor/re-apply loop (now moved out of the Selkies block to run on all arches) doesn't churn.

amd64 behavior is unchanged in both.

## Verification

- **linux-desktop**, live arm64 instance: before `current 8192 x 4096` + the missing-binary error; after deploying and `supervisorctl restart x-server`, the desktop comes up at `1920x1080` with no error.
- **aio-studio** (can't boot on arm64 yet): stubbed `xrandr`/`cvt`/`runuser` and confirmed `resize_display()` emits the correct sequence — same xrandr approach validated live in linux-desktop:

```
xrandr --query
xrandr --newmode 1920x1080 173.00 1920 2048 2248 2576 1080 1083 1088 1120 -hsync +vsync
xrandr --addmode screen 1920x1080
xrandr --output screen --mode 1920x1080
```

`bash -n` clean on both scripts.