### PR TITLE
agents: assemble a combined guide (index + all per-image files) as the AGENTS.md entry point

### DIFF
--- a/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
+++ b/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
@@ -39,16 +39,18 @@ if [[ -f "$AGENTS_BASE" ]]; then
     mapfile -t guides < <( printf '%s\n' "$AGENTS_BASE"; ls "$AGENTS_DIR"/*.md 2>/dev/null | grep -vxF "$AGENTS_BASE" | sort )
     {
         printf '# Agent guide for this instance\n\n'
-        printf 'This instance ships %d guide(s) (full text below, also at %s/). They are\n' "${#guides[@]}" "$AGENTS_DIR"
-        printf 'cumulative — read ALL of them before acting on this instance:\n\n'
+        printf 'This single file IS the complete agent guide — the full text of all %d guide(s)\n' "${#guides[@]}"
+        printf 'is concatenated below (the same files also live individually under %s/, but you\n' "$AGENTS_DIR"
+        printf 'do not need to open them; everything is here). Read this whole file before acting\n'
+        printf 'on this instance. The sections are cumulative:\n\n'
         i=1
         for g in "${guides[@]}"; do
             label=$(grep -m1 -E '^#{1,6} ' "$g" 2>/dev/null | sed -E 's/^#{1,6} *//') || true
             printf '  %d. %s — %s\n' "$i" "$(basename "$g")" "${label:-$(basename "$g")}"
             i=$((i+1))
         done
-        printf '\nDo not stop at base.md: the per-image guide(s) above document services and\n'
-        printf 'APIs (endpoints, wrappers, helpers) you will otherwise miss — read them before\n'
+        printf '\nKeep reading past the base section: the per-image sections below document services\n'
+        printf 'and APIs (endpoints, wrappers, helpers) you would otherwise miss — read them before\n'
         printf 'calling an API, exposing a service, or setting up a model.\n\n'
         for g in "${guides[@]}"; do
             printf '=================== %s ===================\n\n' "$(basename "$g")"

--- a/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
+++ b/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
@@ -35,8 +35,19 @@ fi
 # then their full text. Prevents the failure where an agent reads a base-only
 # AGENTS.md and never discovers the per-image files (pytorch.md, comfyui.md, …).
 if [[ -f "$AGENTS_BASE" ]]; then
-    # base.md first, then the remaining guides in sorted order.
-    mapfile -t guides < <( printf '%s\n' "$AGENTS_BASE"; ls "$AGENTS_DIR"/*.md 2>/dev/null | grep -vxF "$AGENTS_BASE" | sort )
+    # Order as the actual build chain — base (foundation), then the framework
+    # layer (pytorch/tensorflow), then the app guides alphabetically — so each
+    # section's references only point at material already read above it.
+    guides=("$AGENTS_BASE")
+    for fw in pytorch tensorflow; do
+        [[ -f "$AGENTS_DIR/$fw.md" ]] && guides+=("$AGENTS_DIR/$fw.md")
+    done
+    while IFS= read -r g; do
+        case "$g" in
+            "$AGENTS_BASE"|"$AGENTS_DIR/pytorch.md"|"$AGENTS_DIR/tensorflow.md") ;;
+            *) guides+=("$g") ;;
+        esac
+    done < <(ls "$AGENTS_DIR"/*.md 2>/dev/null | sort)
     {
         printf '# Agent guide for this instance\n\n'
         printf 'This single file IS the complete agent guide — the full text of all %d guide(s)\n' "${#guides[@]}"

--- a/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
+++ b/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
@@ -3,18 +3,22 @@
 # Make the agent-facing capability surface discoverable:
 #   1. /etc/vast_capabilities.json  — static snapshot for FS-only/offline agents
 #      (live state is always available at the portal's /capabilities endpoint).
-#   2. {AGENTS.md,CLAUDE.md} symlinks to /etc/vast_agents/base.md, dropped where
-#      an agent lands: ${WORKSPACE} (interactive shells cd here) and the home
-#      dirs (a one-shot `ssh host cmd` lands in $HOME). It's found under whichever
-#      filename/cwd an agent uses. base.md instructs reading every *.md in
-#      /etc/vast_agents/ (base + per-image files).
+#   2. A combined agent guide at /etc/vast-agents-guide.md — a front index naming
+#      every /etc/vast_agents/*.md present on this image plus their full
+#      concatenated text — with {AGENTS.md,CLAUDE.md} symlinks to it, dropped where
+#      an agent lands: ${WORKSPACE} (interactive shells cd here) and the home dirs
+#      (a one-shot `ssh host cmd` lands in $HOME). One artifact is the complete
+#      picture, so an agent that reads it can't treat base.md as the whole story
+#      and miss the per-image files.
 #   3. A pointer line on the SSH banner — shown on every connection, so even a
 #      non-interactive agent that never reads the landing dir sees it.
 
 WORKSPACE="${WORKSPACE:-/workspace}"
 PORTAL_PYTHON=/opt/portal-aio/venv/bin/python
 CAP_JSON=/etc/vast_capabilities.json
-AGENTS_BASE=/etc/vast_agents/base.md
+AGENTS_DIR=/etc/vast_agents
+AGENTS_BASE=${AGENTS_DIR}/base.md
+AGENTS_GUIDE=/etc/vast-agents-guide.md
 
 # --- 1. Static capability snapshot (best-effort) ---
 SNAPSHOT_PY='import json; from capabilities import assemble_static; print(json.dumps(assemble_static(), indent=2))'
@@ -26,17 +30,45 @@ if [[ -x "$PORTAL_PYTHON" ]]; then
     fi
 fi
 
-# --- 2. Symlink the agent guide where agents land ---
-# ${WORKSPACE} (interactive shells cd here) plus the home dirs (a one-shot
-# `ssh host cmd` lands in $HOME). Create only when absent/dangling, or refresh a
-# link that is already ours — never replace a user's real file or their own symlink.
+# --- 2a. Assemble the combined agent guide ---
+# One file = the complete picture: a front index of every base/per-image guide,
+# then their full text. Prevents the failure where an agent reads a base-only
+# AGENTS.md and never discovers the per-image files (pytorch.md, comfyui.md, …).
 if [[ -f "$AGENTS_BASE" ]]; then
+    # base.md first, then the remaining guides in sorted order.
+    mapfile -t guides < <( printf '%s\n' "$AGENTS_BASE"; ls "$AGENTS_DIR"/*.md 2>/dev/null | grep -vxF "$AGENTS_BASE" | sort )
+    {
+        printf '# Agent guide for this instance\n\n'
+        printf 'This instance ships %d guide(s) (full text below, also at %s/). They are\n' "${#guides[@]}" "$AGENTS_DIR"
+        printf 'cumulative — read ALL of them before acting on this instance:\n\n'
+        i=1
+        for g in "${guides[@]}"; do
+            label=$(grep -m1 -E '^#{1,6} ' "$g" 2>/dev/null | sed -E 's/^#{1,6} *//') || true
+            printf '  %d. %s — %s\n' "$i" "$(basename "$g")" "${label:-$(basename "$g")}"
+            i=$((i+1))
+        done
+        printf '\n'
+        for g in "${guides[@]}"; do
+            printf '=================== %s ===================\n\n' "$(basename "$g")"
+            cat "$g"
+            printf '\n'
+        done
+    } > "$AGENTS_GUIDE" 2>/dev/null && echo "Wrote ${AGENTS_GUIDE} (${#guides[@]} guide(s))"
+fi
+
+# --- 2b. Link the combined guide where agents land ---
+# ${WORKSPACE} (interactive shells cd here) plus the home dirs (a one-shot
+# `ssh host cmd` lands in $HOME). Create when absent, or refresh a link that is
+# already ours — including the legacy base.md target, so existing instances
+# upgrade on reboot — never replace a user's real file or their own symlink.
+if [[ -f "$AGENTS_GUIDE" ]]; then
     for dir in "$WORKSPACE" /root /home/user; do
         [[ -d "$dir" ]] || continue
         for name in AGENTS.md CLAUDE.md; do
             target="${dir}/${name}"
-            if [[ ! -e "$target" ]] || [[ "$(readlink "$target" 2>/dev/null)" == "$AGENTS_BASE" ]]; then
-                ln -sfn "$AGENTS_BASE" "$target" && echo "Linked ${target} -> ${AGENTS_BASE}"
+            cur="$(readlink "$target" 2>/dev/null)"
+            if [[ ! -e "$target" ]] || [[ "$cur" == "$AGENTS_GUIDE" ]] || [[ "$cur" == "$AGENTS_BASE" ]]; then
+                ln -sfn "$AGENTS_GUIDE" "$target" && echo "Linked ${target} -> ${AGENTS_GUIDE}"
             else
                 echo "Leaving existing ${target} untouched"
             fi

--- a/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
+++ b/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
@@ -47,7 +47,9 @@ if [[ -f "$AGENTS_BASE" ]]; then
             printf '  %d. %s — %s\n' "$i" "$(basename "$g")" "${label:-$(basename "$g")}"
             i=$((i+1))
         done
-        printf '\n'
+        printf '\nDo not stop at base.md: the per-image guide(s) above document services and\n'
+        printf 'APIs (endpoints, wrappers, helpers) you will otherwise miss — read them before\n'
+        printf 'calling an API, exposing a service, or setting up a model.\n\n'
         for g in "${guides[@]}"; do
             printf '=================== %s ===================\n\n' "$(basename "$g")"
             cat "$g"

--- a/portal-aio/capabilities/manifest.py
+++ b/portal-aio/capabilities/manifest.py
@@ -574,9 +574,10 @@ def _agent_guides() -> dict:
         "dir": "/etc/vast_agents/",
         "files": files,
         "instruction": (
-            "Read the combined guide (or every file in 'files') before acting on "
-            "this instance. They are cumulative: the per-image guides document "
-            "services and APIs this image adds that you will otherwise miss."
+            "Read the combined guide at 'combined' before acting on this instance — "
+            "it already contains the full text of every file in 'files', concatenated, "
+            "so you do not need to open them separately. The per-image guides document "
+            "services and APIs this image adds that you would otherwise miss."
         ),
     }
 

