### PR TITLE
docs(agents): training guides — fluxgym, ostris-ai-toolkit, unsloth-studio (CON-1561/1567/1570)

### DIFF
--- a/derivatives/pytorch/derivatives/fluxgym/ROOT/etc/vast_agents/fluxgym.md
+++ b/derivatives/pytorch/derivatives/fluxgym/ROOT/etc/vast_agents/fluxgym.md
@@ -1,4 +1,39 @@
 ## FluxGym (this image)
 
-Runs FluxGym, a LoRA training UI for FLUX models (supervisor service `fluxgym`).
-It appears in `/capabilities/services`; reach it via `direct_url` + token.
+The PyTorch image plus a preinstalled **FluxGym** (upstream `cocktailpeanut/fluxgym`) — a LoRA
+**training** UI for FLUX models that wraps Kohya `sd-scripts`. Everything in base.md and
+pytorch.md applies unchanged (torch is in `/venv/main`); this file covers what FluxGym adds. It
+is a training tool, **not** an inference/OpenAI endpoint — the deliverable is a trained LoRA
+file, not an API response. Get the externally callable URL + token from the manifest
+(base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The app — a Gradio UI (service "fluxgym")
+
+Supervisor service **`fluxgym`** (`python app.py`), internal `127.0.0.1:17860` (port via
+**`FLUXGYM_PORT`**). It is **UI-driven and has no API**: you add images + captions, set
+parameters, and click train. Under the hood FluxGym **generates a `train.sh` + `dataset.toml`
+and runs Kohya `sd-scripts`** (`accelerate launch sd-scripts/flux_train_network.py …`).
+
+### Driving a run headlessly
+
+There's no FluxGym API, but the Kohya trainer it calls is fully present, so an agent can train
+without the UI. From `${WORKSPACE}/fluxgym` in `/venv/main`, either:
+- re-run a config the UI already produced: `bash outputs/<name>/train.sh`, or
+- invoke Kohya directly: `accelerate launch sd-scripts/flux_train_network.py <args>` (`sd-scripts`
+  lives at `${WORKSPACE}/fluxgym/sd-scripts`).
+
+### Data, models, outputs
+
+All under `${WORKSPACE}/fluxgym` (persisted on the workspace):
+- **Datasets** — `datasets/<name>/`: training images + a matching `.txt` caption per image.
+- **Outputs** — `outputs/<name>/`: the trained **LoRA `.safetensors`**, plus the generated
+  `train.sh` / `dataset.toml`, sample images, and logs. This is what you pull back.
+- **Base weights** — `models/` (unet/clip/vae); **downloaded on first run**, not baked in, so the
+  first training start is slow. Gated FLUX-dev needs a Hugging Face token — enter it in the UI, or
+  export `HF_TOKEN` before a headless Kohya run (nothing in this image pre-sets it).
+
+The app runs in `/venv/main` and **waits for provisioning (`/.provisioning`) to finish before
+starting**, so during boot it may be intentionally down — check that flag before assuming a fault.

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/ROOT/etc/vast_agents/ostris-ai-toolkit.md
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/ROOT/etc/vast_agents/ostris-ai-toolkit.md
@@ -1,5 +1,42 @@
 ## AI Toolkit — ostris (this image)
 
-Runs the ostris AI Toolkit, a diffusion-model training UI (supervisor service
-`ai-toolkit`). It appears in `/capabilities/services`; reach it via `direct_url`
-+ token.
+The PyTorch image plus a preinstalled **ostris AI Toolkit** (upstream `ostris/ai-toolkit`) — a
+diffusion-model **training** suite (LoRA / fine-tunes for FLUX and friends). Everything in
+base.md and pytorch.md applies unchanged (torch is in `/venv/main`); this file covers what it
+adds. It is a training tool, **not** an inference/OpenAI endpoint — the deliverable is a trained
+model file. Get the externally callable URL + token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The app — web UI (service "ai-toolkit")
+
+A Next.js web UI, supervisor service **`ai-toolkit`** (`npm run start`, override via
+**`AI_TOOLKIT_START_CMD`**), internal `127.0.0.1:8675`. You build a job in the UI and click
+train; the UI worker spawns `run.py` training jobs as subprocesses. One UI service + transient
+trainer processes — there is no always-on training API.
+
+### Driving a run headlessly (preferred for automation)
+
+The UI just wraps a CLI an agent can call directly. From `${WORKSPACE}/ai-toolkit` in
+`/venv/main`, training is a **YAML job config** fed to `run.py`:
+```
+cd ${WORKSPACE}/ai-toolkit && . /venv/main/bin/activate
+python run.py config/my_job.yaml
+```
+Start from a template in **`config/examples/*.yaml`** (e.g. `train_lora_flux_24gb.yaml`), copy it,
+and edit the `datasets[].folder_path`, `training_folder`, model, and hyperparameters.
+
+### Data, models, outputs
+
+Under `${WORKSPACE}/ai-toolkit` (persisted on the workspace):
+- **Datasets** — `datasets/` (images + matching `.txt` captions); referenced by `folder_path` in
+  the job YAML.
+- **Outputs** — `output/<job_name>/`: trained LoRA/checkpoints + sample images. This is what you
+  pull back.
+- **Base weights** — **download on first use** into the HF cache; gated models (e.g. FLUX) need
+  **`HF_TOKEN`** set in the instance env (not pre-wired here).
+
+The app runs in `/venv/main` and **starts only after provisioning completes** (it waits for the
+portal config / `/.provisioning`), so during boot it may be intentionally down. This image is built
+**amd64-only** (torchcodec has no aarch64 wheels) and pins torch 2.9.1.

--- a/derivatives/pytorch/derivatives/unsloth-studio/ROOT/etc/vast_agents/unsloth-studio.md
+++ b/derivatives/pytorch/derivatives/unsloth-studio/ROOT/etc/vast_agents/unsloth-studio.md
@@ -1,5 +1,39 @@
 ## Unsloth Studio (this image)
 
-Runs Unsloth Studio for fast LLM fine-tuning (supervisor service
-`unsloth-studio`, portal label "Unsloth Studio"). It appears in
-`/capabilities/services`; reach it via `direct_url` + token.
+The PyTorch image plus a preinstalled **Unsloth Studio** (the AGPL "studio" component of the
+`unsloth` library) — a web UI for fast **LLM fine-tuning** (Llama, Qwen, DeepSeek, Gemma,
+Mistral, Phi …). Everything in base.md and pytorch.md applies unchanged (torch is in
+`/venv/main`); this file covers what it adds. It is a training tool, **not** an inference/OpenAI
+endpoint — the deliverable is a fine-tuned model / adapter / GGUF. Get the externally callable URL
++ token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # the service, with direct_url + state
+```
+
+### The app — web UI (service "unsloth-studio")
+
+Supervisor service **`unsloth-studio`** (`unsloth studio`, flags in **`UNSLOTH_STUDIO_ARGS`**,
+default `--host 127.0.0.1 --port 18888`), internal `127.0.0.1:18888`. It is **click-driven**:
+pick a base model, upload/import a dataset, design a data recipe, set hyperparameters, hit Start
+Training, watch loss curves / GPU usage, then export (incl. **GGUF** — a `llama.cpp` build is
+bundled for conversion/inference). There is no training API to call.
+
+### Driving a fine-tune headlessly
+
+An agent can't click the UI, but the full **`unsloth` Python library is in the shared
+`/venv/main`**, so it can fine-tune from a script — the standard
+`FastLanguageModel.from_pretrained(...)` + TRL `SFTTrainer` pattern — run from a terminal or the
+**Jupyter** service on this image (separate portal entry). No example notebooks/scripts ship here;
+the supported turnkey path is the Studio UI, and headless is the usual library code.
+
+### Data, models, outputs
+
+Studio state — datasets, runs, and **outputs (LoRA adapters / merged models / GGUF exports)** —
+persists under **`${WORKSPACE}/unsloth`** (the app's `~/.unsloth` is repointed there at boot). For
+a headless script, write outputs wherever you like under `${WORKSPACE}`. Base LLMs pull from the
+Hugging Face Hub on first use; **`HF_TOKEN` is NOT pre-set here** — export it yourself for gated
+models (e.g. Llama).
+
+The app runs in `/venv/main` and **waits for provisioning (`/.provisioning`) to finish before
+starting**, so during boot it may be intentionally down — check that flag before assuming a fault.
+This image is built **amd64-only** (torchao has no aarch64 wheels yet).


### PR DESCRIPTION
Fleshes out the agent-aware `/etc/vast_agents/<name>.md` guides for the training derivatives, to the comfyui.md standard. Part of the CON-1556 rollout. Common theme: the UI is the primary path, but each has a real **headless** route, and the deliverable is a **model artifact** (LoRA / checkpoint / GGUF) to pull back — not an inference endpoint.

- **fluxgym** (CON-1561): Gradio UI (`:17860`, `FLUXGYM_PORT`), no API; wraps Kohya `sd-scripts`. Headless via the UI-generated `outputs/<name>/train.sh` or `accelerate launch sd-scripts/flux_train_network.py`. `datasets/` + `outputs/` + `models/` under `${WORKSPACE}/fluxgym`; gated FLUX needs `HF_TOKEN`. Multi-arch.
- **ostris-ai-toolkit** (CON-1567): Next.js UI (`:8675`) that spawns `run.py`; headless via `python run.py config/my_job.yaml` (templates in `config/examples/`). `datasets/` + `output/` under `${WORKSPACE}/ai-toolkit`; `HF_TOKEN` for gated. amd64-only, torch 2.9.1.
- **unsloth-studio** (CON-1570): web UI (`:18888`, `UNSLOTH_STUDIO_ARGS`); GGUF export via bundled `llama.cpp`; headless via the `unsloth` library in `/venv/main` (or Jupyter). State + outputs under `${WORKSPACE}/unsloth`; `HF_TOKEN` NOT pre-set (flagged in guide). amd64-only.

All: not OpenAI `/v1`; reach via the manifest `direct_url` + token; services wait on `/.provisioning`.

Docs-only. Base pins already at 2026-06-15. Test images built from this branch per image.