### PR TITLE
docs(agents): SD image-gen UI guides — a1111, sd-forge, invokeai (CON-1557/1568/1562)

### DIFF
--- a/derivatives/pytorch/derivatives/a1111/ROOT/etc/vast_agents/a1111.md
+++ b/derivatives/pytorch/derivatives/a1111/ROOT/etc/vast_agents/a1111.md
@@ -1,5 +1,41 @@
 ## Stable Diffusion WebUI — AUTOMATIC1111 (this image)
 
-Runs the AUTOMATIC1111 Stable Diffusion image-generation WebUI (supervisor
-service `a1111`). It appears in `/capabilities/services`; reach it via its
-`direct_url` + token (see section 5). It is a web UI, not an OpenAI endpoint.
+The PyTorch image plus a preinstalled **AUTOMATIC1111 Stable Diffusion WebUI**.
+Everything in base.md and pytorch.md applies unchanged (torch is in `/venv/main`); this
+file covers what A1111 adds. One service, and it is **not** an OpenAI `/v1` endpoint — this
+is image generation. Get the externally callable URL + token from the manifest
+(base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The WebUI — and its REST API (service "a1111")
+
+Supervisor service **`a1111`**, internal `127.0.0.1:17860`. Opening its portal entry gives
+the browser GUI (txt2img / img2img / extras). Launch flags live in **`A1111_ARGS`** (default
+`--port 17860`); set it on the instance and restart the `a1111` service to change them.
+
+**The built-in REST API is OFF by default.** To drive A1111 programmatically you must add
+`--api` to `A1111_ARGS` (e.g. `A1111_ARGS="--port 17860 --api"`) and restart the service. The
+API then shares the same port — and therefore the same authed portal path:
+```
+GET  /sdapi/v1/sd-models                                  # list installed checkpoints
+POST /sdapi/v1/options  {"sd_model_checkpoint": "<name>"} # switch the active checkpoint
+POST /sdapi/v1/txt2img  {"prompt": "...", "steps": 20}    # generate; PNGs returned base64 in .images
+POST /sdapi/v1/img2img  {...}
+GET  /docs                                                # full OpenAPI schema (only when --api is on)
+```
+Without `--api`, only the GUI is served — an agent asked to generate headlessly should enable
+it first, then poll `/sdapi/v1/progress` for long runs.
+
+### Models & provisioning
+
+The app runs from `${WORKSPACE}/stable-diffusion-webui` in `/venv/main`; models live under
+`${WORKSPACE}/stable-diffusion-webui/models/` — `Stable-diffusion/` (checkpoints), `Lora/`,
+`VAE/`, `embeddings/`, plus `extensions/`. Add models and extensions declaratively with the
+**provisioning script** (`PROVISIONING_SCRIPT`; the `CHECKPOINT_MODELS` / `LORA_MODELS` /
+`VAE_MODELS` / `EXTENSIONS` arrays in
+`derivatives/pytorch/derivatives/a1111/provisioning_scripts/default.sh` show the format — and
+base.md §10). **The service waits for provisioning (`/.provisioning`) to finish before
+starting**, so during boot it may be intentionally down — check that flag before assuming a
+fault.

--- a/derivatives/pytorch/derivatives/invokeai/ROOT/etc/vast_agents/invokeai.md
+++ b/derivatives/pytorch/derivatives/invokeai/ROOT/etc/vast_agents/invokeai.md
@@ -1,5 +1,37 @@
 ## InvokeAI (this image)
 
-Runs InvokeAI, an image-generation UI/canvas (supervisor service `invokeai`). It
-appears in `/capabilities/services`; reach it via `direct_url` + token. Not an
-OpenAI endpoint.
+The PyTorch image plus a preinstalled **InvokeAI** — a node/canvas image-generation studio.
+Everything in base.md and pytorch.md applies unchanged (torch is in `/venv/main`); this file
+covers what InvokeAI adds. One service, and it is **not** an OpenAI `/v1` endpoint — this is
+image generation. Get the externally callable URL + token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The app — web UI + REST API on one port (service "invokeai")
+
+Supervisor service **`invokeai`**, launched as `invokeai-web --root "${WORKSPACE}/invokeai"`
+(internal `127.0.0.1:19000` by convention — confirm via the manifest's `direct_url`). Unlike
+A1111/Forge there is no `--api` toggle and no `*_ARGS`: the **same port serves both the browser
+UI and InvokeAI's FastAPI backend, always on**. The OpenAPI schema is the source of truth:
+```
+GET  /docs                  # full interactive API schema (models, queue, invocations)
+GET  /api/v1/...            # app + board/image endpoints
+GET  /api/v2/models/        # Model Manager — list/install/scan models
+```
+Headless generation in InvokeAI is **graph/queue based**: you enqueue a generation graph and
+poll the queue for results, rather than calling a single txt2img endpoint. Build the request
+from `/docs` (or capture one from the UI) — don't assume an A1111-style `/sdapi` surface; it is
+not present here.
+
+### Config, models & provisioning
+
+State lives entirely under the InvokeAI root **`${WORKSPACE}/invokeai`** (so it persists on the
+workspace): `invokeai.yaml` config, the model store under `${WORKSPACE}/invokeai/models`, and
+outputs. The app uses `/venv/main`. Models are normally added through InvokeAI's own **Model
+Manager** (the UI's model tab, or `POST /api/v2/models/install` with a HF repo or URL) rather
+than by dropping files — let it register them so they appear in the UI. There is no
+image-specific provisioning script; use the base provisioner (`PROVISIONING_SCRIPT`, base.md
+§10) for anything declarative. **The service waits for provisioning (`/.provisioning`) to finish
+before starting**, so during boot it may be intentionally down — check that flag before
+assuming a fault.

--- a/derivatives/pytorch/derivatives/sd-forge/ROOT/etc/vast_agents/sd-forge.md
+++ b/derivatives/pytorch/derivatives/sd-forge/ROOT/etc/vast_agents/sd-forge.md
@@ -1,5 +1,41 @@
 ## Stable Diffusion WebUI Forge (this image)
 
-Runs SD WebUI Forge, an image-generation UI (supervisor service `forge`). It
-appears in `/capabilities/services`; reach it via `direct_url` + token. Not an
-OpenAI endpoint.
+The PyTorch image plus a preinstalled **SD WebUI Forge** — an AUTOMATIC1111 fork tuned for
+lower VRAM use and for Flux. Everything in base.md and pytorch.md applies unchanged (torch is
+in `/venv/main`); this file covers what Forge adds. One service, and it is **not** an OpenAI
+`/v1` endpoint — this is image generation. Get the externally callable URL + token from the
+manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The WebUI — and its REST API (service "forge")
+
+Supervisor service **`forge`**, internal `127.0.0.1:17860`. Opening its portal entry gives the
+browser GUI. Launch flags live in **`FORGE_ARGS`** (default `--port 17860`); set it on the
+instance and restart the `forge` service to change them.
+
+Forge keeps A1111's API contract, and **the REST API is OFF by default.** Add `--api` to
+`FORGE_ARGS` (e.g. `FORGE_ARGS="--port 17860 --api"`) and restart to expose it on the same port
+(same authed portal path):
+```
+GET  /sdapi/v1/sd-models                                  # list installed checkpoints
+POST /sdapi/v1/options  {"sd_model_checkpoint": "<name>"} # switch the active checkpoint
+POST /sdapi/v1/txt2img  {"prompt": "...", "steps": 20}    # generate; PNGs returned base64 in .images
+POST /sdapi/v1/img2img  {...}
+GET  /docs                                                # full OpenAPI schema (only when --api is on)
+```
+Without `--api`, only the GUI is served.
+
+### Models & provisioning
+
+The app runs from `${WORKSPACE}/stable-diffusion-webui-forge` in `/venv/main`; models live
+under `${WORKSPACE}/stable-diffusion-webui-forge/models/` — `Stable-diffusion/` (checkpoints),
+`VAE/`, `text_encoder/` (CLIP/T5 for Flux), `Lora/`. Add models declaratively with a
+**provisioning script** (base.md §10): two are shipped —
+`derivatives/pytorch/derivatives/sd-forge/provisioning_scripts/default.sh` (SD baseline) and
+`flux.sh` (sets up Flux — pulls gated FLUX.1-dev with a valid `HF_TOKEN`, else open
+FLUX.1-schnell, plus the CLIP/T5 encoders). Both take `HF_MODELS` / `CIVITAI_MODELS` /
+`WGET_DOWNLOADS` (semicolon-separated `URL|PATH` pairs) and `HF_TOKEN` / `CIVITAI_TOKEN`.
+**The service waits for provisioning (`/.provisioning`) to finish before starting**, so during
+boot it may be intentionally down — check that flag before assuming a fault.


### PR DESCRIPTION
Fleshes out the agent-aware `/etc/vast_agents/<name>.md` guides for the three Stable Diffusion image-generation UIs, bringing the first-pass stubs up to the base.md / pytorch.md / comfyui.md standard. Part of the CON-1556 rollout.

## What each guide now covers
- **a1111** (CON-1557) / **sd-forge** (CON-1568): the WebUI service (`a1111` / `forge`, internal `:17860`) plus the built-in `/sdapi/v1` REST API — and the key fact that the API is **off by default** until `--api` is added to `A1111_ARGS` / `FORGE_ARGS`. Model paths under `${WORKSPACE}/<app>/models`, provisioning arrays. sd-forge also documents `flux.sh` (gated FLUX.1-dev with `HF_TOKEN`, else FLUX.1-schnell, + CLIP/T5 encoders).
- **invokeai** (CON-1562): single service, web UI + FastAPI on one port (always on, no `--api`/`*_ARGS`), graph/queue generation, Model Manager (`/api/v2/models`) for installs, all state under `${WORKSPACE}/invokeai`. Explicitly notes there is **no** A1111-style `/sdapi` surface.

All three: not OpenAI `/v1` (image generation); reach via the manifest `direct_url` + token; services wait on `/.provisioning`.

Docs-only. Base pins already at 2026-06-15. Test images will be built from this branch per image.