### PR TITLE
docs(agents): audio/speech/video guides — ace-step, voicebox, whisper, wan2gp (CON-1558/1573/1575/1574)

### DIFF
--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -137,18 +137,24 @@ jobs:
         id: decision
         run: |
           SECRETS="${{ steps.secrets.outputs.available }}"
-          MANUAL_REF="${{ inputs.ACE_STEP_REF }}"
+          TRIGGER="${{ github.event_name }}"
+          RESOLVED_REF="${{ steps.resolve-ref.outputs.ref }}"
           NEW_RELEASE="${{ steps.commit-check.outputs.new-release }}"
 
           if [[ "$SECRETS" != "true" ]]; then
             echo "should-run=false" >> $GITHUB_OUTPUT
             echo "::notice::Skipping - Required secrets not configured"
-          elif [[ -n "$MANUAL_REF" ]]; then
+          elif [[ "$TRIGGER" == "workflow_dispatch" ]]; then
+            # Manual dispatch: always build, but fail fast if no ref could be resolved
+            if [[ -z "$RESOLVED_REF" ]]; then
+              echo "::error::workflow_dispatch requested a build but no ref could be resolved (manual input empty and commit lookup returned nothing)"
+              exit 1
+            fi
             echo "should-run=true" >> $GITHUB_OUTPUT
-            echo "Manual build for ref: ${{ steps.resolve-ref.outputs.ref }}"
+            echo "Manual build for ref: $RESOLVED_REF"
           elif [[ "$NEW_RELEASE" == "true" ]]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
-            echo "New commit detected, building ref: ${{ steps.resolve-ref.outputs.ref }}"
+            echo "New commit detected, building ref: $RESOLVED_REF"
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
             echo "::notice::Skipping - No new commits detected"

--- a/derivatives/pytorch/derivatives/ace-step/ROOT/etc/vast_agents/ace-step.md
+++ b/derivatives/pytorch/derivatives/ace-step/ROOT/etc/vast_agents/ace-step.md
@@ -1,5 +1,32 @@
 ## ACE-Step (this image)
 
