### PR TITLE
extend-pytorch: add multi-torch handling

### DIFF
--- a/.github/workflows/extend-pytorch.yml
+++ b/.github/workflows/extend-pytorch.yml
@@ -42,6 +42,9 @@ jobs:
       mini-build-matrix: ${{ steps.matrix.outputs.mini-build-matrix }}
       mini-merge-matrix: ${{ steps.matrix.outputs.mini-merge-matrix }}
       has-mini: ${{ steps.matrix.outputs.has-mini }}
+      multi-build-matrix: ${{ steps.matrix.outputs.multi-build-matrix }}
+      multi-merge-matrix: ${{ steps.matrix.outputs.multi-merge-matrix }}
+      has-multi: ${{ steps.matrix.outputs.has-multi }}
       build-date: ${{ steps.matrix.outputs.build-date }}
     steps:
       - name: Generate matrices
@@ -88,6 +91,12 @@ jobs:
             "2.11.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
             "2.12.0|cu126-mini|cu126|12.9|linux/amd64,linux/arm64|310 311 312 313 314"
             "2.12.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
+          )
+
+          # Multi-torch format: key|primary_torch|primary_backend|cuda_minor|arches|python_versions
+          # (key already encodes the full tag; extend overlays the prod manifest per arch)
+          ALL_MULTI_CONFIGS=(
+            "multi-210-291-271|2.10.0|cu128|12.9|linux/amd64,linux/arm64|312"
           )
 
           BUILD_MATRIX="[]"
@@ -168,6 +177,51 @@ jobs:
             echo "has-mini=false" >> $GITHUB_OUTPUT
           fi
 
+          # Multi-torch configs
+          MULTI_BUILD_MATRIX="[]"
+          MULTI_MERGE_MATRIX="[]"
+
+          for multi_config in "${ALL_MULTI_CONFIGS[@]}"; do
+            IFS='|' read -r key primary_torch primary_backend cuda_minor arches python_versions <<< "$multi_config"
+
+            # FILTER=mini also includes multi since multi layers on mini.
+            if [[ -n "$FILTER" && "$key" != *"$FILTER"* && "$primary_torch" != *"$FILTER"* && "multi" != *"$FILTER"* && "mini" != *"$FILTER"* ]]; then
+              continue
+            fi
+
+            MULTI_MERGE_MATRIX=$(echo "$MULTI_MERGE_MATRIX" | jq -c \
+              --arg key "$key" \
+              --arg primary_torch "$primary_torch" \
+              --arg primary_backend "$primary_backend" \
+              --arg cuda_minor "$cuda_minor" \
+              --arg arches "$arches" \
+              --arg python_versions "$python_versions" \
+              '. + [{"config_key": $key, "primary_torch": $primary_torch, "primary_backend": $primary_backend, "cuda_minor": $cuda_minor, "arches": $arches, "python_versions": $python_versions}]')
+
+            IFS=',' read -ra ARCH_LIST <<< "$arches"
+            for arch in "${ARCH_LIST[@]}"; do
+              arch_suffix="${arch#linux/}"
+              # Native runner per arch — no QEMU. arm64 builds on arm hardware.
+              [[ "$arch_suffix" == "arm64" ]] && runs_on="ubuntu-24.04-arm" || runs_on="ubuntu-latest"
+              MULTI_BUILD_MATRIX=$(echo "$MULTI_BUILD_MATRIX" | jq -c \
+                --arg key "$key" \
+                --arg primary_torch "$primary_torch" \
+                --arg primary_backend "$primary_backend" \
+                --arg cuda_minor "$cuda_minor" \
+                --arg arch "$arch" \
+                --arg arch_suffix "$arch_suffix" \
+                --arg runs_on "$runs_on" \
+                --arg python_versions "$python_versions" \
+                '. + [{"config_key": $key, "primary_torch": $primary_torch, "primary_backend": $primary_backend, "cuda_minor": $cuda_minor, "arch": $arch, "arch_suffix": $arch_suffix, "runs_on": $runs_on, "python_versions": $python_versions}]')
+            done
+          done
+
+          if [[ $(echo "$MULTI_BUILD_MATRIX" | jq length) -gt 0 ]]; then
+            echo "has-multi=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-multi=false" >> $GITHUB_OUTPUT
+          fi
+
           {
             echo "build-matrix<<BUILD_MATRIX_EOF"
             echo "{\"include\":${BUILD_MATRIX}}"
@@ -188,9 +242,20 @@ jobs:
             echo "{\"include\":${MINI_MERGE_MATRIX}}"
             echo "MINI_MERGE_MATRIX_EOF"
           } >> $GITHUB_OUTPUT
