### PR TITLE
agent docs: default internet-facing apps to the authed Caddy edge

### DIFF
--- a/ROOT/etc/vast_agents/base.md
+++ b/ROOT/etc/vast_agents/base.md
@@ -222,6 +222,11 @@ Then load it: `supervisorctl reread && supervisorctl update` (later:
 **Step 3 — expose it externally.** Pick a **free** open port (`in_use: false`, §6 —
 don't reuse one a service holds).
 
+**For anything internet-facing, default to the authed Caddy edge** (below): the user
+still reaches it with their token (§5), whereas an open port is reachable by *anyone*
+with the URL. A normal port bound directly with **no** `/etc/portal.yaml` entry works
+but is **unauthenticated** — only do that when open public access is explicitly wanted.
+
 *If the only free port is `self_mapped` (§6):* no Caddy path — bind your app to its
 `bind_port` (= `$VAST_TCP_PORT_<container_port>`, the script's `--port`); it's reachable
 at `$PUBLIC_IPADDR:$VAST_TCP_PORT_<container_port>` with **no token auth** (enforce your


### PR DESCRIPTION
Follow-up to #175 (docs only — no behaviour change).

## Why

When asked to expose an app *"over the internet"*, a test agent bound it **directly to a normal NATed port with no `/etc/portal.yaml` entry** — publicly reachable but **unauthenticated** — instead of the authed Caddy path that §7 already recommends. The agent was transparent (it flagged the lack of auth/TLS and offered the secure route), so the behaviour was acceptable, but the default leaned toward "open to anyone with the URL" when the user can reach an **authed** port with their own token (`?token=…`) at no extra cost.

Root cause in the guide: §7 Step 3 steers normal ports to the Caddy auth edge, but never spells out that a normal port with **no** portal.yaml entry is still publicly reachable — just unauthenticated. The agent found that shortcut and took it, with nothing flagging it as a security downgrade or stating a default posture.

## Change

One short paragraph in §7 Step 3:

> **For anything internet-facing, default to the authed Caddy edge** (below): the user still reaches it with their token (§5), whereas an open port is reachable by *anyone* with the URL. A normal port bound directly with **no** `/etc/portal.yaml` entry works but is **unauthenticated** — only do that when open public access is explicitly wanted.

This names the direct-bind shortcut as a deliberate opt-in and sets the safe default.
