### PR TITLE
extend-pytorch: cover torch 2.12 + resync cuda_short to build config

### DIFF
--- a/.github/workflows/extend-pytorch.yml
+++ b/.github/workflows/extend-pytorch.yml
@@ -61,16 +61,18 @@ jobs:
             "2.7.1|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313"
             "2.8.0|cu126|12.6.3|linux/amd64|310 311 312"
             "2.8.0|cu128|12.8.1|linux/amd64|310 311 312 313"
-            "2.8.0|cu129|12.9.1|linux/amd64|310 311 312 313"
+            "2.8.0|cu129|12.9.2|linux/amd64|310 311 312 313"
             "2.9.1|cu126|12.6.3|linux/amd64|310 311 312"
             "2.9.1|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.9.1|cu130|13.0.2|linux/amd64,linux/arm64|310 311 312 313 314"
+            "2.9.1|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
             "2.10.0|cu126|12.6.3|linux/amd64|310 311 312"
             "2.10.0|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.10.0|cu130|13.0.2|linux/amd64,linux/arm64|310 311 312 313 314"
+            "2.10.0|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
             "2.11.0|cu126|12.6.3|linux/amd64|310 311 312"
             "2.11.0|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.11.0|cu130|13.0.2|linux/amd64,linux/arm64|310 311 312 313 314"
+            "2.11.0|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
+            "2.12.0|cu126|12.6.3|linux/amd64,linux/arm64|310 311 312 313 314"
+            "2.12.0|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
           )
 
           # Mini format: torch_ver|key|torch_backend|cuda_minor|arches|python_versions
@@ -84,6 +86,8 @@ jobs:
             "2.10.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
             "2.11.0|cu128-mini|cu128|12.9|linux/amd64,linux/arm64|310 311 312 313 314"
             "2.11.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
+            "2.12.0|cu126-mini|cu126|12.9|linux/amd64,linux/arm64|310 311 312 313 314"
+            "2.12.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
           )
 
           BUILD_MATRIX="[]"


### PR DESCRIPTION
## Problem

`extend-pytorch.yml` had drifted from `build-pytorch.yml`. Commit b87534c (#173, "DRAFT: pytorch torch 2.12 config") updated **build-pytorch** and **promote-pytorch** for torch 2.12 but left **extend-pytorch** untouched. As a result the extend workflow:

1. **Could not produce torch 2.12 images** (cu126 + cu130, full + mini) — they were simply absent from its config lists.
2. Pointed at **stale CUDA patch tags** for the cu130/cu129 lines, which the same commit bumped on the build side.

## Change — resync the config lists to mirror build-pytorch

- **Add 2.12.0**: `cu126` + `cu130` (full) and `cu126-mini` + `cu130-mini` (mini), cp310–cp314, multi-arch.
- **cu130** `cuda_short` `13.0.2` → `13.0.3` (2.9.1 / 2.10.0 / 2.11.0).
- **cu129** `cuda_short` `12.9.1` → `12.9.2` (2.8.0).

The extend sources from the promoted prod tag `…-cuda-<cuda_short>-…`, so these values must match what build/promote published. They now mirror build-pytorch exactly. The dry-run reads the generated matrices, so it lists 2.12 automatically — no separate dry-run edit needed.

## Note on the cuda_short bumps

The `13.0.2→13.0.3` / `12.9.1→12.9.2` bumps are coupled to 2.12: 2.12 was built on the `13.0.3` base from the same commit, so if 2.12 exists in prod, the cu130 base bump shipped too and the older cu130/cu129 prod tags are now on the bumped patch versions. **Before a real extend run, do a `DRY_RUN=true` and confirm a cu130 source tag actually resolves** for your `SOURCE_DATE` (cheap sanity check that prod matches these values).
