### PR TITLE
SECURITY: ollama binds 0.0.0.0 — unauthenticated API exposure

### DIFF
--- a/external/ollama/Dockerfile
+++ b/external/ollama/Dockerfile
@@ -33,14 +33,6 @@ RUN \
 
 ### Begin Ollama specific configuration ###
 
-# SECURITY: the upstream ollama/ollama image bakes `ENV OLLAMA_HOST=0.0.0.0:11434`.
-# Left in place, Ollama binds all interfaces on 11434 — colliding with the Caddy edge
-# and, via the upstream `EXPOSE 11434`, exposing the API unauthenticated. Override the
-# inherited value so Ollama binds loopback on the internal port; the Caddy edge proxies
-# the external 11434 vhost to it with token auth. A Vast template env var still overrides
-# this at runtime for anyone who deliberately wants a different bind.
-ENV OLLAMA_HOST=127.0.0.1:21434
-
 # Install Model UI (lightweight web interface) — chat only by default
 ENV MODEL_UI_CHAT_CAPS=all
 COPY --from=base_image_source tools/model-ui /opt/model-ui

--- a/external/ollama/Dockerfile
+++ b/external/ollama/Dockerfile
@@ -33,6 +33,14 @@ RUN \
 
 ### Begin Ollama specific configuration ###
 
+# SECURITY: the upstream ollama/ollama image bakes `ENV OLLAMA_HOST=0.0.0.0:11434`.
+# Left in place, Ollama binds all interfaces on 11434 — colliding with the Caddy edge
+# and, via the upstream `EXPOSE 11434`, exposing the API unauthenticated. Override the
+# inherited value so Ollama binds loopback on the internal port; the Caddy edge proxies
+# the external 11434 vhost to it with token auth. A Vast template env var still overrides
+# this at runtime for anyone who deliberately wants a different bind.
+ENV OLLAMA_HOST=127.0.0.1:21434
+
 # Install Model UI (lightweight web interface) — chat only by default
 ENV MODEL_UI_CHAT_CAPS=all
 COPY --from=base_image_source tools/model-ui /opt/model-ui

--- a/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
+++ b/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
@@ -13,9 +13,11 @@ export OLLAMA_MODEL="$MODEL_NAME"
 
 # Bind the internal port to loopback ONLY. External access is via the authenticated
 # Caddy edge, which proxies external 11434 -> internal 21434 over localhost.
