### PR TITLE
agents: imperative banner + vast-capabilities guide pointer (entry-path fixes)

### DIFF
--- a/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
+++ b/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
@@ -104,6 +104,6 @@ if [[ -f "$BANNER" ]]; then
     # Refresh on every boot (drop any prior "AI agents:" line we added, then re-add) so
     # existing instances upgrade the wording. The control plane owns the rest of the file.
     sed -i '/^AI agents:/d' "$BANNER" 2>/dev/null || true
-    printf '%s\n' "AI agents: READ /etc/vast-agents-guide.md (also linked as ./AGENTS.md) before acting on or describing this instance — it is the operating guide. ('vast-capabilities' shows live state only, not the guide.)" >> "$BANNER" \
+    printf '%s\n' "AI agents: READ /etc/vast-agents-guide.md (also linked as ./AGENTS.md) before acting on or describing this instance: it is the operating guide. ('vast-capabilities' shows live state only, not the guide.)" >> "$BANNER" \
         && echo "Refreshed agent notice in ${BANNER}"
 fi

--- a/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
+++ b/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
@@ -97,7 +97,13 @@ fi
 # non-interactive agent can't miss. Append our pointer at boot (idempotent); we
 # can't bake it in because the control plane owns the file.
 BANNER=/etc/banner
-if [[ -f "$BANNER" ]] && ! grep -qF "vast-capabilities" "$BANNER"; then
-    printf '%s\n' "AI agents: run 'vast-capabilities' or read ./AGENTS.md to understand this instance." >> "$BANNER" \
-        && echo "Appended agent notice to ${BANNER}"
+if [[ -f "$BANNER" ]]; then
+    # Imperative, single directive — no "or" (which let agents treat the guide and
+    # vast-capabilities as interchangeable and skip the guide). Reading the guide is
+    # the instruction; vast-capabilities is called out as live state, not a substitute.
+    # Refresh on every boot (drop any prior "AI agents:" line we added, then re-add) so
+    # existing instances upgrade the wording. The control plane owns the rest of the file.
+    sed -i '/^AI agents:/d' "$BANNER" 2>/dev/null || true
+    printf '%s\n' "AI agents: READ /etc/vast-agents-guide.md (also linked as ./AGENTS.md) before acting on or describing this instance — it is the operating guide. ('vast-capabilities' shows live state only, not the guide.)" >> "$BANNER" \
+        && echo "Refreshed agent notice in ${BANNER}"
 fi

--- a/ROOT/opt/instance-tools/bin/vast-capabilities
+++ b/ROOT/opt/instance-tools/bin/vast-capabilities
@@ -11,13 +11,30 @@ INCLUDE="${1:-}"
 URL="http://localhost:11111/capabilities"
 [[ -n "$INCLUDE" ]] && URL="${URL}?include=${INCLUDE}"
 
+# A directive the agent can't miss even if it only skims the JSON. Printed to
+# stderr so stdout stays pure JSON for `| jq`. The JSON is LIVE STATE, not the
+# operating guide — point explicitly at the guide so this command isn't mistaken
+# for a substitute for reading it.
+emit_guide_pointer() {
+    {
+        echo
+        echo ">>> The output above is this instance's LIVE STATE, not the operating guide."
+        echo ">>> Before acting on — or answering questions about — this instance, READ"
+        echo ">>> /etc/vast-agents-guide.md (also linked as ./AGENTS.md)."
+    } >&2
+}
+
 if curl -fsS "$URL" 2>/dev/null; then
     echo
+    emit_guide_pointer
     exit 0
 fi
 
 # Fallback: assemble the static snapshot directly (no portal app required).
-cd /opt/portal-aio 2>/dev/null && exec /opt/portal-aio/venv/bin/python -c \
-    'import json; from capabilities import assemble_static; print(json.dumps(assemble_static(), indent=2))'
+if cd /opt/portal-aio 2>/dev/null && /opt/portal-aio/venv/bin/python -c \
+    'import json; from capabilities import assemble_static; print(json.dumps(assemble_static(), indent=2))'; then
+    emit_guide_pointer
+    exit 0
+fi
 echo "ERROR: could not reach the portal and no fallback available" >&2
 exit 1


### PR DESCRIPTION
Follow-up to the combined-guide work (#192), from a second field test — the inverse failure: an agent ran `vast-capabilities`, felt it had enough, and never read the guide.

Two entry-path causes:
1. **Banner used "or".** `run 'vast-capabilities' or read ./AGENTS.md` frames them as interchangeable; `vast-capabilities` (live state) and the guide (how to operate) are complementary, so the agent satisfied "understand this instance" with the one already in hand.
2. **The read-the-guide instruction was buried** in a nested JSON field (`discovery.agents_guide.instruction`) — parsed, but not surfaced as a directive.

Fixes:
- **Banner → single imperative**, no "or": *READ /etc/vast-agents-guide.md … before acting on or describing this instance — it is the operating guide. ('vast-capabilities' shows live state only, not the guide.)* Refreshes on every boot so existing instances upgrade.
- **`vast-capabilities` stderr trailer** after the JSON pointing at the guide and clarifying the output is live state, not the guide. On **stderr**, so `| jq` still works; also covers "describing", not just "acting".

Base-image change → reaches images on rebuild/extend; safe to hot-apply to running instances.