### PR TITLE
provisioning scripts: drop --cache-dir from hf downloads (hf 1.18.0 compat)

### DIFF
--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/flux.2-dev.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/flux.2-dev.sh
@@ -107,8 +107,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/hidream-i1-full.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/hidream-i1-full.sh
@@ -113,8 +113,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/juggernaut-xi.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/juggernaut-xi.sh
@@ -103,8 +103,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/ltx-2.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/ltx-2.sh
@@ -133,8 +133,7 @@ download_hf_file() {
 
             if hf download "$repo" \
                 "$file_path" \
-                --local-dir "$temp_dir" \
-                --cache-dir "$temp_dir/.cache" 2>&1 | tee -a "$MODEL_LOG"; then
+                --local-dir "$temp_dir" 2>&1 | tee -a "$MODEL_LOG"; then
 
                 # Verify the file was actually downloaded
                 if [ -f "$temp_dir/$file_path" ]; then

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/mochi-1-preview.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/mochi-1-preview.sh
@@ -107,8 +107,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/qwen-image.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/qwen-image.sh
@@ -102,8 +102,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/realvisxl-v5.0.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/realvisxl-v5.0.sh
@@ -103,8 +103,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/sdxl.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/sdxl.sh
@@ -109,8 +109,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/ace-step-v1-3.5b.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/ace-step-v1-3.5b.sh
@@ -105,8 +105,7 @@ download_hf_file() {
 
             if hf download "$repo" \
                 "$file_path" \
-                --local-dir "$temp_dir" \
-                --cache-dir "$temp_dir/.cache" 2>&1 | tee -a "$MODEL_LOG"; then
+                --local-dir "$temp_dir" 2>&1 | tee -a "$MODEL_LOG"; then
 
                 # Verify the file was actually downloaded
                 if [ -f "$temp_dir/$file_path" ]; then

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/starter-template.sh
@@ -103,8 +103,7 @@ download_hf_file() {
 
             if hf download "$repo" \
                 "$file_path" \
-                --local-dir "$temp_dir" \
-                --cache-dir "$temp_dir/.cache" 2>&1 | tee -a "$MODEL_LOG"; then
+                --local-dir "$temp_dir" 2>&1 | tee -a "$MODEL_LOG"; then
 
                 # Verify the file was actually downloaded
                 if [ -f "$temp_dir/$file_path" ]; then

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/wan-2.2-14b-t2v.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/serverless/wan-2.2-14b-t2v.sh
@@ -115,8 +115,7 @@ download_hf_file() {
 
             if hf download "$repo" \
                 "$file_path" \
-                --local-dir "$temp_dir" \
-                --cache-dir "$temp_dir/.cache" 2>&1 | tee -a "$MODEL_LOG"; then
+                --local-dir "$temp_dir" 2>&1 | tee -a "$MODEL_LOG"; then
 
                 # Verify the file was actually downloaded
                 if [ -f "$temp_dir/$file_path" ]; then

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/wan2.2-i2v.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/wan2.2-i2v.sh
@@ -111,8 +111,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/wan2.2-t2v.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/wan2.2-t2v.sh
@@ -108,8 +108,7 @@ download_hf_file() {
     
     if hf download "$repo" \
       "$file_path" \
-      --local-dir "$temp_dir" \
-      --cache-dir "$temp_dir/.cache" 2>&1; then
+      --local-dir "$temp_dir" 2>&1; then
       
       # Success - move file and clean up
       mkdir -p "$(dirname "$output_path")"

--- a/derivatives/pytorch/derivatives/sd-forge/provisioning_scripts/default.sh
+++ b/derivatives/pytorch/derivatives/sd-forge/provisioning_scripts/default.sh
@@ -244,8 +244,7 @@ download_hf_file() {
             hf_command=$(command -v hf || command -v huggingface-cli)
             if "$hf_command" download "$repo" \
                 "$file_path" \
-                --local-dir "$temp_dir" \
-                --cache-dir "$temp_dir/.cache" 2>&1; then
+                --local-dir "$temp_dir" 2>&1; then
 
                 # Verify the file was actually downloaded
                 if [[ -f "$temp_dir/$file_path" ]]; then

--- a/derivatives/pytorch/derivatives/sd-forge/provisioning_scripts/flux.sh
+++ b/derivatives/pytorch/derivatives/sd-forge/provisioning_scripts/flux.sh
@@ -250,8 +250,7 @@ download_hf_file() {
 
             if hf download "$repo" \
                 "$file_path" \
-                --local-dir "$temp_dir" \
-                --cache-dir "$temp_dir/.cache" 2>&1 | tee -a "$PROVISIONING_LOG"; then
+                --local-dir "$temp_dir" 2>&1 | tee -a "$PROVISIONING_LOG"; then
 
                 # Verify the file was actually downloaded
                 if [[ -f "$temp_dir/$file_path" ]]; then


### PR DESCRIPTION
Follow-up to #188. The same `hf download --local-dir … --cache-dir …` pattern (a hard error on huggingface_hub 1.18.0) exists in **15** comfyui/sd-forge model-provisioning scripts, so those model downloads fail on any instance with current hf.

## Fix
Drop `--cache-dir` (merging the trailing `2>&1; then` / `2>&1 | tee …; then` onto the `--local-dir` line). **Compatible with both hf versions**, which matters because these scripts can run on instances of varying age:
- **new (≥1.18.0):** `--local-dir` is a direct download → real file in `$temp_dir`, no cache used.
- **old (<1.18.0, but new enough to have the `hf` CLI):** the cache falls back to the persistent default `$HF_HOME`, which the script's `rm -rf "$temp_dir"` does **not** delete — so the file stays valid for the subsequent `mv "$temp_dir/$file"`.

Redirecting the cache into `$temp_dir` (e.g. `HF_HOME=$temp_dir/.cache`) was deliberately **not** used: on old hf that makes the downloaded file a symlink into `.cache`, which the `rm -rf "$temp_dir"` would then break.

## Files (15)
comfyui: `flux.2-dev`, `hidream-i1-full`, `juggernaut-xi`, `ltx-2`, `mochi-1-preview`, `qwen-image`, `realvisxl-v5.0`, `sdxl`, `wan2.2-i2v`, `wan2.2-t2v`, `serverless/{ace-step-v1-3.5b, starter-template, wan-2.2-14b-t2v}`; sd-forge: `default`, `flux`.

All 15 pass `bash -n`.