-# Do NOT default to 0.0.0.0: the upstream ollama/ollama image sets `EXPOSE 11434`
-# (which a child image cannot remove), so a 0.0.0.0 bind leaves Ollama reachable
-# unauthenticated on any directly-forwarded port, bypassing Caddy token auth.
+# NOTE: the upstream image bakes `ENV OLLAMA_HOST=0.0.0.0:11434`, so this `:-` default
+# would never fire on its own — the Dockerfile resets ENV OLLAMA_HOST=127.0.0.1:21434
+# to override it (see the SECURITY note there). This line keeps loopback as the value of
+# record and as a fallback. Never let Ollama bind 0.0.0.0: combined with the upstream
+# `EXPOSE 11434` it leaves the API reachable unauthenticated, bypassing Caddy token auth.
 export OLLAMA_HOST=${OLLAMA_HOST:-127.0.0.1:21434}
 export OLLAMA_PORT=${OLLAMA_HOST##*:}
 

--- a/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
+++ b/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
@@ -4,21 +4,25 @@
 
 # Do not require this to be set in the template unless user wants an override
 if [[ -z $PORTAL_CONFIG ]]; then
-    export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:7860:17860:/:Model UI|localhost:11434:21434:/:Ollama API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+    export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:7860:17860:/:Model UI|localhost:21434:11434:/:Ollama API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
 fi
 
 # OLLAMA_MODEL takes precedence over serverless convention if set
 export MODEL_NAME="${OLLAMA_MODEL:-$MODEL_NAME}"
 export OLLAMA_MODEL="$MODEL_NAME"
 
-# Bind the internal port to loopback ONLY. External access is via the authenticated
-# Caddy edge, which proxies external 11434 -> internal 21434 over localhost.
-# NOTE: the upstream image bakes `ENV OLLAMA_HOST=0.0.0.0:11434`, so this `:-` default
-# would never fire on its own — the Dockerfile resets ENV OLLAMA_HOST=127.0.0.1:21434
-# to override it (see the SECURITY note there). This line keeps loopback as the value of
-# record and as a fallback. Never let Ollama bind 0.0.0.0: combined with the upstream
-# `EXPOSE 11434` it leaves the API reachable unauthenticated, bypassing Caddy token auth.
-export OLLAMA_HOST=${OLLAMA_HOST:-127.0.0.1:21434}
+# Bind Ollama to loopback ONLY (on its native port 11434). External access is via the
+# authenticated Caddy edge, which proxies external 21434 -> internal 11434 over localhost.
+# The upstream image bakes `ENV OLLAMA_HOST=0.0.0.0:11434`, so a plain `:-` default would
+# never fire (the var is already set). Rewrite an all-interfaces host to loopback, keeping
+# the port — a 0.0.0.0 bind, combined with the upstream `EXPOSE 11434`, would leave the API
+# reachable unauthenticated, bypassing Caddy token auth. An operator can still set a
+# non-0.0.0.0 OLLAMA_HOST to override.
+case "${OLLAMA_HOST:-}" in
+    ""|0.0.0.0)  OLLAMA_HOST="127.0.0.1:11434" ;;
+    0.0.0.0:*)   OLLAMA_HOST="127.0.0.1:${OLLAMA_HOST##*:}" ;;
+esac
+export OLLAMA_HOST
 export OLLAMA_PORT=${OLLAMA_HOST##*:}
 
 # Model UI connects to the Ollama API

--- a/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
+++ b/external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh
@@ -11,8 +11,12 @@ fi
 export MODEL_NAME="${OLLAMA_MODEL:-$MODEL_NAME}"
 export OLLAMA_MODEL="$MODEL_NAME"
 
-# Bind to internal port (Caddy proxies external 11434 -> internal 21434)
-export OLLAMA_HOST=${OLLAMA_HOST:-0.0.0.0:21434}
+# Bind the internal port to loopback ONLY. External access is via the authenticated
+# Caddy edge, which proxies external 11434 -> internal 21434 over localhost.
+# Do NOT default to 0.0.0.0: the upstream ollama/ollama image sets `EXPOSE 11434`
+# (which a child image cannot remove), so a 0.0.0.0 bind leaves Ollama reachable
+# unauthenticated on any directly-forwarded port, bypassing Caddy token auth.
+export OLLAMA_HOST=${OLLAMA_HOST:-127.0.0.1:21434}
 export OLLAMA_PORT=${OLLAMA_HOST##*:}
 
 # Model UI connects to the Ollama API


### PR DESCRIPTION
## Security fix — unauthenticated Ollama API exposure

**Severity:** high — the Ollama API (model management + inference) was reachable by anyone with the instance address, with **no token auth**.

### Root cause
`external/ollama/ROOT/etc/vast_boot.d/05-ollama-env.sh` defaulted `OLLAMA_HOST=0.0.0.0:21434`, so Ollama listened on all interfaces. The upstream `ollama/ollama` base image sets `EXPOSE 11434`, which a child image cannot remove, so the port is directly forwarded — bypassing the authenticated Caddy edge that is supposed to front every web service.

### Fix
Default `OLLAMA_HOST=127.0.0.1:21434` (loopback only). A loopback-bound socket cannot accept connections from Vast's port forwarder (which targets the container's external interface), while Caddy still reaches it over `localhost` and serves the external `11434` vhost with token auth. Model UI connects via `localhost:${OLLAMA_PORT}` and is unaffected. An explicit `OLLAMA_HOST` override still lets a user opt into a direct bind.

### Notes
- ollama-specific: vLLM/SGLang/vLLM-Omni bind internal ports (18xxx) that are not published, so only Caddy's external port is reachable.
- Found by an AI agent testing the Ollama image (the agent docs work, #184).
- Recommend an expedited review + rebuild/repush of the production Ollama image.