### PR TITLE
multi-torch: refresh usage-example date to 2026-06-15

### DIFF
--- a/derivatives/pytorch/Dockerfile.multi-torch
+++ b/derivatives/pytorch/Dockerfile.multi-torch
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   docker buildx build -f Dockerfile.multi-torch \
-#     --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15 \
+#     --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15 \
 #     --build-arg PYTORCH_BACKEND=cu128 \
 #     -t my-multi-torch .
 


### PR DESCRIPTION
Cosmetic follow-up to #195: the `--build-arg` usage example in `Dockerfile.multi-torch`'s header still referenced `2026-04-15`. It's an illustrative comment, not a pin, but bumping it leaves zero stale dates after the 06-15 finalization.