### PR TITLE
ollama: agent-aware guide (CON-1565)

### DIFF
--- a/external/ollama/ROOT/etc/vast_agents/ollama.md
+++ b/external/ollama/ROOT/etc/vast_agents/ollama.md
@@ -47,8 +47,12 @@ needed.)
 
 ### Other env vars and companion service
 
-- **`OLLAMA_HOST`** — bind address, default `0.0.0.0:21434` (keep the `21434` port so
-  the Caddy mapping works). **`OLLAMA_ARGS`** — extra flags for `ollama serve`.
+- **`OLLAMA_HOST`** — bind address, default **`127.0.0.1:21434`** (loopback only: the
+  only external path is the token-authed Caddy edge; keep the `21434` port so the Caddy
+  mapping works). **Do not bind `0.0.0.0`** unless you deliberately want a direct,
+  *unauthenticated* Ollama port — the upstream image's `EXPOSE 11434` means a `0.0.0.0`
+  bind is reachable by anyone, bypassing auth. **`OLLAMA_ARGS`** — extra flags for
+  `ollama serve`.
 - **`OLLAMA_MODELS`** — model store, default `${WORKSPACE}/ollama/models`.
 - **`model-ui`** — a lightweight web frontend (portal label **"Model UI"**) for
   exercising a model from a browser; a convenience proxy in front of the Ollama

--- a/external/ollama/ROOT/etc/vast_agents/ollama.md
+++ b/external/ollama/ROOT/etc/vast_agents/ollama.md
@@ -1,6 +1,59 @@
 ## Ollama (this image)
 
-Runs Ollama — service label **"Ollama API"**, OpenAI-compatible at `/v1`.
+The base image plus a preinstalled **Ollama** model server. Everything in base.md
+(supervisor, Caddy auth edge, ports, storage, GPU/CUDA, provisioning) applies
+unchanged — this file covers only what Ollama adds.
 
-- Manage models with the `ollama` CLI: `ollama list`, `ollama pull <model>`, `ollama run <model>`.
-- For the externally callable `base_url` + auth: `curl -s http://localhost:11111/capabilities/endpoints`.
+### The server and its endpoints
+
+Ollama runs as the supervisor service **`ollama`** (portal label **"Ollama API"**) and
+exposes **two** APIs on the same port: Ollama's **native REST API** (`/api/*` —
+`/api/generate`, `/api/chat`, `/api/tags`, `/api/pull`, …) and an **OpenAI-compatible**
+surface at **`/v1`**. Get the externally callable `base_url` + auth from the capability
+manifest rather than guessing the port (base.md §9):
+```
+curl -s http://localhost:11111/capabilities/endpoints   # base_url (/v1), capabilities (chat/completions/embeddings/models), auth
+```
+Internally it listens on `127.0.0.1:21434` (Caddy proxies external `11434` → `21434`).
+Call `/v1` like the OpenAI API with the instance token (base.md §5); the client picks
+the model per request, so **any pulled model can be served** — there is no single
+"loaded" model as with vLLM.
+
+### Managing models
+
+The `ollama` CLI is the main tool, and models persist in
+`OLLAMA_MODELS` (default `${WORKSPACE}/ollama/models`, so they survive on a volume):
+```
+ollama list                 # what's pulled
+ollama pull qwen3:8b        # fetch a model (then it's immediately servable via /v1 or /api)
+ollama run  qwen3:8b        # pull + interactive chat
+ollama rm   qwen3:8b
+```
+
+**`OLLAMA_MODEL`** names a model to **pull automatically at boot** (the service blocks
+on the pull and exits if it fails). Unlike vLLM, the server still starts with no model
+set — it just has nothing pulled yet. To change the boot-time model persistently, set
+it where the instance sources env on every boot, then restart. **Set both
+`OLLAMA_MODEL` and `MODEL_NAME`** — the boot-time linking between them does *not* re-run
+on a `supervisorctl restart`, and **Model UI keys off `MODEL_NAME`** (won't start
+without it). `/etc/environment` survives stop/start; `${WORKSPACE}/.env` additionally
+survives recycle/destroy *if* a volume is mounted (base.md §3, §8):
+```
+printf 'OLLAMA_MODEL="%s"\nMODEL_NAME="%s"\n' qwen3:8b qwen3:8b >> /etc/environment
+supervisorctl restart ollama model-ui
+```
+(For a model you just want available now, a plain `ollama pull` is enough — no restart
+needed.)
+
+### Other env vars and companion service
+
+- **`OLLAMA_HOST`** — bind address, default `0.0.0.0:21434` (keep the `21434` port so
+  the Caddy mapping works). **`OLLAMA_ARGS`** — extra flags for `ollama serve`.
+- **`OLLAMA_MODELS`** — model store, default `${WORKSPACE}/ollama/models`.
+- **`model-ui`** — a lightweight web frontend (portal label **"Model UI"**) for
+  exercising a model from a browser; a convenience proxy in front of the Ollama
+  endpoint, **not a second API** (call `/v1` or `/api` directly for programmatic use).
+  Only starts when `MODEL_NAME` is set; configure with `MODEL_UI_*` env vars. Full docs
+  ship at **`/opt/model-ui/README.md`** (also `tools/model-ui/` in the base-image repo).
+- Both wait for provisioning (`/.provisioning`) before starting (base.md §10). Ollama
+  has no Ray service.