-Runs ACE-Step music/audio generation as a web UI (`ace-step-ui`) plus an HTTP API
-(`ace-step-api`). Both appear in `/capabilities/services`; reach them via
-`direct_url` + token. The API is app-specific (not OpenAI).
+The PyTorch image plus a preinstalled **ACE-Step** music/audio generation stack. Everything in
+base.md and pytorch.md applies unchanged (torch is in `/venv/main`); this file covers what
+ACE-Step adds. **Two** services, and the API is **not** an OpenAI `/v1` endpoint. Get the
+externally callable URLs + token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # both services, with direct_url + state
+```
+
+### ace-step-api — programmatic generation (service "ace-step-api")
+
+A **FastAPI** server (`acestep-api`), supervisor service **`ace-step-api`**, internal
+`127.0.0.1:8001`. This is the path to generate music in code. The endpoints + request schema
+are the source of truth at **`/docs`** (the OpenAPI page on port 8001) — read it before building
+a request; it is app-specific, not OpenAI-shaped.
+
+### ace-step-ui — interactive (service "ace-step-ui")
+
+A Node web app (`ace-step-ui`), supervisor service **`ace-step-ui`**, internal
+`127.0.0.1:3000`. It **waits for the API's `/docs` to return 200 before starting**, so on a
+fresh boot the UI lags the API.
+
+### Models, outputs & provisioning
+
+The app lives at `${WORKSPACE}/ACE-Step-1.5` and runs in `/venv/main`; generated audio lands
+under `${WORKSPACE}`. The language model is selected by **`ACESTEP_LM_MODEL_PATH`** (default
+`acestep-5Hz-lm-4B`); **model weights download on first generation**, so the first request is
+slow — that is expected, not a hang. Add anything declaratively with the base provisioner
+(`PROVISIONING_SCRIPT`, base.md §10). **Both services wait for provisioning (`/.provisioning`)
+to finish before starting**, so during boot they may be intentionally down — check that flag
+before assuming a fault. (This image is built amd64-only.)

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -27,16 +27,6 @@ RUN \
     git clone https://github.com/jamiepine/voicebox.git && \
     cd /opt/voicebox && \
     git checkout "${VOICEBOX_REF}" && \
-    # Upstream bug fix: the Whisper STT backend loads with a plain
-    # from_pretrained() + .to(device), which under transformers' accelerate
-    # lazy-load leaves weights on the `meta` device — /transcribe then fails with
-    # "Tensor on device meta is not on the expected device cuda:0!". Their TTS
-    # backend already forces eager load (low_cpu_mem_usage=False / device_map);
-    # mirror that for Whisper. Verify the edit applied so upstream drift fails the
-    # build loudly instead of silently shipping the bug.
-    { grep -q 'WhisperForConditionalGeneration.from_pretrained(model_name)' backend/backends/pytorch_backend.py || { echo "voicebox whisper meta-device patch: target line not found (upstream drift?)"; exit 1; }; } && \
-    sed -i 's/WhisperForConditionalGeneration.from_pretrained(model_name)/WhisperForConditionalGeneration.from_pretrained(model_name, low_cpu_mem_usage=False)/' backend/backends/pytorch_backend.py && \
-    { grep -q 'from_pretrained(model_name, low_cpu_mem_usage=False)' backend/backends/pytorch_backend.py || { echo "voicebox whisper meta-device patch: verification failed"; exit 1; }; } && \
     # Install Python dependencies — strip base-provided torch ecosystem pins
     # from upstream requirements so the pytorch base remains the single
     # source of truth. The diff-based assertion at the end of this RUN

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -27,6 +27,16 @@ RUN \
     git clone https://github.com/jamiepine/voicebox.git && \
     cd /opt/voicebox && \
     git checkout "${VOICEBOX_REF}" && \
+    # Upstream bug fix: the Whisper STT backend loads with a plain
+    # from_pretrained() + .to(device), which under transformers' accelerate
+    # lazy-load leaves weights on the `meta` device — /transcribe then fails with
+    # "Tensor on device meta is not on the expected device cuda:0!". Their TTS
+    # backend already forces eager load (low_cpu_mem_usage=False / device_map);
+    # mirror that for Whisper. Verify the edit applied so upstream drift fails the
+    # build loudly instead of silently shipping the bug.
+    { grep -q 'WhisperForConditionalGeneration.from_pretrained(model_name)' backend/backends/pytorch_backend.py || { echo "voicebox whisper meta-device patch: target line not found (upstream drift?)"; exit 1; }; } && \
+    sed -i 's/WhisperForConditionalGeneration.from_pretrained(model_name)/WhisperForConditionalGeneration.from_pretrained(model_name, low_cpu_mem_usage=False)/' backend/backends/pytorch_backend.py && \
+    { grep -q 'from_pretrained(model_name, low_cpu_mem_usage=False)' backend/backends/pytorch_backend.py || { echo "voicebox whisper meta-device patch: verification failed"; exit 1; }; } && \
     # Install Python dependencies — strip base-provided torch ecosystem pins
     # from upstream requirements so the pytorch base remains the single
     # source of truth. The diff-based assertion at the end of this RUN

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -65,6 +65,38 @@ RUN \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Vast patch: the Whisper STT backend has no lock around model load vs inference,
+# so concurrent /transcribe calls (or model-size switches) can run generate()
+# against a model another request is still mid-(re)load on — the load race behind
+# "Tensor on device meta is not on the expected device cuda:0!" under rapid calls.
+# Wrap transcribe() in a per-backend asyncio.Lock so load+inference are serialized.
+# Self-verifying (anchor count + ast.parse): the build fails loudly if upstream drifts.
+RUN /venv/main/bin/python <<'PYEOF'
+import pathlib, ast
+p = pathlib.Path("/opt/voicebox/backend/backends/pytorch_backend.py")
+src = p.read_text()
+anchor = "    async def transcribe(\n"
+assert src.count(anchor) == 1, "voicebox stt-lock: transcribe anchor not found exactly once (upstream drift)"
+if "import asyncio" not in src:
+    src = "import asyncio\n" + src
+wrapper = (
+    "    async def transcribe(self, *args, **kwargs):\n"
+    "        # Vast patch: serialize load + inference so concurrent transcribe calls\n"
+    "        # can't run generate() against a model another request is mid-(re)load\n"
+    "        # on (the load race behind 'Tensor on device meta' under rapid calls).\n"
+    "        if getattr(self, '_load_lock', None) is None:\n"
+    "            self._load_lock = asyncio.Lock()\n"
+    "        async with self._load_lock:\n"
+    "            return await self._transcribe_locked(*args, **kwargs)\n"
+    "\n"
+)
+src = src.replace(anchor, wrapper + "    async def _transcribe_locked(\n", 1)
+ast.parse(src)
+assert "async with self._load_lock" in src and "async def _transcribe_locked(" in src, "voicebox stt-lock: verification failed"
+p.write_text(src)
+print("voicebox stt-lock patch applied")
+PYEOF
+
 ENV VOICEBOX_ARGS="--host 127.0.0.1 --port 17493"
 
 # Defend against environment clashes when syncing to volume

--- a/derivatives/pytorch/derivatives/voicebox/ROOT/etc/vast_agents/voicebox.md
+++ b/derivatives/pytorch/derivatives/voicebox/ROOT/etc/vast_agents/voicebox.md
@@ -51,7 +51,9 @@ POST /transcribe                  # speech-to-text
 **Cloning** is zero-shot from a short reference clip: register it as a profile, then synthesize with
 that profile. Engines: `qwen` / `qwen_custom_voice` / `luxtts` / `chatterbox` / `chatterbox_turbo` /
 `tada` / `kokoro` (choose via the `engine` arg); **engine model weights download on first use**, so
-the first call is slow — expected, not a hang. Persistent state — the DB, voice profiles, and
+the first call is slow — expected, not a hang. Transcription (`/transcribe`, `voicebox.transcribe`)
+likewise loads its Whisper model on first use; let that first call finish before firing more —
+hammering it concurrently during the load can surface a transient device error. Persistent state — the DB, voice profiles, and
 generated audio — lives under **`VOICEBOX_DATA_DIR`** (default `${WORKSPACE}/voicebox-data`). **The
 service waits for provisioning (`/.provisioning`) to finish before starting**, so during boot it may
 be intentionally down — check that flag before assuming a fault. (This image is built amd64-only.)

--- a/derivatives/pytorch/derivatives/voicebox/ROOT/etc/vast_agents/voicebox.md
+++ b/derivatives/pytorch/derivatives/voicebox/ROOT/etc/vast_agents/voicebox.md
@@ -1,4 +1,26 @@
 ## Voicebox (this image)
 
-Runs Voicebox, a text-to-speech / voice UI (supervisor service `voicebox`). It
-appears in `/capabilities/services`; reach it via `direct_url` + token.
+The PyTorch image plus a preinstalled **Voicebox** (upstream `jamiepine/voicebox`) — a
+text-to-speech / voice studio. Everything in base.md and pytorch.md applies unchanged (torch is
+in `/venv/main`); this file covers what Voicebox adds. One service, and it is **not** an OpenAI
+`/v1` endpoint. Get the externally callable URL + token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The app — web UI + REST API on one port (service "voicebox")
+
+Supervisor service **`voicebox`** (`python -m backend.main` from `/opt/voicebox`), internal
+`127.0.0.1:17493`. Like InvokeAI, the **same port serves both the web UI and a FastAPI backend**,
+always on — the browser app calls that backend. The OpenAPI schema is the source of truth at
+**`/docs`**: read it to drive synthesis (and voice profiles) programmatically rather than through
+the UI. Launch flags are in **`VOICEBOX_ARGS`** (default `--host 127.0.0.1 --port 17493`).
+
+### Data, models & provisioning
+
+Persistent state — the database, voice profiles, and generated audio — lives under
+**`VOICEBOX_DATA_DIR`** (default `${WORKSPACE}/voicebox-data`), so it survives on the workspace;
+the app runs in `/venv/main`. Add anything declaratively with the base provisioner
+(`PROVISIONING_SCRIPT`, base.md §10). **The service waits for provisioning (`/.provisioning`) to
+finish before starting**, so during boot it may be intentionally down — check that flag before
+assuming a fault. (This image is built amd64-only.)

--- a/derivatives/pytorch/derivatives/voicebox/ROOT/etc/vast_agents/voicebox.md
+++ b/derivatives/pytorch/derivatives/voicebox/ROOT/etc/vast_agents/voicebox.md
@@ -1,26 +1,57 @@
 ## Voicebox (this image)
 
-The PyTorch image plus a preinstalled **Voicebox** (upstream `jamiepine/voicebox`) — a
-text-to-speech / voice studio. Everything in base.md and pytorch.md applies unchanged (torch is
-in `/venv/main`); this file covers what Voicebox adds. One service, and it is **not** an OpenAI
+The PyTorch image plus a preinstalled **Voicebox** (upstream `jamiepine/voicebox`) — a local
+voice studio: clone a voice from a few seconds of audio (or use 50+ preset voices), generate
+speech across several TTS engines, and transcribe. Everything in base.md and pytorch.md applies
+unchanged (torch is in `/venv/main`); this file covers what Voicebox adds. It is **not** an OpenAI
 `/v1` endpoint. Get the externally callable URL + token from the manifest (base.md §5, §9):
 ```
 curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
 ```
 
-### The app — web UI + REST API on one port (service "voicebox")
+### Use the supported interfaces — do NOT patch the package
 
-Supervisor service **`voicebox`** (`python -m backend.main` from `/opt/voicebox`), internal
-`127.0.0.1:17493`. Like InvokeAI, the **same port serves both the web UI and a FastAPI backend**,
-always on — the browser app calls that backend. The OpenAPI schema is the source of truth at
-**`/docs`**: read it to drive synthesis (and voice profiles) programmatically rather than through
-the UI. Launch flags are in **`VOICEBOX_ARGS`** (default `--host 127.0.0.1 --port 17493`).
+One service, **`voicebox`** (`python -m backend.main` from `/opt/voicebox`), internal
+`127.0.0.1:17493` (flags in `VOICEBOX_ARGS`), serves the web UI, a REST API, **and an MCP server**
+on that single port. Synthesis, cloning, and transcription are all driven through the API/MCP by
+choosing a voice **profile** and **engine** — you never need to edit the TTS engine code or the
+Python package to make it work. If an engine errors, switch engines (below); don't patch internals.
 
-### Data, models & provisioning
+### MCP server — the best path for an agent (mounted at /mcp)
 
-Persistent state — the database, voice profiles, and generated audio — lives under
-**`VOICEBOX_DATA_DIR`** (default `${WORKSPACE}/voicebox-data`), so it survives on the workspace;
-the app runs in `/venv/main`. Add anything declaratively with the base provisioner
-(`PROVISIONING_SCRIPT`, base.md §10). **The service waits for provisioning (`/.provisioning`) to
-finish before starting**, so during boot it may be intentionally down — check that flag before
-assuming a fault. (This image is built amd64-only.)
+Voicebox ships a built-in Model Context Protocol server (Streamable HTTP) at
+**`http://127.0.0.1:17493/mcp`**. Add it and call tools instead of hand-rolling HTTP. On the box:
+```
+claude mcp add voicebox --transport http \
+  --url http://127.0.0.1:17493/mcp \
+  --header "X-Voicebox-Client-Id: claude-code"
+```
+The header is just a label for the per-client voice binding (not a secret). Off-box, use the
+service's authed `direct_url` from the manifest instead of `127.0.0.1`, or SSH-forward 17493.
+stdio-only clients can point at the bundled shim **`/opt/voicebox/voicebox-mcp`**. Four tools:
+- **`voicebox.list_profiles`** — available voices (cloned + preset). Start here.
+- **`voicebox.speak({text, profile?, engine?, language?})`** — synthesize; returns a
+  `generation_id` + `poll_url` (`/generate/<id>/status`); fetch the finished audio when it's done.
+- **`voicebox.transcribe(...)`** — Whisper STT of a local path or base64 clip.
+- **`voicebox.list_captures`** — recent captures, paginated.
+
+### REST API (equivalent, for non-MCP callers)
+
+Same port; full schema at **`/docs`**:
+```
+GET  /profiles                    # list voices (cloned + preset)
+POST /generate                    # synthesize -> poll /generate/<id>/status, then fetch the file
+POST /speak    {text, profile}    # speak with a profile (name or id)
+POST /transcribe                  # speech-to-text
+```
+
+### Voices, engines, cloning, data
+
+**Preset voices** (e.g. **Kokoro**) need no reference audio — pick a preset profile and synthesize.
+**Cloning** is zero-shot from a short reference clip: register it as a profile, then synthesize with
+that profile. Engines: `qwen` / `qwen_custom_voice` / `luxtts` / `chatterbox` / `chatterbox_turbo` /
+`tada` / `kokoro` (choose via the `engine` arg); **engine model weights download on first use**, so
+the first call is slow — expected, not a hang. Persistent state — the DB, voice profiles, and
+generated audio — lives under **`VOICEBOX_DATA_DIR`** (default `${WORKSPACE}/voicebox-data`). **The
+service waits for provisioning (`/.provisioning`) to finish before starting**, so during boot it may
+be intentionally down — check that flag before assuming a fault. (This image is built amd64-only.)

