### PR TITLE
derivatives: bump base/pytorch pins 2026-06-10 -> 2026-06-12 (provisioner fix)

### DIFF
--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -137,7 +137,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-12
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -196,7 +196,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -166,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-10
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-12
         # arm64 is intentionally absent: ACE-Step-1.5's pyproject.toml
         # declares `torchao ; platform_machine == 'aarch64'`, and torchao
         # ships no aarch64 wheels (manylinux_x86_64 only), so the upstream
@@ -233,7 +233,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-10
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-aio-studio-base.yml
+++ b/.github/workflows/build-aio-studio-base.yml
@@ -15,7 +15,7 @@ on:
       PYTORCH_BASE:
         description: "Multi-torch base image"
         required: true
-        default: "vastai/pytorch:multi-210-291-271-2026-06-10"
+        default: "vastai/pytorch:multi-210-291-271-2026-06-12"
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
         required: true

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -101,8 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-10
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-06-10
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-12
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-06-12
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -161,8 +161,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-10
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-06-10
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-12
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-12
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -195,7 +195,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-12.9-mini-py312-2026-06-10
+          - vastai/base-image:cuda-12.9-mini-py312-2026-06-12
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-12.9-mini-py312-2026-06-10
+          - vastai/base-image:cuda-12.9-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-12
         # arm64 is intentionally absent: torchcodec is required at runtime
         # (transitive via torchaudio.load() in toolkit/dataloader_mixins.py)
         # but ships no aarch64 Linux wheels at any version. Re-add when
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   DEFAULT_DOCKERHUB_REPO: "sd-forge"
-  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-06-10"
+  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-06-12"
   # 7 days in seconds
   COMMIT_AGE_THRESHOLD: 604800
 

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-12
         # arm64 is intentionally absent: `torchao` (transitive via
         # unsloth-zoo>=2026.5.3 -> unsloth) only publishes amd64 manylinux
         # wheels as of v0.17.0+cu128. Re-add when upstream torchao ships
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-voicebox.yml
+++ b/.github/workflows/build-voicebox.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
         # arm64 is intentionally absent: Wan2GP requires onnxruntime-gpu
         # (pulled from the Azure ort-cuda-13-nightly index), which has no
         # aarch64 wheels — and PyPI's stable onnxruntime-gpu is also
@@ -212,7 +212,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
     steps:
       - name: Checkout

--- a/derivatives/llama-cpp/Dockerfile
+++ b/derivatives/llama-cpp/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-06-10
+ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-06-12
 
 FROM ${BASE_IMAGE}
 ARG BASE_IMAGE

--- a/derivatives/pytorch/derivatives/a1111/Dockerfile
+++ b/derivatives/pytorch/derivatives/a1111/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/comfyui/Dockerfile
+++ b/derivatives/pytorch/derivatives/comfyui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fluxgym/Dockerfile
+++ b/derivatives/pytorch/derivatives/fluxgym/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/invokeai/Dockerfile
+++ b/derivatives/pytorch/derivatives/invokeai/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/sd-forge/Dockerfile
+++ b/derivatives/pytorch/derivatives/sd-forge/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-12
 FROM ${PYTORCH_BASE}
 
 LABEL org.opencontainers.image.source="https://github.com/vastai/"

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/wan2gp/Dockerfile
+++ b/derivatives/pytorch/derivatives/wan2gp/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/whisper/Dockerfile
+++ b/derivatives/pytorch/derivatives/whisper/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-10
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-12
 
 FROM ${PYTORCH_BASE}
 


### PR DESCRIPTION
Re-pins the active derivatives onto the **2026-06-12** base/pytorch images, which carry the provisioner HF-download fix (extended + promoted from 2026-06-10; source fix #188).

- Workflow matrices + Dockerfile `PYTORCH_BASE`/`BASE_IMAGE` defaults, `2026-06-10 → 2026-06-12`. All target tags verified present in the registry.
- **11 pytorch-derivatives** (a1111, ace-step, aio-studio-base, fluxgym, invokeai, ostris-ai-toolkit, sd-forge, unsloth-studio, voicebox, wan2gp, whisper) + **llama-cpp** (base pin).
- **comfyui excluded** — bumped on its agents branch (#187) so its rebuild carries both the guide and the pin.

After merge, each derivative needs a rebuild to publish a corrected image.