--- a/external/ollama/ROOT/etc/vast_agents/ollama.md
+++ b/external/ollama/ROOT/etc/vast_agents/ollama.md
@@ -14,7 +14,7 @@ manifest rather than guessing the port (base.md §9):
 ```
 curl -s http://localhost:11111/capabilities/endpoints   # base_url (/v1), capabilities (chat/completions/embeddings/models), auth
 ```
-Internally it listens on `127.0.0.1:21434` (Caddy proxies external `11434` → `21434`).
+Internally it listens on loopback `127.0.0.1:11434` (Caddy proxies external `21434` → `11434`).
 Call `/v1` like the OpenAI API with the instance token (base.md §5); the client picks
 the model per request, so **any pulled model can be served** — there is no single
 "loaded" model as with vLLM.
@@ -47,12 +47,12 @@ needed.)
 
 ### Other env vars and companion service
 
-- **`OLLAMA_HOST`** — bind address, default **`127.0.0.1:21434`** (loopback only: the
-  only external path is the token-authed Caddy edge; keep the `21434` port so the Caddy
-  mapping works). **Do not bind `0.0.0.0`** unless you deliberately want a direct,
-  *unauthenticated* Ollama port — the upstream image's `EXPOSE 11434` means a `0.0.0.0`
-  bind is reachable by anyone, bypassing auth. **`OLLAMA_ARGS`** — extra flags for
-  `ollama serve`.
+- **`OLLAMA_HOST`** — bind address, default **`127.0.0.1:11434`** (loopback only: the
+  only external path is the token-authed Caddy edge, which fronts external `21434`).
+  **Do not bind `0.0.0.0`** unless you deliberately want a direct, *unauthenticated*
+  Ollama port — the upstream image's `EXPOSE 11434` means a `0.0.0.0` bind is reachable
+  by anyone, bypassing auth (the image rewrites the upstream `0.0.0.0:11434` default to
+  loopback for exactly this reason). **`OLLAMA_ARGS`** — extra flags for `ollama serve`.
 - **`OLLAMA_MODELS`** — model store, default `${WORKSPACE}/ollama/models`.
 - **`model-ui`** — a lightweight web frontend (portal label **"Model UI"**) for
   exercising a model from a browser; a convenience proxy in front of the Ollama

--- a/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
+++ b/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
@@ -4,15 +4,25 @@
 
 # Do not require this to be set in the template unless user wants an override
 if [[ -z $PORTAL_CONFIG ]]; then
-    export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:7860:17860:/:Model UI|localhost:11434:21434:/:Ollama API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+    export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:7860:17860:/:Model UI|localhost:21434:11434:/:Ollama API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
 fi
 
 # OLLAMA_MODEL takes precedence over serverless convention if set
 export MODEL_NAME="${OLLAMA_MODEL:-$MODEL_NAME}"
 export OLLAMA_MODEL="$MODEL_NAME"
 
-# Bind to internal port (Caddy proxies external 11434 -> internal 21434)
-export OLLAMA_HOST=${OLLAMA_HOST:-0.0.0.0:21434}
+# Bind Ollama to loopback ONLY (on its native port 11434). External access is via the
+# authenticated Caddy edge, which proxies external 21434 -> internal 11434 over localhost.
+# The upstream image bakes `ENV OLLAMA_HOST=0.0.0.0:11434`, so a plain `:-` default would
+# never fire (the var is already set). Rewrite an all-interfaces host to loopback, keeping
+# the port — a 0.0.0.0 bind, combined with the upstream `EXPOSE 11434`, would leave the API
+# reachable unauthenticated, bypassing Caddy token auth. An operator can still set a
+# non-0.0.0.0 OLLAMA_HOST to override.
+case "${OLLAMA_HOST:-}" in
+    ""|0.0.0.0)  OLLAMA_HOST="127.0.0.1:11434" ;;
+    0.0.0.0:*)   OLLAMA_HOST="127.0.0.1:${OLLAMA_HOST##*:}" ;;
+esac
+export OLLAMA_HOST
 export OLLAMA_PORT=${OLLAMA_HOST##*:}
 
 # Model UI connects to the Ollama API


### PR DESCRIPTION
Part of CON-1556 (agent-aware AGENTS files for all active images). LLM inference-engine set; follows the vLLM template (#180), adapted for Ollama.

Expands `external/ollama/ROOT/etc/vast_agents/ollama.md` from the #165 stub to the base.md / pytorch.md standard:

- dual API: native `/api/*` **and** OpenAI `/v1` on internal `21434` (Caddy maps external `11434`)
- `ollama` CLI for model management; persistent `OLLAMA_MODELS` store; any pulled model is servable (no single "loaded" model)
- `OLLAMA_MODEL` pulls at boot; runtime change sets **both** `OLLAMA_MODEL` and `MODEL_NAME` (Model UI keys off the latter); a plain `ollama pull` needs no restart
- `OLLAMA_HOST` / `OLLAMA_ARGS`; `model-ui` companion (no Ray)

Docs-only change to the in-image guide. Build a test image with `gh workflow run "Build Ollama Image" --ref docs/agents-ollama`.