--- a/derivatives/pytorch/derivatives/wan2gp/ROOT/etc/vast_agents/wan2gp.md
+++ b/derivatives/pytorch/derivatives/wan2gp/ROOT/etc/vast_agents/wan2gp.md
@@ -1,29 +1,48 @@
 ## Wan2GP (this image)
 
-The PyTorch image plus a preinstalled **Wan2GP** (upstream `deepbeepmeep/Wan2GP`) — a low-VRAM
-**video generation** UI (text-to-video / image-to-video with Wan-family models). Everything in
-base.md and pytorch.md applies unchanged (torch is in `/venv/main`); this file covers what Wan2GP
-adds. One service, and it is **not** an OpenAI `/v1` endpoint. Get the externally callable URL +
-token from the manifest (base.md §5, §9):
+The PyTorch image plus a preinstalled **Wan2GP / WanGP** (upstream `deepbeepmeep/Wan2GP`) — a
+low-VRAM **video generation** app (text-to-video / image-to-video with Wan-family models).
+Everything in base.md and pytorch.md applies unchanged (torch is in `/venv/main`); this file
+covers what Wan2GP adds. It is **not** an OpenAI `/v1` endpoint. Get the externally callable URL
++ token for the UI from the manifest (base.md §5, §9):
 ```
 curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
 ```
 
