### PR TITLE
agents: gate SSH banner notice behind ENABLE_AGENT_BANNER (default true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The default boot script (`/opt/instance-tools/bin/boot_default.sh`) accepts thes
 | `--sync-home` | Sync home directories to workspace |
 | `--jupyter-override` | Force Jupyter to start even in non-Jupyter launch modes |
 | `--no-force-jupyter` | Don't re-add Jupyter to the portal config in entrypoint mode (no `/.launch`) |
+| `--no-agent-banner` | Suppress the AI-agent notice on the SSH banner (sets `ENABLE_AGENT_BANNER=false`) |
 
 **Example** (in Docker run command or template):
 ```bash

--- a/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
+++ b/ROOT/etc/vast_boot.d/80-capabilities-manifest.sh
@@ -98,12 +98,20 @@ fi
 # can't bake it in because the control plane owns the file.
 BANNER=/etc/banner
 if [[ -f "$BANNER" ]]; then
-    # Imperative, single directive — no "or" (which let agents treat the guide and
-    # vast-capabilities as interchangeable and skip the guide). Reading the guide is
-    # the instruction; vast-capabilities is called out as live state, not a substitute.
-    # Refresh on every boot (drop any prior "AI agents:" line we added, then re-add) so
-    # existing instances upgrade the wording. The control plane owns the rest of the file.
+    # Always drop any prior "AI agents:" line we added — so the wording refreshes and an
+    # opt-out (below) actually removes a previously-added line on the next boot. The
+    # control plane owns the rest of the file.
     sed -i '/^AI agents:/d' "$BANNER" 2>/dev/null || true
-    printf '%s\n' "AI agents: READ /etc/vast-agents-guide.md (also linked as ./AGENTS.md) before acting on or describing this instance: it is the operating guide. ('vast-capabilities' shows live state only, not the guide.)" >> "$BANNER" \
-        && echo "Refreshed agent notice in ${BANNER}"
+    # Gated by ENABLE_AGENT_BANNER (default true). Set it false — via the template env or
+    # the entrypoint flag --no-agent-banner — to suppress the agent notice entirely.
+    enable_agent_banner="${ENABLE_AGENT_BANNER:-true}"
+    if [[ "${enable_agent_banner,,}" != "false" ]]; then
+        # Imperative, single directive — no "or" (which let agents treat the guide and
+        # vast-capabilities as interchangeable and skip the guide). Reading the guide is
+        # the instruction; vast-capabilities is called out as live state, not a substitute.
+        printf '%s\n' "AI agents: READ /etc/vast-agents-guide.md (also linked as ./AGENTS.md) before acting on or describing this instance: it is the operating guide. ('vast-capabilities' shows live state only, not the guide.)" >> "$BANNER" \
+            && echo "Refreshed agent notice in ${BANNER}"
+    else
+        echo "Agent banner suppressed (ENABLE_AGENT_BANNER=false)"
+    fi
 fi

--- a/ROOT/opt/instance-tools/bin/boot_default.sh
+++ b/ROOT/opt/instance-tools/bin/boot_default.sh
@@ -57,6 +57,10 @@ main() {
                 export FORCE_JUPYTER=false
                 shift
                 ;;
+            --no-agent-banner)
+                export ENABLE_AGENT_BANNER=false
+                shift
+                ;;
             *)
                 echo "Warning: Unknown flag: $1" >&2
                 shift


### PR DESCRIPTION
Lets users turn off the AI-agent banner line, via the same env-var/entrypoint-flag convention as the other toggles (e.g. `FORCE_JUPYTER` / `--no-force-jupyter`).

- **`ENABLE_AGENT_BANNER`** env var — default **true** when unset; set `false` (case-insensitive) to suppress. Read in `80-capabilities-manifest.sh`, which always strips any prior `AI agents:` line first, so flipping it to `false` also removes the line on the next boot of an existing instance.
- **`--no-agent-banner`** entrypoint flag → `export ENABLE_AGENT_BANNER=false` (`boot_default.sh`).
- Added to the README entrypoint-arguments table.

Scoped to the banner only — the combined guide, the `AGENTS.md`/`CLAUDE.md` symlinks, and the `vast-capabilities` pointer are unaffected.