### PR TITLE
comfyui agents: point to Comfy-Org/workflow_templates for tested workflows

### DIFF
--- a/derivatives/pytorch/derivatives/comfyui/ROOT/etc/vast_agents/comfyui.md
+++ b/derivatives/pytorch/derivatives/comfyui/ROOT/etc/vast_agents/comfyui.md
@@ -53,6 +53,12 @@ startup hook (`convert-workflows.sh`) auto-converts every saved GUI workflow int
 payload. So the loop is: build a workflow in the GUI → save it → it appears as a runnable
 payload under `/opt/comfyui-api-wrapper/payloads/` for `/generate/sync`.
 
+**Asked to set up a specific model? Don't build a graph from scratch — start from a tested
+template.** `https://github.com/Comfy-Org/workflow_templates` is the official library of
+ComfyUI workflow templates (the same set behind the app's built-in template browser),
+covering many common models and tasks. Grab the matching template, adjust the model/inputs,
+then run it through either API above.
+
 ### Models, custom nodes, provisioning
 
 Add models, custom nodes, and workflows declaratively with the **ComfyUI provisioner**


### PR DESCRIPTION
Small addition to the ComfyUI agent guide (follow-up to #187).

When an agent is asked to set up a specific model, it should start from a tested workflow rather than hand-building a graph. Adds a pointer to `Comfy-Org/workflow_templates` (the official template library behind ComfyUI's built-in template browser) in the 'Using the two together' section, with the suggested flow: grab the matching template → adjust model/inputs → run it through either API.

Docs-only; lands in the image on the next comfyui build.