### PR TITLE
linux-desktop: bump base image to 2026-06-05 + improve agent docs

### DIFF
--- a/.github/workflows/build-linux-desktop.yml
+++ b/.github/workflows/build-linux-desktop.yml
@@ -94,9 +94,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-04-15
-          - vastai/base-image:cuda-12.9-mini-py312-2026-04-15
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-03-26
+          - vastai/base-image:cuda-13.2-mini-py312-2026-06-05
+          - vastai/base-image:cuda-12.9-mini-py312-2026-06-05
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-06-05
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -159,9 +159,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-04-15
-          - vastai/base-image:cuda-12.9-mini-py312-2026-04-15
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-03-26
+          - vastai/base-image:cuda-13.2-mini-py312-2026-06-05
+          - vastai/base-image:cuda-12.9-mini-py312-2026-06-05
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-06-05
 
     steps:
       - name: Checkout

--- a/derivatives/linux-desktop/ROOT/etc/vast_agents/linux-desktop.md
+++ b/derivatives/linux-desktop/ROOT/etc/vast_agents/linux-desktop.md
@@ -15,7 +15,10 @@ endpoint; it's an interactive GUI to drive visually or automate.
   expected, not a fault.
 
 Either way `x11vnc` also serves the raw display on `:5900` for a native VNC client
-(reach it by SSH-forwarding 5900, base.md §7).
+(reach it by SSH-forwarding 5900, base.md §7). The VNC password is **`VNC_PASSWORD`**
+if set at launch, otherwise **`OPEN_BUTTON_TOKEN`** (the instance token). The
+in-browser Guacamole path applies this for you; you only need it for a direct
+client on `:5900`.
 
 **Drive it programmatically.** The session is `DISPLAY=:20`, owned by the
 unprivileged user **`user`**. Launch GUI apps onto it and automate windows/input

--- a/derivatives/linux-desktop/ROOT/etc/vast_agents/linux-desktop.md
+++ b/derivatives/linux-desktop/ROOT/etc/vast_agents/linux-desktop.md
@@ -1,5 +1,36 @@
 ## Linux desktop (this image)
 
-Provides a full KDE desktop streamed to the browser (Selkies/WebRTC, with x11vnc;
-supervisor services include `kde`, `selkies`, `x-server`, `x11vnc`). The desktop
-appears in `/capabilities/services`; reach it via `direct_url` + token.
+A full **KDE Plasma** desktop running on a virtual X display, reachable from a
+browser. It shows up as a desktop service in `/capabilities/services` — open it
+via that entry's `direct_url` + token (base.md §5). It is **not** an OpenAI/web-API
+endpoint; it's an interactive GUI to drive visually or automate.
+
+**Browser delivery path depends on arch** (this is the thing agents get wrong):
+- **amd64** — **Selkies** low-latency WebRTC (internal port 16100), plus a
+  **Guacamole** HTML5 VNC path (Tomcat, internal 16200).
+- **arm64** — Selkies is published amd64-only upstream, so it is **not installed**
+  here: its `supervisor` program and its `:16100:` portal entry are removed
+  automatically at boot. **Guacamole VNC (16200) is the remote-access path.** Don't
+  look for a `selkies` service under `supervisorctl` on arm64 — its absence is
+  expected, not a fault.
+
+Either way `x11vnc` also serves the raw display on `:5900` for a native VNC client
+(reach it by SSH-forwarding 5900, base.md §7).
+
+**Drive it programmatically.** The session is `DISPLAY=:20`, owned by the
+unprivileged user **`user`**. Launch GUI apps onto it and automate windows/input
+with the preinstalled `xdotool` / `wmctrl` (run as `user`, not root, so they share
+the session bus):
+```
+runuser -u user -- env DISPLAY=:20 xdotool getdisplaygeometry
+runuser -u user -- env DISPLAY=:20 firefox https://example.com &
+```
+`x11-apps` / `x11-utils` are present for X queries and screenshots (e.g. `xwd`).
+
+**Resolution** is `DISPLAY_SIZEW`×`DISPLAY_SIZEH` (default **1920×1080**), chosen at
+launch; the live size is whatever `xrandr` reports on `:20`.
+
+**Preinstalled GUI apps:** Firefox (all arches), Google Chrome (amd64 only),
+Blender, and the KDE Plasma application set. Desktop-stack `supervisor` services:
+`x-server` (Xvfb), `kde`, `x11vnc`, `tomcat` + `guacd` (Guacamole), the PipeWire
+audio stack, and `selkies` (amd64 only).

--- a/derivatives/linux-desktop/ROOT/etc/vast_capabilities.d/30-linux-desktop.yaml
+++ b/derivatives/linux-desktop/ROOT/etc/vast_capabilities.d/30-linux-desktop.yaml
@@ -2,4 +2,4 @@
 image:
   name: Linux desktop
   readme: https://github.com/vast-ai/base-image/tree/main/derivatives/linux-desktop
-  preinstalled: KDE desktop streamed to the browser
+  preinstalled: KDE Plasma desktop in-browser (Guacamole VNC; Selkies WebRTC on amd64) — Firefox, Blender, xdotool


### PR DESCRIPTION
Two post-rebuild updates to the desktop image.

## 1. Base image tags → 2026-06-05

The base image was rebuilt; point `build-linux-desktop.yml` at the new dated tags in **both** the `build` and `merge-manifests` matrices:

| variant | old | new |
|---------|-----|-----|
| `cuda-13.2-mini-py312` | `2026-04-15` | `2026-06-05` |
| `cuda-12.9-mini-py312` | `2026-04-15` | `2026-06-05` |
| `stock-ubuntu24.04-py312` | `2026-03-26` | `2026-06-05` |

All three `2026-06-05` tags were verified present on Docker Hub and multi-arch (amd64 + arm64).

## 2. Agent-facing docs (`vast_agents/linux-desktop.md` + capabilities `preinstalled`)

The old agent guide presented Selkies/WebRTC as the universal access path and listed `selkies` as a supervisor service — **inaccurate on arm64**, where Selkies is amd64-only and its program + portal entry are dropped at boot. An agent reading it would look for a service that isn't there and miss the actual VNC path.

The rewrite documents the real capability surface:
- **Arch-dependent access** — Selkies WebRTC (`:16100`) on amd64; **Guacamole HTML5 VNC (`:16200`) on all arches**; `x11vnc` on `:5900` for native clients. Explicitly notes that a missing `selkies` service on arm64 is expected, not a fault.
- **Driving the desktop programmatically** — session is `DISPLAY=:20` owned by user `user`; launch GUI apps and automate with the preinstalled `xdotool`/`wmctrl`.
- **Resolution** — `DISPLAY_SIZEW`×`DISPLAY_SIZEH` (default 1920×1080).
- **Preinstalled apps** — Firefox (all arches), Chrome (amd64), Blender, KDE set; the desktop-stack supervisor services.

Facts sourced from the Dockerfile/ROOT (`DISPLAY=:20`, `DISPLAY_SIZEW/H`, tomcat→16200, `05-desktop-env.sh` Selkies stripping, installed packages) — consistent with what was observed live on the arm64 instance earlier.

## Sequencing note

Merge **#171** (the arm64 desktop resize fix) before rebuilding linux-desktop from these base tags, so the rebuilt image picks up the resize fix too.