### PR TITLE
provisioner: fix HF single-file download broken by huggingface_hub 1.18.0

### DIFF
--- a/ROOT/opt/instance-tools/lib/provisioner/downloaders/huggingface.py
+++ b/ROOT/opt/instance-tools/lib/provisioner/downloaders/huggingface.py
@@ -146,12 +146,17 @@ def _download_file(
         def _do_download() -> bool:
             tmp_dir = tempfile.mkdtemp()
             try:
+                # `--local-dir` is a direct download in current huggingface_hub
+                # (it does not populate the HF cache), and as of 1.18.0 combining
+                # it with `--cache-dir` is a hard error ("Cannot use both
+                # `--local-dir` and `--cache-dir` at the same time"). The temp
+                # `--local-dir` already isolates the download for the move below,
+                # so no separate `--cache-dir` is needed.
                 cmd = [
                     "hf", "download",
                     repo, file_path,
                     "--revision", revision,
                     "--local-dir", tmp_dir,
-                    "--cache-dir", os.path.join(tmp_dir, ".cache"),
                 ]
                 try:
                     run_cmd(cmd, label="hf", check=True)


### PR DESCRIPTION
## Bug
The base provisioner's HuggingFace single-file downloader (dest mode) ran:
```
hf download <repo> <file> --revision <rev> --local-dir <tmp> --cache-dir <tmp>/.cache
```
**huggingface_hub 1.18.0** made `--local-dir` and `--cache-dir` mutually exclusive and now **hard-errors**:
```
Cannot use both `--local-dir` and `--cache-dir` at the same time.
```
So every single-file HF download via provisioning fails in **Phase 6: Downloads**, unrecoverably across all retries (the command is malformed for the installed CLI, so retries can't help).

Reproduced via ComfyUI's `PROVISIONING_COMFYUI_WORKFLOWS` (SDXL-Turbo checkpoint → `models/checkpoints/`), but the root cause is in **`ROOT/opt/instance-tools/lib/provisioner/downloaders/huggingface.py`** — i.e. the **base image**, affecting every derivative that downloads a single HF file through the provisioner, not just ComfyUI.

## Fix
Drop `--cache-dir`. In current huggingface_hub `--local-dir` is a direct download that doesn't populate the HF cache, and the temp `--local-dir` already isolates the download for the atomic move to `dest` — so `--cache-dir` was both unnecessary and now fatal.

`_download_repo` (line ~76) only ever passed `--local-dir`, so it's unaffected. Tests mock the runner and don't assert on `--cache-dir`, so they stay green.

## Related (not in this PR)
Several derivative model-provisioning shell scripts use the same `--local-dir … --cache-dir` pattern and will hit the identical error if used (comfyui: `wan2.2-t2v.sh`, `wan2.2-i2v.sh`, `mochi-1-preview.sh`, `flux.2-dev.sh`; sd-forge: `default.sh`). Flagging for a follow-up.