-### The app — a Gradio UI (service "wan2gp")
+### Interactive — the Gradio UI (service "wan2gp")
 
-Supervisor service **`wan2gp`** (`python wgp.py`), internal `127.0.0.1:7860`. It is a **Gradio**
-app and is **UI-first** — pick a model and generate from the browser. Gradio does expose a
-programmatic API (the "Use via API" link at the bottom of the UI, served under `/gradio_api/`),
-but there is no curated REST surface here, so for most tasks drive the UI rather than scripting
-it. The port is set by **`WAN2GP_PORT`** (default `7860`) and extra launch flags by
-**`WAN2GP_ARGS`**.
+Supervisor service **`wan2gp`** (`python wgp.py`), internal `127.0.0.1:7860` — pick a model and
+generate from the browser. Port is set by **`WAN2GP_PORT`** (default `7860`), extra launch flags
+by **`WAN2GP_ARGS`**. This is the only service running by default.
+
+### Programmatic — Python API + MCP (prefer this for automation)
+
+WanGP ships a real agent-facing API; **don't assume it's UI-only.** Two paths, both documented
+on the box at **`${WORKSPACE}/Wan2GP/docs/API.md`** (read it — it's version-matched to this image
+and is the source of truth):
+
+- **In-process Python API** (`shared/api.py`). Run it with `/venv/main` python from the app dir:
+  ```python
+  from shared.api import init
+  session = init(root="${WORKSPACE}/Wan2GP")
+  print(session.list_model_metadata())          # discover available models/features
+  settings = session.get_default_settings("<model_type>")   # then set prompt/resolution/etc
+  settings["prompt"] = "a neon train entering a rainy station"
+  job = session.submit_task(settings)
+  result = job.result()                          # result.generated_files -> the video(s)
+  ```
+  Settings are *WanGP Settings* dicts; the easiest way to get a known-good one is the UI's
+  **"Export Settings"** button, or `get_model_schema(model_type)` / `get_default_settings(...)`.
+- **MCP server** — WanGP includes an MCP server with discovery functions (it can enumerate the
+  available generative models and features for an agent). It is **not started by default here**
+  (only the Gradio service runs); launch it per `docs/API.md` if your agent speaks MCP.
 
 ### Models, outputs & provisioning
 
