### PR TITLE
Retry the Vast cert fetch in image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -281,7 +281,10 @@ RUN \
     set -euo pipefail && \
     cd /opt && \
     git clone https://github.com/vast-ai/vast-cli && \
-    wget -O /usr/local/share/ca-certificates/jvastai.crt https://console.vast.ai/static/jvastai_root.cer && \
+    wget --tries=5 --retry-connrefused --waitretry=5 --timeout=30 \
+        --retry-on-http-error=403,429,500,502,503,504 \
+        -O /usr/local/share/ca-certificates/jvastai.crt \
+        https://console.vast.ai/static/jvastai_root.cer && \
     update-ca-certificates && \
     pip install --no-cache-dir --ignore-installed \
         jupyter \

--- a/tools/convert-non-vast-image.sh
+++ b/tools/convert-non-vast-image.sh
@@ -144,7 +144,13 @@ ln -s /opt/portal-aio/tunnel_manager/cloudflared /opt/instance-tools/bin/cloudfl
 
 cd /opt
 git clone https://github.com/vast-ai/vast-cli
-wget -O /usr/local/share/ca-certificates/jvastai.crt https://console.vast.ai/static/jvastai_root.cer
+# console.vast.ai occasionally returns a transient 403 (edge/WAF blip) for
+# this static cert; without retries a single bad response aborts the whole
+# build under `set -euo pipefail`. Retry a few times before giving up.
+wget --tries=5 --retry-connrefused --waitretry=5 --timeout=30 \
+    --retry-on-http-error=403,429,500,502,503,504 \
+    -O /usr/local/share/ca-certificates/jvastai.crt \
+    https://console.vast.ai/static/jvastai_root.cer
 update-ca-certificates
 
 # Protect the system python directory when Vast bootstrapping adds jupyter.


### PR DESCRIPTION
## What

Wrap the `wget` of `https://console.vast.ai/static/jvastai_root.cer` in retries at both fetch sites:

- `Dockerfile:284` — base image build
- `tools/convert-non-vast-image.sh:147` — non-Vast image conversion (used by derivative builds)

Retry config: `--tries=5 --retry-connrefused --waitretry=5 --timeout=30 --retry-on-http-error=403,429,500,502,503,504`.

## Why

`console.vast.ai` intermittently returns a transient `403` for this static cert (edge/WAF blip). Under `set -euo pipefail`, a single bad response aborts the entire build. On 2026-06-05 this failed the amd64 legs of **both** the vLLM and Ollama builds within hours of each other — same root cause, different derivatives. Plain `wget` treats a 403 as fatal and won't retry it, so `--retry-on-http-error` is the key flag.

## Scope

- `Dockerfile.runtime` needs no change — it `FROM`s the base image and only layers CUDA apt packages, inheriting the already-installed cert.
- Other unguarded downloads (e.g. `cloudflared`) are intentionally left alone; if one of those fails we'd rather it fail loudly and investigate.

## Notes

`--retry-on-http-error` requires GNU wget >= 1.20; Ubuntu noble ships 1.21.4, and `wget` is installed earlier in the conversion script, so the flag is available at build time.