--- a/portal-aio/capabilities/manifest.py
+++ b/portal-aio/capabilities/manifest.py
@@ -557,6 +557,30 @@ def load_fragments(fragments_dir: str = FRAGMENTS_DIR) -> dict:
     return merged
 
 
+def _agent_guides() -> dict:
+    """The agent-guide files baked into this image.
+
+    Surfaced in the manifest (not just a bare directory path) so an agent that
+    reads the JSON sees exactly which guides exist and is told to read them —
+    including the per-image files (pytorch.md, comfyui.md, …) it would otherwise
+    never discover. base.md is listed first; the rest follow sorted.
+    """
+    files = sorted(glob.glob("/etc/vast_agents/*.md"))
+    base = "/etc/vast_agents/base.md"
+    if base in files:
+        files = [base] + [f for f in files if f != base]
+    return {
+        "combined": "/etc/vast-agents-guide.md",
+        "dir": "/etc/vast_agents/",
+        "files": files,
+        "instruction": (
+            "Read the combined guide (or every file in 'files') before acting on "
+            "this instance. They are cumulative: the per-image guides document "
+            "services and APIs this image adds that you will otherwise miss."
+        ),
+    }
+
+
 def _detect_env_kind(path: str) -> Optional[str]:
     """Detect a python environment's kind by inspecting it on disk.
 
@@ -840,7 +864,7 @@ def assemble(
             "well_known_url": "/.well-known/vast-capabilities",
             "openapi_url": "/openapi.json",
             "snapshot_file": "/etc/vast_capabilities.json",
-            "agents_guide": "/etc/vast_agents/",
+            "agents_guide": _agent_guides(),
         },
     }
 


### PR DESCRIPTION
## Problem (observed in the field)
`AGENTS.md`/`CLAUDE.md` were symlinks to `base.md` **alone**. An agent reading the entry artifact saw one self-contained-looking document with nothing revealing that per-image guides (`pytorch.md`, `comfyui.md`, …) existed as separate, unread files. Discovery relied on the prose line "read every `*.md` in `/etc/vast_agents/`" — exactly the soft indirection an unblocked agent rationalizes past.

Real case: a model on a ComfyUI instance used the low-level `/prompt` + `/history` polling API and hand-built a workflow graph, missing the API wrapper (`/generate/sync`), the prebuilt payloads, and the workflow-template pointer — all documented in `comfyui.md` — because it never opened that file. It had read `AGENTS.md` (base.md) and treated it as the whole picture.

## Fix
Assemble `/etc/vast-agents-guide.md` at boot (`80-capabilities-manifest.sh`):
- a **front index** naming every `/etc/vast_agents/*.md` present on this image (each file's first heading as a one-line label), with a "read ALL of them" instruction, then
- the **full concatenated text** of all of them (base.md first).

Point the `AGENTS.md`/`CLAUDE.md` symlinks at this combined guide. The single artifact an agent reads is now the complete picture — no discovery step survives to be skipped, and the index surfaces any unread per-image guide up front.

The symlink refresh recognizes the legacy `base.md` target as "ours", so existing instances upgrade on reboot; a user's own file/symlink is still left untouched.

## Notes
- Base-image change → reaches images on rebuild (external images copy `/ROOT` from the repo on their next build; pytorch-derivatives inherit it once base/pytorch are rebuilt).
- `base.md`'s own "read every *.md" line is kept (harmless, and base.md is still read standalone).