-The app lives at `${WORKSPACE}/Wan2GP` and runs in `/venv/main`; generated videos land under
-that app directory's own outputs (`${WORKSPACE}/Wan2GP/...`). **Model weights download on first
-use** and large video runs are slow — expected, not a hang. Add anything declaratively with the
-base provisioner (`PROVISIONING_SCRIPT`, base.md §10). **The service waits for provisioning
-(`/.provisioning`) to finish before starting**, so during boot it may be intentionally down —
-check that flag before assuming a fault. (This image is built amd64-only — it needs
-onnxruntime-gpu, which ships x86_64 wheels only.)
+The app lives at `${WORKSPACE}/Wan2GP` and runs in `/venv/main`; generated videos land under that
+app directory's outputs (`${WORKSPACE}/Wan2GP/...`, also surfaced via `result.generated_files`).
+**Model weights download on first use** and large runs are slow — expected, not a hang. Add
+anything declaratively with the base provisioner (`PROVISIONING_SCRIPT`, base.md §10). **The
+service waits for provisioning (`/.provisioning`) to finish before starting**, so during boot it
+may be intentionally down — check that flag before assuming a fault. (This image is built
+amd64-only — it needs onnxruntime-gpu, which ships x86_64 wheels only.)

--- a/derivatives/pytorch/derivatives/wan2gp/ROOT/etc/vast_agents/wan2gp.md
+++ b/derivatives/pytorch/derivatives/wan2gp/ROOT/etc/vast_agents/wan2gp.md
@@ -1,4 +1,29 @@
 ## Wan2GP (this image)
 