+          {
+            echo "multi-build-matrix<<MULTI_BUILD_MATRIX_EOF"
+            echo "{\"include\":${MULTI_BUILD_MATRIX}}"
+            echo "MULTI_BUILD_MATRIX_EOF"
+          } >> $GITHUB_OUTPUT
+          {
+            echo "multi-merge-matrix<<MULTI_MERGE_MATRIX_EOF"
+            echo "{\"include\":${MULTI_MERGE_MATRIX}}"
+            echo "MULTI_MERGE_MATRIX_EOF"
+          } >> $GITHUB_OUTPUT
 
           echo "Build matrix entries: $(echo "$BUILD_MATRIX" | jq length)"
           echo "Mini build matrix entries: $(echo "$MINI_BUILD_MATRIX" | jq length)"
+          echo "Multi build matrix entries: $(echo "$MULTI_BUILD_MATRIX" | jq length)"
           echo "Build date: $BUILD_DATE"
 
   extend:
@@ -448,8 +513,123 @@ jobs:
           path: built-tags/
           retention-days: 1
 
+  extend-multi:
+    needs: [generate-matrix]
+    if: ${{ needs.generate-matrix.outputs.has-multi == 'true' && !inputs.DRY_RUN }}
+    runs-on: ${{ matrix.runs_on }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.multi-build-matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extend multi-torch Python versions
+        env:
+          NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          PROD_NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE }}
+          CONFIG_KEY: ${{ matrix.config_key }}
+          ARCH: ${{ matrix.arch }}
+          ARCH_SUFFIX: ${{ matrix.arch_suffix }}
+          PYTHON_VERSIONS: ${{ matrix.python_versions }}
+          SOURCE_DATE: ${{ inputs.SOURCE_DATE }}
+          BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/built-tags"
+          cd derivatives/pytorch
+
+          for py_tag in ${PYTHON_VERSIONS}; do
+            SOURCE="${PROD_NAMESPACE}/pytorch:${CONFIG_KEY}-py${py_tag}-${SOURCE_DATE}"
+            TAG="${NAMESPACE}/pytorch:${CONFIG_KEY}-py${py_tag}-${BUILD_DATE}-${ARCH_SUFFIX}"
+
+            echo "=== Extending multi-torch: ${CONFIG_KEY} py${py_tag} for ${ARCH} ==="
+            echo "    Source: ${SOURCE}"
+            docker buildx build \
+              --progress=plain \
+              --platform "${ARCH}" \
+              -f Dockerfile.extend \
+              --build-arg BASE_IMAGE="${SOURCE}" \
+              --tag "${TAG}" \
+              --push .
+
+            echo "$TAG" >> "$GITHUB_WORKSPACE/built-tags/tags.txt"
+          done
+
+      - name: Upload multi tags
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-tags-${{ matrix.config_key }}-${{ matrix.arch_suffix }}
+          path: built-tags/
+          retention-days: 1
+
+  merge-multi-manifests:
+    needs: [generate-matrix, extend-multi]
+    if: ${{ needs.generate-matrix.outputs.has-multi == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.multi-merge-matrix) }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Merge multi-torch manifests
+        env:
+          NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          CONFIG_KEY: ${{ matrix.config_key }}
+          ARCHES: ${{ matrix.arches }}
+          PYTHON_VERSIONS: ${{ matrix.python_versions }}
+          BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
+        run: |
+          mkdir -p built-tags
+
+          IFS=',' read -ra ARCH_LIST <<< "$ARCHES"
+
+          for py_tag in ${PYTHON_VERSIONS}; do
+            FINAL_TAG="${NAMESPACE}/pytorch:${CONFIG_KEY}-py${py_tag}-${BUILD_DATE}"
+            AMD64_TAG="${FINAL_TAG}-amd64"
+
+            echo "=== Merging multi-torch manifest: ${FINAL_TAG} ==="
+            if [[ ${#ARCH_LIST[@]} -gt 1 ]]; then
+              ARM64_TAG="${FINAL_TAG}-arm64"
+              docker buildx imagetools create \
+                -t "${FINAL_TAG}" \
+                "${AMD64_TAG}" "${ARM64_TAG}"
+            else
+              docker buildx imagetools create \
+                -t "${FINAL_TAG}" \
+                "${AMD64_TAG}"
+            fi
+
+            echo "$FINAL_TAG" >> built-tags/tags.txt
+          done
+
+      - name: Upload multi manifest tags
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-manifest-tags-${{ matrix.config_key }}
+          path: built-tags/
+          retention-days: 1
+
   collect-tags:
-    needs: [generate-matrix, extend, merge-manifests, extend-mini, merge-mini-manifests]
+    needs: [generate-matrix, extend, merge-manifests, extend-mini, merge-mini-manifests, extend-multi, merge-multi-manifests]
     if: always() && !inputs.DRY_RUN
     runs-on: ubuntu-latest
     outputs:
@@ -458,7 +638,7 @@ jobs:
       - name: Download all tag artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "{built-tags-*,manifest-tags-*,mini-tags-*,mini-manifest-tags-*}"
+          pattern: "{built-tags-*,manifest-tags-*,mini-tags-*,mini-manifest-tags-*,multi-tags-*,multi-manifest-tags-*}"
           path: all-tags/
 
       - name: Aggregate tags
@@ -488,6 +668,8 @@ jobs:
           MERGE_MATRIX: ${{ needs.generate-matrix.outputs.merge-matrix }}
           MINI_BUILD_MATRIX: ${{ needs.generate-matrix.outputs.mini-build-matrix }}
           HAS_MINI: ${{ needs.generate-matrix.outputs.has-mini }}
+          MULTI_BUILD_MATRIX: ${{ needs.generate-matrix.outputs.multi-build-matrix }}
+          HAS_MULTI: ${{ needs.generate-matrix.outputs.has-multi }}
           BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
           SOURCE_DATE: ${{ inputs.SOURCE_DATE }}
           NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
@@ -548,6 +730,26 @@ jobs:
               for py_tag in ${python_versions}; do
                 echo "  ${PROD_NAMESPACE}/pytorch:${torch_ver}-${torch_backend}-cuda-${cuda_minor}-mini-py${py_tag}-${SOURCE_DATE}"
                 echo "    -> ${NAMESPACE_STAGING}/pytorch:${torch_ver}-${torch_backend}-cuda-${cuda_minor}-mini-py${py_tag}-${BUILD_DATE}"
+              done
+            done
+          fi
+
+          if [[ "$HAS_MULTI" == "true" ]]; then
+            echo ""
+            MULTI_COUNT=$(echo "$MULTI_BUILD_MATRIX" | jq '.include | length')
+            echo "=== Multi-torch Extend Jobs ==="
+            for ((i=0; i<MULTI_COUNT; i++)); do
+              arch_suffix=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].arch_suffix")
+              [[ "$arch_suffix" != "amd64" ]] && continue
+
+              key=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].config_key")
+              python_versions=$(echo "$MULTI_BUILD_MATRIX" | jq -r ".include[$i].python_versions")
+
+              echo ""
+              echo "--- ${key} ---"
+              for py_tag in ${python_versions}; do
+                echo "  ${PROD_NAMESPACE}/pytorch:${key}-py${py_tag}-${SOURCE_DATE}"
+                echo "    -> ${NAMESPACE_STAGING}/pytorch:${key}-py${py_tag}-${BUILD_DATE}"
               done
             done
           fi


### PR DESCRIPTION
## Problem

`extend-pytorch` built full + mini staging images but had **no multi-torch handling**, while `build-pytorch` and `promote-pytorch` both include the multi-torch config (`multi-210-291-271`, wired into promote since #149). So promoting a date whose staging images came from an *extend* run aborted on the missing source:

```
MISSING: .../pytorch:multi-210-291-271-py312-<date>
ERROR: 1 staging source(s) missing; real promote would abort
```

(The full build produces multi; the extend silently skipped it — the gap only surfaced when promoting an extend-produced date.)

## Change — mirror the full/mini pattern (and build-pytorch)

- **generate-matrix**: `ALL_MULTI_CONFIGS` + `multi-build-matrix` / `multi-merge-matrix` / `has-multi` outputs, native runner per arch (`arm64 → ubuntu-24.04-arm`).
- **extend-multi**: overlay the prod multi manifest per arch via `Dockerfile.extend` → staging `<key>-py<py>-<date>-<arch>`.
- **merge-multi-manifests**: combine into the `<key>-py<py>-<date>` manifest (what promote expects).
- **collect-tags** + **dry-run**: include the multi tags.

The extend **overlays the existing prod multi image** (it does not rebuild the layered torch venvs), so it's the same lightweight overlay the other extend jobs perform. Validated: YAML parses, and the matrix builds 2 native-runner entries (amd64/arm64) → 1 merged `multi-210-291-271-py312-<date>` manifest.

This closes the last of the build↔extend drift (after #177 torch 2.12 + #178 native runners).