-Runs Wan2GP, a video-generation UI (supervisor service `wan2gp`). It appears in
-`/capabilities/services`; reach it via `direct_url` + token. Not an OpenAI endpoint.
+The PyTorch image plus a preinstalled **Wan2GP** (upstream `deepbeepmeep/Wan2GP`) — a low-VRAM
+**video generation** UI (text-to-video / image-to-video with Wan-family models). Everything in
+base.md and pytorch.md applies unchanged (torch is in `/venv/main`); this file covers what Wan2GP
+adds. One service, and it is **not** an OpenAI `/v1` endpoint. Get the externally callable URL +
+token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The app — a Gradio UI (service "wan2gp")
+
+Supervisor service **`wan2gp`** (`python wgp.py`), internal `127.0.0.1:7860`. It is a **Gradio**
+app and is **UI-first** — pick a model and generate from the browser. Gradio does expose a
+programmatic API (the "Use via API" link at the bottom of the UI, served under `/gradio_api/`),
+but there is no curated REST surface here, so for most tasks drive the UI rather than scripting
+it. The port is set by **`WAN2GP_PORT`** (default `7860`) and extra launch flags by
+**`WAN2GP_ARGS`**.
+
+### Models, outputs & provisioning
+
+The app lives at `${WORKSPACE}/Wan2GP` and runs in `/venv/main`; generated videos land under
+that app directory's own outputs (`${WORKSPACE}/Wan2GP/...`). **Model weights download on first
+use** and large video runs are slow — expected, not a hang. Add anything declaratively with the
+base provisioner (`PROVISIONING_SCRIPT`, base.md §10). **The service waits for provisioning
+(`/.provisioning`) to finish before starting**, so during boot it may be intentionally down —
+check that flag before assuming a fault. (This image is built amd64-only — it needs
+onnxruntime-gpu, which ships x86_64 wheels only.)

--- a/derivatives/pytorch/derivatives/whisper/ROOT/etc/vast_agents/whisper.md
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/etc/vast_agents/whisper.md
@@ -20,6 +20,13 @@ the same port) — read it before building a request, since options (model, lang
 transcribe-vs-translate, diarization) are passed there rather than via OpenAI-style fields.
 Launch flags are in **`WHISPER_API_ARGS`** (default `--host 0.0.0.0 --port 8000`).
 
+**Language gotcha (will save you a hang):** the `lang` field wants the full lowercase language
+**name** — `english`, not the ISO code `en`. A wrong value raises `KeyError` *inside a background
+task*, so the request doesn't fail cleanly: the job **silently hangs at `progress: 0.0` with the
+GPU idle** and never flips to `failed`. Omit `lang` (or use the auto-detect option) to let Whisper
+detect the language. If a job sits at 0.0 doing nothing, check the backend log — that's where the
+real error is.
+
 ### whisper-ui — interactive (service "whisper-ui")
 
 A **Gradio** UI, supervisor service **`whisper-ui`**, internal `127.0.0.1:7860` — drag in audio,

--- a/derivatives/pytorch/derivatives/whisper/ROOT/etc/vast_agents/whisper.md
+++ b/derivatives/pytorch/derivatives/whisper/ROOT/etc/vast_agents/whisper.md
@@ -1,5 +1,37 @@
 ## Whisper (this image)
 
-Runs Whisper speech-to-text as a web UI (`whisper-ui`) plus an HTTP API
-(`whisper-api`). Both appear in `/capabilities/services`; reach them via
-`direct_url` + token. Use the API for programmatic transcription.
+The PyTorch image plus a preinstalled **Whisper-WebUI** (upstream `jhj0517/Whisper-WebUI`)
+for speech-to-text. Everything in base.md and pytorch.md applies unchanged (torch is in
+`/venv/main`); this file covers what Whisper adds. **Two** services — get their externally
+callable URLs + token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # both services, with direct_url + state
+```
+
+### whisper-api — programmatic transcription (the one agents want)
+
+FastAPI backend (`uvicorn backend.main:app`), supervisor service **`whisper-api`**, internal
+`0.0.0.0:8000`. This is the path for transcribing audio in code.
+
+**It is NOT OpenAI-compatible — do not call `/v1/audio/transcriptions`.** This server has its
+own routes; the transcription endpoint is **`POST /transcription`** (upload the audio file).
+The full request/response schema is the source of truth at **`/docs`** (the OpenAPI page on
+the same port) — read it before building a request, since options (model, language,
+transcribe-vs-translate, diarization) are passed there rather than via OpenAI-style fields.
+Launch flags are in **`WHISPER_API_ARGS`** (default `--host 0.0.0.0 --port 8000`).
+
+### whisper-ui — interactive (service "whisper-ui")
+
+A **Gradio** UI, supervisor service **`whisper-ui`**, internal `127.0.0.1:7860` — drag in audio,
+pick model/language/task. Flags are in **`WHISPER_UI_ARGS`** (default
+`--whisper_type whisper --server_port 7860`). It **waits for `whisper-api` to answer on `/docs`
+before starting**, so on a fresh boot the UI can lag the API.
+
+### Models & provisioning
+
+Runs from `${WORKSPACE}/Whisper-WebUI` in `/venv/main`. Whisper model weights download on first
+use and cache to the Hugging Face cache (`HF_HOME`); the model size/variant is selected through
+the UI or the API request, not a dedicated env var. Add anything declaratively with the base
+provisioner (`PROVISIONING_SCRIPT`, base.md §10). **Both services wait for provisioning
+(`/.provisioning`) to finish before starting**, so during boot they may be intentionally down —
+check that flag before assuming a fault.


### PR DESCRIPTION
Fleshes out the agent-aware `/etc/vast_agents/<name>.md` guides for the audio/speech/video derivatives, to the base.md / pytorch.md / comfyui.md standard. Part of the CON-1556 rollout.

## What each guide now covers
- **whisper** (CON-1575): `whisper-api` (FastAPI, internal `:8000`) + `whisper-ui` (Gradio, `:7860`). **Key fact: NOT OpenAI-compatible** — transcription is `POST /transcription`, *not* `/v1/audio/transcriptions`; full schema at `/docs`. Models cache to `HF_HOME`. Multi-arch.
- **ace-step** (CON-1558): `ace-step-api` (FastAPI, `:8001`, `/docs`) + `ace-step-ui` (Node, `:3000`). `ACESTEP_LM_MODEL_PATH` selects the LM; weights download on first generation. amd64-only.
- **voicebox** (CON-1573): `jamiepine/voicebox` TTS — one service, web UI + FastAPI on `:17493` (always on, `/docs`); persistent state under `VOICEBOX_DATA_DIR` (`${WORKSPACE}/voicebox-data`). amd64-only.
- **wan2gp** (CON-1574): `deepbeepmeep/Wan2GP` Gradio video-gen UI on `:7860`, **UI-first** (Gradio API under `/gradio_api/`); outputs under `${WORKSPACE}/Wan2GP`. amd64-only (onnxruntime-gpu).

All: not OpenAI `/v1`; reach via the manifest `direct_url` + token; services wait on `/.provisioning`.

Docs-only. Base pins already at 2026-06-15. Test images built from this branch per image.