### PR TITLE
Image scaffolding tooling: invariant-linter + generator + skill (CON-1585)

### DIFF
--- a/.claude/skills/new-image/SKILL.md
+++ b/.claude/skills/new-image/SKILL.md
@@ -58,18 +58,31 @@ always diff against ground truth.)
 
 ## Step 4 — Fill only the fenced residue
 Resolve every `>>> FILL` / `CHANGEME` / `CHANGEPORT`:
-- **Dockerfile**: the install step (git clone at the pinned ref, strip torch pins for
-  pytorch-nested, `uv pip install`), and the real base tag for `CHANGEME`.
-- **supervisor script**: the real launch (use `pty`, like the sibling); remove the
-  `exit 1 # >>> FILL` stub line entirely.
-- **capability yaml / agent doc / READMEs**: real content (README.md = dev docs,
-  README.template.md = marketplace listing — keep them distinct).
-- **external**: the `05-<name>-env.sh` PORTAL_CONFIG ports (match the app's real bind
-  port — `+10000` is a common convention, NOT a rule).
+- **Dockerfile install (pytorch-nested)**: the install MUST stay **inside the existing
+  RUN, between the `torch_versions_pre` and `torch_versions_post` lines** — the marker is
+  already placed there; do **not** move it to a separate RUN. An install outside that
+  window makes the torch-drift guard a silent no-op that the linter CANNOT catch. Keep
+  the generated `[[ -n "${NAME_REF}" ]] || exit` ref-presence guard. Inside: git clone at
+  the pinned ref, strip torch pins, `uv pip install`.
+- **`CHANGEME` base tag**: set it to the tag the chosen **sibling currently pins** (an
+  existing tag — e.g. comfyui pins a dated `vastai/pytorch:...` tag). Never invent a tag;
+  a non-existent tag lints clean but fails `docker build` on the `FROM` pull. (Filling
+  this token is a normal in-fence fill, NOT an escape-hatch case.)
+- **supervisor script**: the real launch (use `pty`, like the sibling); ensure it binds
+  the `--port` you supplied; remove the `exit 1  # >>> FILL` stub line entirely.
+- **PORTAL_CONFIG / port wiring**: external → fill `05-<name>-env.sh` with the app's real
+  bind port. **pytorch-nested / derivative** → check the sibling: if it ships a
+  `ROOT/etc/vast_boot.d/05-<name>-env.sh`, add one wiring your port into PORTAL_CONFIG;
+  otherwise confirm how the sibling's port reaches the portal. The `--port` is not wired
+  automatically — you must place it.
+- **capability yaml / agent doc / READMEs**: real content (capability `readme:` = the
+  GitHub URL; README.md = dev docs; README.template.md = marketplace listing — distinct).
 
-**Escape hatch:** if a correct change is needed *outside* a fence (bump the base tag's
-real value, add a build stage, change the CI shape), **stop and surface it to the human**
-— do not silently edit beyond the markers.
+**Escape hatch:** if a correct change requires touching **structure the generator did not
+scaffold** — adding a build stage, changing the CI job shape, changing the class or the
+base-image repo, or any edit outside a `>>> FILL` / `CHANGE*` token — **stop and surface
+it to the human**. (Resolving the scaffolded tokens themselves is not an escape-hatch
+case.)
 
 ## Step 5 — Lint to zero
 ```bash

--- a/.claude/skills/new-image/SKILL.md
+++ b/.claude/skills/new-image/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: new-image
+description: Scaffold a new Vast.ai base-image (derivative / pytorch-nested / external) for a GitHub project, using the imagegen generator + linter. Use when adding a new image to this repo. The human picks the class; the agent fills only the fenced residue and must reach a clean lint before a PR.
+---
+
+# Add a new image
+
+Orchestrates the deterministic generator (`tools/imagegen`) and the static linter to
+scaffold a new image, then fills only the judgment residue. Read
+[docs/invariants.md](../../../docs/invariants.md),
+[docs/context-map.md](../../../docs/context-map.md), and
+[docs/adr/0001-image-scaffolding-tooling.md](../../../docs/adr/0001-image-scaffolding-tooling.md)
+first.
+
+**Contract (non-negotiable, from ADR 0001):**
+- The **human picks the class** — never infer it silently.
+- Edit **only** the `>>> FILL` markers and `CHANGEME`/`CHANGEPORT` tokens. Do **not**
+  touch anything outside them without surfacing it (see Escape hatch).
+- **Static lint is the fast gate, not the correctness gate.** Zero lint errors means
+  *structurally valid*, NOT *builds/runs*. The real `docker build` (+ smoke test) is
+  the correctness gate — always say so.
+- Never open a PR while `imagegen lint <name>` reports errors (including L040).
+
+## Step 0 — Confirm the class (human decides)
+
+Present the decision and let the human choose; if their choice looks wrong, **challenge
+it once** with evidence, then defer:
+
+| Class | When | Lives in |
+|---|---|---|
+| **pytorch-nested** | GPU app that needs PyTorch (image-gen, training, audio/video, transcription) — the common case | `derivatives/pytorch/derivatives/<name>/` |
+| **derivative** | Needs the base image but not PyTorch (e.g. a non-torch runtime) | `derivatives/<name>/` |
+| **external** | Wraps a large, trusted upstream that already ships a maintained image (vLLM, SGLang, Ollama) | `external/<name>/` |
+| *provisioning-only* | Prototype/proof-of-concept; runtime install at boot | `provisioning_scripts/<name>.sh` (no dedicated image — out of scope for this skill) |
+
+**Class-sanity check:** does the project ship its own upstream Docker image and is it
+impractical to rebuild? → likely `external`. Does it import torch / need CUDA wheels? →
+`pytorch-nested`, not `derivative`. If the human's pick contradicts these signals, say so.
+
+## Step 1 — Gather inputs
+- `--name` (lowercase, matches the dir), `--label` (display name), `--port` (the app's
+  real bind port), and for **external** `--upstream <image:tag>`.
+- The GitHub project URL + the ref/version to pin.
+
+## Step 2 — Generate the skeleton
+```bash
+PYTHONPATH=tools/imagegen python3 -m imagegen.cli new \
+  --class <class> --name <name> --label "<Label>" --port <port> [--upstream <image:tag>]
+```
+It reports `structure: valid ✓` and `skeleton: N files … NOT buildable yet`. That N is
+your fill list.
+
+## Step 3 — Study a real sibling FIRST
+Before filling, read the closest **same-class** existing image as an exemplar (e.g. a
+pytorch-nested app like `derivatives/pytorch/derivatives/comfyui/`, or `external/vllm/`).
+Match its real conventions — do not invent. (This is where guessing has burned us:
+always diff against ground truth.)
+
+## Step 4 — Fill only the fenced residue
+Resolve every `>>> FILL` / `CHANGEME` / `CHANGEPORT`:
+- **Dockerfile**: the install step (git clone at the pinned ref, strip torch pins for
+  pytorch-nested, `uv pip install`), and the real base tag for `CHANGEME`.
+- **supervisor script**: the real launch (use `pty`, like the sibling); remove the
+  `exit 1 # >>> FILL` stub line entirely.
+- **capability yaml / agent doc / READMEs**: real content (README.md = dev docs,
+  README.template.md = marketplace listing — keep them distinct).
+- **external**: the `05-<name>-env.sh` PORTAL_CONFIG ports (match the app's real bind
+  port — `+10000` is a common convention, NOT a rule).
+
+**Escape hatch:** if a correct change is needed *outside* a fence (bump the base tag's
+real value, add a build stage, change the CI shape), **stop and surface it to the human**
+— do not silently edit beyond the markers.
+
+## Step 5 — Lint to zero
+```bash
+PYTHONPATH=tools/imagegen python3 -m imagegen.cli lint <name>
+```
+Loop until 0 errors. All `L040` (unfilled markers) must clear. If a structural check
+(L001–L030) fails, fix the cause; do not work around the linter.
+
+## Step 6 — Hand off honestly
+State plainly: lint is green = structurally conformant; the image is **not** verified
+until the real CI `docker build` + smoke test pass. Then prepare the change / open a PR
+referencing the tracking ticket (e.g. CON-####), and add the `build-<name>.yml` workflow
+(generated as a skeleton — complete it per `.github/AGENTS.md`; CI job-shape is not
+linted, so review against a sibling).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md — base-image
+
+Monorepo for the Vast.ai Docker image family (base image + derivative/external app
+images sharing the `ROOT/` overlay, built and promoted to DockerHub via GitHub
+Actions). Orient with [docs/context-map.md](docs/context-map.md).
+
+## Ground truth (read before non-trivial work)
+- [docs/context-map.md](docs/context-map.md) — modules, responsibilities, where
+  things live.
+- [docs/invariants.md](docs/invariants.md) — the rules that must hold, **verified
+  against reality**. The authoritative `CONTRIBUTING.md` / `.github/AGENTS.md` are
+  partly STALE; where they disagree with `invariants.md`, reality wins.
+- [docs/adr/](docs/adr/) — decisions + rejected alternatives. Read these fresh.
+
+## How to work in this repo (expert-panel workflow)
+- For any non-trivial decision, run /panel (or /forge for idea→plan) BEFORE building.
+- Brief experts with the ARTIFACT only — never my preference or authorship.
+- Before claiming done, /redteam the change.
+- Record decisions as ADRs in docs/adr/ (template: docs/adr/0000-template.md).
+  Experts read these fresh each call.
+- Surface expert disagreement to me RAW; do not pre-resolve it.
+- Keep docs/invariants.md and docs/context-map.md current as the project grows.
+
+## Repo-specific cautions
+- **Bash for build/registry plumbing; Python 3.12 for structured/tested logic**
+  (precedent: `lib/provisioner`, `portal-aio`, `tools/model-ui`). Don't introduce a
+  new toolchain without a reason.
+- Static checks are a fast gate, not a correctness gate — the real `docker build`
+  (+ smoke test) is the correctness check (see ADR 0001).
+- Several headline "invariants" in the docs are NOT real (notably
+  `external port == internal + 10000`). Confirm against `docs/invariants.md` before
+  encoding any rule.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,27 @@ Actions). Orient with [docs/context-map.md](docs/context-map.md).
 - Surface expert disagreement to me RAW; do not pre-resolve it.
 - Keep docs/invariants.md and docs/context-map.md current as the project grows.
 
+## Bug → Invariant protocol (when I report a mistake/miss/regression)
+
+A reported defect means a MISSING INVARIANT, not just a line to patch. When I say
+"we missed X" or report a bug in the image tooling, do this yourself, unprompted —
+do not just patch the symptom:
+
+1. **Ground truth first** — inspect the real repo; restate the exact invariant and
+   its boundary/exemptions.
+2. **Linter check BEFORE the fix** — add a new `RULES` code in
+   `tools/imagegen/imagegen/linter.py`; regenerate `docs/lint-rules.md`
+   (`imagegen rules > docs/lint-rules.md`). Run `imagegen lint --all`: the baseline
+   must stay CLEAN. If a real image fails, STOP and tell me (latent bug, or the
+   invariant is wrong).
+3. **Prove it bites** — a mutation test that corrupts a real image and asserts the
+   new code fires. No mutation test = the check doesn't count.
+4. **Then fix the source** (generator/etc.) + a round-trip/regression assertion.
+5. **Show evidence, don't claim** — report the new code, the baseline result, and
+   the mutation-test name. "Done" without evidence is a failure.
+
+Don't edit beyond what this requires; surface anything larger.
+
 ## Repo-specific cautions
 - **Bash for build/registry plumbing; Python 3.12 for structured/tested logic**
   (precedent: `lib/provisioner`, `portal-aio`, `tools/model-ui`). Don't introduce a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,27 @@ do not just patch the symptom:
 
 Don't edit beyond what this requires; surface anything larger.
 
+## Idea → Vetted change protocol (when I spring a new idea)
+
+Unreviewed ideas are how drift enters a shared repo. When I (or anyone) floats a
+feature/change/idea — especially one touching shared conventions, the `ROOT/`
+contract, invariants, CI, or the generator/linter — do NOT start building. Force
+the clean path, even against enthusiasm (mine included):
+
+1. **Triage blast radius.** Local, trivial, reversible → say so and proceed. Touches
+   conventions / the image contract / invariants / CI / tooling → full path below.
+   When unsure, treat it as non-trivial.
+2. **Challenge before designing.** State the strongest objection and the existing
+   invariants/ADRs it interacts with. If it contradicts a current ADR or invariant,
+   say so — it must SUPERSEDE that ADR explicitly, never silently drift.
+3. **Run it through `/forge`** (idea → red-team gate → competing designs → blind
+   panel → synthesis). Surface the disagreement to me RAW; don't pre-resolve it.
+4. **Record an ADR** in `docs/adr/` before building — decision + rejected
+   alternatives. If it changes an enforced rule, also update the linter (`RULES`) +
+   `docs/invariants.md` so the new pattern is CODIFIED, not just described.
+5. **Build only after the plan survives the gate.** "Great idea, here's the code" on
+   the spot is the failure mode — agreeing fast is how the pattern erodes.
+
 ## Repo-specific cautions
 - **Bash for build/registry plumbing; Python 3.12 for structured/tested logic**
   (precedent: `lib/provisioner`, `portal-aio`, `tools/model-ui`). Don't introduce a

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,26 @@
+# ADR NNNN — <short title>
+
+- **Status:** Proposed | Accepted | Accepted (conditional) | Superseded by ADR-NNNN
+- **Date:** YYYY-MM-DD
+- **Decision owner:** <name>
+
+## Context
+The forces and constraints. What problem is being decided, and why now. Link
+relevant invariants ([docs/invariants.md](../invariants.md)) and prior ADRs.
+
+## Options considered
+Each real alternative, with its key technical trade-offs and **why it was
+rejected** — not just the winner. Record the dissent.
+
+## Decision
+What was chosen.
+
+## Binding conditions
+Non-negotiable conditions the decision depends on (e.g. surviving findings from a
+`/redteam` gate). If a condition is later refused, the decision is void.
+
+## Consequences
+Positive and accepted-negative outcomes.
+
+## What would reverse this
+The evidence or change that would invalidate the decision.

--- a/docs/adr/0001-image-scaffolding-tooling.md
+++ b/docs/adr/0001-image-scaffolding-tooling.md
@@ -1,0 +1,136 @@
+# ADR 0001 — Tooling + skill for scaffolding new images
+
+- **Status:** Accepted (conditional — see Binding conditions), **revised 2026-06-22 — see Revision**
+- **Date:** 2026-06-22
+- **Process:** idea brief → red-team gate → 2 blind architects → 3-lens blind panel → synthesis (panel red-team served as final gate)
+
+## Revision (2026-06-22) — invariants verified against the repo
+
+Before building, the documented invariants were verified against the actual files
+(see [docs/invariants.md](../invariants.md)). The decision's *shape* holds, but
+findings change scope:
+
+- **DROPPED: port-arithmetic gate and generation.** `external port == internal +
+  10000` is **not a real invariant** — widely violated (Jupyter delta 0; `ollama`
+  reversed vs `openwebui`; `aio-studio` columns transposed). The generator must
+  **not** fabricate a `+10000`; the linter must **not** gate it (soft warning at
+  most). This falsifies the original Decision/Context assumption that listed port
+  arithmetic as a generated + checked rule.
+- **NARROWED: linter scope = `docs/invariants.md` §1–2** (the verified gateable
+  set). Notable corrections it must respect: utils are an *ordered subsequence*
+  (not a fixed set of 4); CI is the **5-job** shape (incl. `merge-manifests`), not
+  4; `base_image_source` is injected via `--build-context` (don't flag it as an
+  undeclared stage); class/torch exceptions exist (`aio-studio`, `openwebui`,
+  `voicebox`).
+- **Reversal condition NOT triggered:** a clean baseline *is* reachable on the
+  verified subset (the `conf.d↔script↔program-name` triple is 60/60 clean). The
+  pattern is established enough — just narrower than the docs claim.
+- **Docs are stale** (`CONTRIBUTING.md`, `.github/AGENTS.md`) — see invariants §5;
+  correcting them is in scope.
+
+## Context
+
+Adding a new image to this monorepo (`derivatives/<x>`, nested
+`derivatives/pytorch/derivatives/<x>`, or `external/<x>`) is currently manual,
+driven by `CONTRIBUTING.md` + `.github/AGENTS.md`. The pattern is dense and
+invariant-heavy (exactly 3 LABELs; `PORTAL_CONFIG` external port = internal +
+10000; commit-hash tags append an ISO date while version tags must not; torch-
+drift guard; supervisor scripts source 4 utils in fixed order; `env-hash`
+trailer; strict 4/5-job CI shape with a `base_image × arch` matrix to staging +
+`crane` manifest merge). We want to automate the mechanical bulk without
+producing plausible-but-wrong infrastructure.
+
+A red-team review of the original "an agent generates everything" idea rated it
+**fatal as framed**: a new image is an all-green PR diff a reviewer can't
+diff-check, real validation needs GPUs/secrets/build, and the "which class /
+does it warrant an image" call is exactly what LLMs are worst at. The idea was
+reshaped before any design.
+
+## Decision
+
+Adopt a four-part shape:
+1. **Human picks the image class** (not the agent).
+2. A **deterministic generator** emits the mechanical ~80% (Dockerfile skeleton
+   with correct ARG/FROM/3 LABELs, supervisor `.conf`, `build-<name>.yml`,
+   README from template, port arithmetic).
+3. The **LLM/skill drafts only the judgment residue** (install steps, external
+   graft, app launch body) inside clearly fenced blocks.
+4. A **static invariant-linter** (no GPU/registry/build) gates before PR.
+
+### Implementation: linter-as-B, maintained-as-A
+
+- **Linter = robust, parsed-model, tested** (the "Design B" approach): parse each
+  artifact once into a typed model (Dockerfile tokenizer → instruction list;
+  `configparser` for `.conf`; `yaml.safe_load` for YAML/CI), checks operate on
+  structure not regex, stable machine codes per finding. **Python**, reusing the
+  repo's existing pytest setup (portal-aio, model-ui). Tests: one **mutant per
+  invariant** (proves each check has teeth), a **regression net** over all
+  existing images, and a **generator round-trip** test.
+- **Rejected: the pure shell linter** (the "Design A" approach, grep/awk +
+  *optional* `yq`). It scored highest on team-fit but the correctness lens rated
+  it 4/10 and the red-team called it *trending fatal as specified*: grep/awk over
+  YAML cannot model the CI job-shape DAG, and optional-`yq`-with-graceful-
+  degradation yields **silent false passes** and machine-dependent verdicts on
+  the single hardest invariant. A gate you can't trust is worse than no gate.
+- **Generator** shares the one Python/Jinja2 toolchain (plain, reviewable
+  templates); do **not** split languages within the tool.
+
+## Binding conditions (non-negotiable — from the panel red-team)
+
+If any is refused, the approach reverts to fatal (it would manufacture false
+confidence — a green check that ships broken infra past a disengaged reviewer):
+
+1. **Static lint is the FAST first gate, not the correctness gate.** The existing
+   `docker build` (+ a smoke test) is the real check behind it. "Green lint" =
+   *ready to build*, never *correct*. Conformance ≠ correctness.
+2. **Defeat drift structurally:** the linter is authoritative; a CI test asserts
+   `CONTRIBUTING.md`/`.github/AGENTS.md` agree with the linter (or the
+   human-facing checklist is generated FROM the linter rules). Two hand-
+   maintained encodings of one ruleset will otherwise diverge by default.
+3. **Class-sanity check:** a heuristic that challenges the human's class choice
+   (*"this looks like class X but you declared Y"* from FROM/upstream cues) — the
+   one verification on the unverifiable input. It advises; it does not override.
+4. **Minimal deps + a named owner** for the Python toolchain (the maintainability
+   risk in a bash-first team is dep rot and an under-serviced test suite). Triage
+   regression-net failures on existing images as *real bug vs wrong invariant*
+   with a dated, reasoned allowlist — never silently pin a bug.
+5. **Fence escape hatch:** if a correct fix needs changes outside the residue
+   fence (base bump, extra stage), the skill surfaces it to the human rather than
+   contorting the fix to fit the box.
+
+## Consequences
+
+- **Positive:** correctness oracle you can trust; mechanical 80% correct by
+  construction; LLM confined to where judgment actually lives; the linter is
+  independently valuable (a regression net for all existing images) and exists
+  regardless of the generator/skill.
+- **Negative / accepted cost:** introduces Python as the canonical image-tooling
+  path in a bash-heavy repo (mitigated: Python already present, minimal deps,
+  named owner); the generator/skill are conveniences that hang off the linter and
+  can lag without breaking the gate.
+
+## Build order (linter first — contract before generator)
+
+1. Write the linter; run `lint --all` over the real repo; triage to a clean
+   baseline (proves the invariants are real).
+2. Add mutant fixtures + regression net + CI job (lint + pytest, advisory
+   hadolint/actionlint).
+3. Build the generator (Jinja2 templates per class, fenced residue); add the
+   round-trip test.
+4. Wire `lint --all` into the CI **preflight** job; add the docs⟷linter agreement
+   test (condition 2) and the class-sanity check (condition 3).
+5. Author the Claude skill: confirm human class → class-sanity challenge →
+   generate → fill only fenced residue (escape hatch per condition 5) → lint
+   until clean → PR → existing build CI is the real gate.
+
+## What would reverse this
+
+- If the static linter cannot reach a clean baseline over existing images
+  because the "invariants" aren't actually consistent → the pattern isn't as
+  established as believed; stop and codify it first.
+- If new-image volume is low enough that the manual + good-docs process already
+  wins → don't build the generator/skill; ship only the linter as a regression
+  net (still net-positive).
+- If no named owner can be committed to the Python toolchain → reconsider a
+  smaller shell linter with `yq` REQUIRED (not optional) and a known-bad fixture
+  corpus.

--- a/docs/adr/0001-image-scaffolding-tooling.md
+++ b/docs/adr/0001-image-scaffolding-tooling.md
@@ -123,6 +123,22 @@ confidence — a green check that ships broken infra past a disengaged reviewer)
    generate → fill only fenced residue (escape hatch per condition 5) → lint
    until clean → PR → existing build CI is the real gate.
 
+## Implementation status (2026-06-22)
+
+Built on `feature/CON-1585-image-linter`, each layer hardened by adversarial review:
+- **Linter** (`tools/imagegen`) — checks per §1–2; mutation-tested; clean baseline over 27 images.
+- **Generator** (`imagegen new`) — templates from real images; L040 gates unfilled skeletons.
+- **Skill** (`.claude/skills/new-image`) — orchestrates the flow with the contract above.
+- **Binding condition #1** — honoured: static lint is the fast gate; the README/skill
+  state the real `docker build` is the correctness gate.
+- **Binding condition #2** (docs⟷linter agreement) — DONE: `RULES` is the single source
+  of truth, `docs/lint-rules.md` is generated (`imagegen rules`), and tests fail on drift
+  between the catalog, the emitted codes, and the doc.
+- **Binding condition #3** (class-sanity) — DONE mechanically: `--upstream` must agree
+  with the class, and L004 enforces path⟷FROM class consistency at lint time; the skill
+  adds the human-facing "challenge the class" step.
+- **Port arithmetic** — dropped (see Revision); ports are FILL markers, not fabricated.
+
 ## What would reverse this
 
 - If the static linter cannot reach a clean baseline over existing images

--- a/docs/context-map.md
+++ b/docs/context-map.md
@@ -1,0 +1,102 @@
+# Context map
+
+Where things live and what they're responsible for. A monorepo that builds the
+Vast.ai Docker image family: a CUDA/ML base image + a tree of derived application
+images, sharing a common runtime overlay (`ROOT/`), built and promoted to DockerHub
+via GitHub Actions. **Bash for build/registry plumbing; Python for structured,
+tested logic** (this split matters for tooling decisions — see §9).
+
+## 1. Root build/release tooling (bash)
+Local counterparts to CI. Model: **staging namespace → prod namespace via retag**
+(no rebuild on promote).
+- `build.sh` — the builder; `build_image()` wraps `docker buildx build` (base-image
+  cuda/rocm/stock × ubuntu × python matrix). Supports `DRY_RUN`.
+- `retag.sh` — primitive used by all promote/backup scripts; `crane copy`
+  (registry-to-registry, near-instant).
+- `build-staging-to-prod.sh` — promote staging → prod via `retag.sh`; strips date
+  suffix, adds floating alias tags.
+- `build-prod-backup.sh` / `build-prod-restore-backup.sh` — snapshot prod before a
+  promotion / roll back.
+
+## 2. The base image
+- `Dockerfile` — real base build; `caddy_builder` stage then `FROM ${BASE_IMAGE}`;
+  `COPY ./ROOT/ /`; full toolchain. Source of all `vastai/base-image:*` tags.
+- `Dockerfile.runtime` — CUDA runtime variant from a stock (non-NVIDIA) base.
+- `Dockerfile.extend` — hotfix path: re-overlay `ROOT/` + `portal-aio` on a dated
+  prod image, re-run `env-hash`, no full rebuild.
+- **`ROOT/` overlay** (copied to `/`, inherited by all images):
+  - `etc/vast_boot.d/` — ordered boot sequence (`NN-name.sh`), run by
+    `boot_default.sh`: configure-cuda → prep-env → … → supervisor-launch →
+    instance-test → manifests → supervisor-wait. `first_boot/` runs once.
+  - `opt/instance-tools/bin/` — PATH executables: `entrypoint.sh`, `boot_default.sh`,
+    `provisioner`, `vast-capabilities`, `env-hash`, `jupyter`, etc.
+  - `opt/instance-tools/lib/provisioner/` — **Python** package (`python -m provisioner`):
+    phased, idempotent manifest runner (apt/git/pip/conda installers, HF/wget
+    downloaders, schema/state/concurrency). Has its own `tests/`.
+  - `opt/instance-tools/tests/` — bash test harness (`runner.sh`) for capabilities.
+  - `opt/supervisor-scripts/` — service launch scripts (`caddy.sh`, `jupyter.sh`,
+    `instance_portal.sh`, …) + `utils/` (6 sourced helpers).
+  - `etc/supervisor/` — `supervisord.conf` + `conf.d/*.conf` (one per service).
+  - `etc/vast_capabilities.d/NN-*.yaml` — capability fragments (base 10-,
+    derivative 30-, nested 50-), merged at request time.
+  - `etc/vast_agents/*.md` — AI-agent operating guides baked into images.
+- Provides to all images: boot orchestration, supervisor framework, Caddy proxy +
+  TLS + token auth, instance portal, provisioner, capabilities + agent-docs.
+
+## 3. Image tree — directory layout mirrors the FROM chain
+- `derivatives/<x>/` — `FROM vastai/base-image` (pytorch, tensorflow, llama-cpp,
+  linux-desktop, UnrealPixelStreaming).
+- `derivatives/pytorch/` — the hub; own `build-many.sh`, `torch-companions.json`,
+  `install-torch-venv.sh`, `Dockerfile.{extend,multi-torch}`.
+- `derivatives/pytorch/derivatives/<app>/` — `FROM vastai/pytorch` (~16: comfyui,
+  a1111, sd-forge, invokeai, fooocus, swarmui, kohya_ss, fluxgym, ostris-ai-toolkit,
+  unsloth-studio, oobabooga, whisper, voicebox, ace-step, wan2gp, aio-studio).
+- `external/<x>/` — multi-stage wrap of an upstream image + `convert-non-vast-image.sh`
+  graft (vllm, sglang, ollama, openwebui, vllm-omni).
+
+## 4. portal-aio/ (Python)
+Instance-portal web/proxy suite, launched by supervisor, shipped in every image
+via `Dockerfile.extend`. `portal/portal.py` (serves capabilities at :11111),
+`caddy_manager/` (generates Caddy config from `PORTAL_CONFIG`), `tunnel_manager/`
+(Cloudflare), `capabilities/`, `mcp_server/` (MCP tools for agents). Own pytest
+suite (`portal-aio/tests/`).
+
+## 5. provisioning/ & provisioning_scripts/
+Legacy/prototype provisioning path (distinct from the `lib/provisioner` package).
+`provisioning/` = example manifests; `provisioning_scripts/*.sh` = standalone
+installers — the "no dedicated image" route for an app.
+
+## 6. tools/
+- `convert-non-vast-image.sh` — installs the base toolset onto a non-Vast upstream
+  (the mechanism behind `external/*`).
+- `model-ui/` (**Python**, Starlette proxy) — shared inference UI for vLLM/SGLang.
+
+## 7. CI — .github/
+Per `.github/AGENTS.md`: native-arch builds (no QEMU) → arch-suffixed tags to
+**staging** → `crane` merge to the **prod** multi-arch tag.
+- `workflows/build-*.yml` — one per image (~21). Schedule + `workflow_dispatch`.
+- `workflows/extend-*.yml` — overlay-only rebuilds. `promote-*.yml` — retag
+  staging→prod. `notify-slack.yml` — reusable.
+- `actions/` — composite: `build-arch-image`, `merge-arch-manifests`,
+  `maximize-build-space`, and `check-{dockerhub,ghcr,github,pypi}-release` pollers.
+- Secrets: `DOCKERHUB_USERNAME/TOKEN`, `DOCKERHUB_NAMESPACE`,
+  `DOCKERHUB_NAMESPACE_STAGING`, optional `SLACK_WEBHOOK_URL`.
+- ⚠️ Real job shape is 5-job (with `merge-manifests`), not the docs' 4-job — see
+  [invariants §2](invariants.md).
+
+## 8. Docs & references
+- `CONTRIBUTING.md` — how to add an image (the invariant set; **partly stale** —
+  see [invariants.md](invariants.md)).
+- `.github/AGENTS.md` — canonical CI/CD conventions for agents.
+- `README.template.md` — source for per-image generated `README.md`.
+- `docs/adr/` — decision records; `docs/invariants.md`, `docs/context-map.md` (here).
+
+## 9. Languages / toolchains (decides where new tooling goes)
+- **Python 3.12 already established** in three islands: `lib/provisioner` (packaged,
+  pytest), `portal-aio/` (web + MCP, pytest), `tools/model-ui/` (Starlette). →
+  natural home for anything structured/testable (relevant to the ADR 0001 linter).
+- **Bash dominates** build/release (`build*.sh`, `retag.sh`), in-image boot/service
+  glue, and `convert-non-vast-image.sh`.
+- The two are deliberately separated: Python for logic-with-tests, bash for
+  Docker/registry plumbing.
+- Note: root `test/` is a stray virtualenv, **not** a test suite.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -51,6 +51,11 @@ All verified clean across existing images.
 - **External build passes `--build-context base_image_source=.`** (all 5). This is
   what makes the otherwise-undeclared `base_image_source` stage resolve.
 
+> Note: "one `build-<name>.yml` per image" is **not** universal — 6 images
+> (fooocus, kohya_ss, oobabooga, swarmui, tensorflow, UnrealPixelStreaming) build
+> via shared/other workflows. The linter treats workflow presence as a WARN (L030),
+> not a gate.
+
 ## 2. Conditional invariants — GATE per-class, with exceptions encoded
 
 - **FROM matches class** — EXCEPT: `aio-studio` builds on a custom

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -1,0 +1,114 @@
+# Invariants
+
+Rules the image family actually relies on, **verified against the real files** (not
+transcribed from docs). This is the spec a static linter should encode (see
+[ADR 0001](adr/0001-image-scaffolding-tooling.md)). Where reality diverges from
+`CONTRIBUTING.md` / `.github/AGENTS.md`, it is flagged — **reality wins here.**
+
+Classes: **derivative** (`FROM vastai/base-image`), **pytorch-nested**
+(`FROM vastai/pytorch`, under `derivatives/pytorch/derivatives/`), **external**
+(`external/*`, multi-stage wrapping an upstream image).
+
+> ⚠️ **Key finding for the linter:** the pattern is *less* uniform than the docs
+> claim. Some headline "rules" cannot reach a clean baseline and **must not be
+> gated** (see §3). Most importantly, **`external port == internal + 10000` is
+> NOT a real invariant** — this directly affects ADR 0001's plan.
+
+---
+
+## 1. Hard invariants — safe to GATE (clean baseline reachable)
+
+All verified clean across existing images.
+
+- **3 LABELs.** Exactly three top-level `LABEL` lines, keys:
+  `org.opencontainers.image.source`, `org.opencontainers.image.description`
+  (value ends `suitable for Vast.ai.`), `maintainer="Vast.ai Inc <contact@vast.ai>"`.
+- **`env-hash` trailer.** Final build instruction is `env-hash > /.env_hash`.
+  *(External: it's the last `RUN`, before only `ENTRYPOINT`/`CMD` — not literally
+  the last line.)*
+- **`COPY ./ROOT /`** present exactly once. *(External also has
+  `COPY --from=base_image_source /ROOT /`.)*
+- **External graft block** (`external` only): the fixed env block → 4 `COPY`s
+  (incl. `convert-non-vast-image.sh`) → the convert `RUN` → `COPY ./ROOT /` →
+  `ENTRYPOINT ["/opt/instance-tools/bin/entrypoint.sh"]` + `CMD []`.
+- **No surviving `--torch-backend auto`.** The only `auto` occurrences are `sed`
+  rewrites that *replace* it with a concrete backend. Flag `auto` only when it's
+  the *argument of an install command*.
+- **`uv pip` only**, never bare `pip install` (pytorch-nested; spot-check externals).
+- **Supervisor util source ORDER.** When utils are sourced, they appear as a
+  *subsequence* of: `logging.sh → cleanup_generic.sh → environment.sh →
+  exit_serverless.sh → exit_portal.sh`. Zero inversions exist. Match on path
+  (`logging.sh` is sometimes called with an argument).
+- **conf.d ↔ script ↔ program-name triple** (STRONGEST invariant, 60/60 clean):
+  every `etc/supervisor/conf.d/*.conf` has `environment=PROC_NAME="%(program_name)s"`,
+  `command=/opt/supervisor-scripts/<x>.sh`, and `[program:NAME]` where `NAME` ==
+  conf filename stem. Bonus checkable: the `command=` target script exists on disk.
+- **External `05-<name>-env.sh`** present setting `PORTAL_CONFIG` (externals + a
+  few derivatives).
+- **PORTAL_CONFIG anchors.** First entry always
+  `localhost:1111:11111:/:Instance Portal`; a Jupyter entry present.
+- **One `build-<name>.yml` per image.**
+- **External build passes `--build-context base_image_source=.`** (all 5). This is
+  what makes the otherwise-undeclared `base_image_source` stage resolve.
+
+## 2. Conditional invariants — GATE per-class, with exceptions encoded
+
+- **FROM matches class** — EXCEPT: `aio-studio` builds on a custom
+  `robatvastai/aio-studio:base-*` (not `vastai/pytorch`); `external/openwebui`'s
+  upstream stage has **no `AS` alias** (others use `*_build`). The
+  `vast_base_image`-first / upstream-second ORDER *is* hard across all externals.
+- **torch-drift guard** (pytorch-nested) — present 16/17. EXEMPT: `aio-studio`
+  (per-app venvs). ⚠️ The doc describes the **stale torch-only** form; reality
+  checks the 4-package ecosystem (`torch|torchvision|torchaudio|torchcodec`).
+- **strip upstream torch pins** (`sed` before install) — strong convention, not
+  universal; gate only "if requirements installed, a torch-strip precedes it."
+- **CI job set** — app images: `{preflight, build, merge-manifests, collect-tags,
+  notify}` (allow `resolve-refs` variant; allow drop of `merge-manifests` for
+  single-arch, e.g. voicebox). EXEMPT: `base-image`/`pytorch` (bespoke pipelines),
+  `aio-studio-base` (2-job). ⚠️ Docs say 4-job and **omit `merge-manifests`** —
+  wrong; 5-job dominates (16 workflows).
+- **`MATRIX_ID` / built-tag** — `md5sum | cut -c1-8`; artifact `built-tag-*`.
+  Strong convention in app workflows.
+
+## 3. NOT invariants — DO NOT GATE (doc claims false against reality)
+
+- ❌ **`external port == internal + 10000`.** Widely violated: Jupyter terminal
+  (delta 0), `ollama` (reversed: `21434:11434`) vs `openwebui` (`11434:21434`) —
+  the two even disagree on the *same* service; `aio-studio` pervasively (columns
+  appear transposed). **This kills a binding assumption in ADR 0001.** At most a
+  *soft warning* excluding known-exempt labels; possibly flag "likely transposed
+  columns."
+- ❌ **Fixed util SET** ("must source all 4"). The set varies legitimately;
+  only the order is invariant. *(And there are 6 utils, not 4 —
+  `exit_serverless.sh`, `pty.sh` are undocumented.)*
+- ❌ **Uniform cron** `'0 0,12 * * *'`. Deliberately staggered across images.
+- ❌ **Required `DEFAULT_MULTI_ARCH` / `RELEASE_AGE_THRESHOLD`.** First exists in
+  one workflow; the latter is class-dependent (`COMMIT_AGE_THRESHOLD` for git-ref
+  images) and absent in several. Only `DEFAULT_DOCKERHUB_REPO` is near-hard.
+- ❌ **`set -euo pipefail` in every RUN.** Only the primary install RUN reliably
+  has it.
+- ❌ **The docs' specific `vast_boot.d` script list.** Numbering scheme is a rule
+  (`^[0-9]{2}-.*\.sh$`); the exact list is mid-migration and already wrong in docs.
+
+## 4. Real but NOT statically checkable (linter blind spots → need the build)
+
+These are why ADR 0001 condition #1 holds: **static lint is the fast gate, the
+real `docker build` + smoke test is the correctness gate.**
+
+- torch ecosystem *actually* unchanged after install (guard presence ≠ success).
+- CPU smoke-tests pass (presence checkable; success runtime-only).
+- PORTAL_CONFIG ports match the port the app actually binds.
+- Tag commit-hash-vs-version date suffix (depends on the runtime-resolved ref).
+- `base_image_source` build-context *content*.
+- single shared `/venv/main` assumption (false for aio-studio by design).
+
+**Feasible future cross-file static check:** every `exit_portal.sh "<Label>"` in
+an image should have a matching `:<Label>` entry in that image's `PORTAL_CONFIG`
+(catches typos). Not currently enforced.
+
+## 5. Docs needing correction before they can be trusted
+
+`CONTRIBUTING.md` / `.github/AGENTS.md` are stale on: the torch guard form (§2),
+the boot-sequence list (§3), the 4-job pipeline + missing `merge-manifests` (§2),
+the undeclared `base_image_source` stage (§1), the missing utils
+`exit_serverless.sh`/`pty.sh` (§1), the port +10000 claim (§3), and uniform cron (§3).

--- a/docs/lint-rules.md
+++ b/docs/lint-rules.md
@@ -1,0 +1,19 @@
+# Lint rules (generated)
+
+> Generated from `tools/imagegen/imagegen/linter.py` (`RULES`). Do not edit by
+> hand — run `imagegen rules > docs/lint-rules.md`. This is the authoritative
+> rule list; `CONTRIBUTING.md` / `.github/AGENTS.md` must not contradict it.
+
+| Code | Severity | Rule |
+|---|---|---|
+| L001 | ERROR | Exactly 3 LABEL key=value pairs, including the required keys |
+| L002 | ERROR | `env-hash > /.env_hash` is the final RUN (executed shell, not heredoc data) |
+| L003 | ERROR | A local `COPY ./ROOT /` is present |
+| L004 | ERROR | FROM matches the declared class — structural base identity (registry+repo), incl. external stage order |
+| L010 | ERROR | Each [program:NAME]: PROC_NAME + command=/opt/supervisor-scripts/NAME.sh; file stem is a program |
+| L011 | ERROR | Sourced utils appear as an ordered subsequence of the canonical order |
+| L020 | ERROR | torch-drift guard: a pre==post comparison wired to an exit on the same statement |
+| L021 | ERROR | No `--torch-backend auto` except inside a real sed substitution |
+| L022 | WARN | Prefer `uv pip install` over bare `pip install` |
+| L030 | WARN | A build-<name>.yml workflow exists (not universal) |
+| L040 | ERROR | No unfilled generator skeleton markers (CHANGEME / CHANGEPORT / >>> FILL) |

--- a/tools/imagegen/README.md
+++ b/tools/imagegen/README.md
@@ -43,6 +43,18 @@ PYTHONPATH=tools/imagegen python3 -m imagegen.cli lint comfyui
 Once installed (`pip install -e tools/imagegen`) the `imagegen` console script works
 directly.
 
+## Rules reference (single source of truth)
+
+`RULES` in `imagegen/linter.py` is authoritative. `docs/lint-rules.md` is **generated**
+from it — regenerate after changing checks:
+
+```bash
+PYTHONPATH=tools/imagegen python3 -m imagegen.cli rules > docs/lint-rules.md
+```
+
+Tests fail if the catalog, the codes the checks actually emit, and the generated doc
+drift apart — so the docs can't silently disagree with the enforced rules.
+
 ## Tests
 
 ```bash

--- a/tools/imagegen/README.md
+++ b/tools/imagegen/README.md
@@ -1,0 +1,61 @@
+# imagegen
+
+Static invariant-linter for base-image Docker images (the generator comes later).
+Scope and rationale: [docs/adr/0001](../../docs/adr/0001-image-scaffolding-tooling.md),
+verified rules: [docs/invariants.md](../../docs/invariants.md).
+
+**The linter is a FAST gate, not a correctness gate.** It checks file *shape* with
+no build/GPU/registry. The real `docker build` (+ smoke test) is the correctness
+check — green lint means "ready to build", never "correct" (ADR 0001 condition 1).
+
+## Run
+
+```bash
+# from the repo root — lint every image (errors gate, exit non-zero on any)
+PYTHONPATH=tools/imagegen python3 -m imagegen.cli lint --all
+
+# include advisory warnings
+PYTHONPATH=tools/imagegen python3 -m imagegen.cli lint --all --warn
+
+# a single image by name or path
+PYTHONPATH=tools/imagegen python3 -m imagegen.cli lint comfyui
+```
+
+Once installed (`pip install -e tools/imagegen`) the `imagegen` console script works
+directly.
+
+## Tests
+
+```bash
+cd tools/imagegen
+PYTHONPATH=. python3 -m pytest -q          # CI / where pytest is available
+PYTHONPATH=. python3 tests/test_linter.py  # stdlib fallback (no pytest needed)
+```
+
+The suite has one **mutant per invariant** (proves each check has teeth) plus a
+**regression net** that lints the whole real repo and asserts it's clean.
+
+## Checks (gated = ERROR; advisory = WARN)
+
+| Code | Sev | Applies | Rule |
+|---|---|---|---|
+| L001 | ERROR | all | exactly 3 LABEL lines |
+| L002 | ERROR | all | `env-hash > /.env_hash` trailer present |
+| L003 | ERROR | all | `COPY ./ROOT /` present |
+| L004 | ERROR | all | FROM matches class (base via inline pin or `ARG VAST_BASE`) |
+| L010 | ERROR | all w/ ROOT | conf.d ↔ script ↔ program-name triple + PROC_NAME |
+| L011 | ERROR | all w/ ROOT | sourced utils are an ordered subsequence of canonical order |
+| L020 | ERROR | pytorch-nested | torch-drift guard present |
+| L021 | ERROR | pytorch-nested/external | no surviving `--torch-backend auto` |
+| L022 | WARN | pytorch-nested | prefer `uv pip` over bare `pip install` |
+| L030 | WARN | all | a `build-<name>.yml` workflow exists |
+
+Documented, verified exceptions live in `EXCEPTIONS` in `imagegen/linter.py`
+(currently `aio-studio` L004/L020 — custom base + per-app venvs).
+
+## Not yet covered (deferred)
+- CI **job-shape** parsing (5-job DAG, matrix, MATRIX_ID) — only existence (L030) so far.
+- `PORTAL_CONFIG` port checks — intentionally **not** gated (`+10000` is not a real
+  invariant; see invariants §3).
+- docs⟷linter agreement test; class-sanity check; cross-file `exit_portal` label ↔
+  PORTAL_CONFIG match (invariants §4).

--- a/tools/imagegen/README.md
+++ b/tools/imagegen/README.md
@@ -37,21 +37,35 @@ The suite has one **mutant per invariant** (proves each check has teeth) plus a
 
 ## Checks (gated = ERROR; advisory = WARN)
 
+Checks are **instruction-aware** (a small Dockerfile parser in `dockerfile.py`):
+keywords in comments, across `\` continuations, or in the wrong position do not
+produce false passes.
+
 | Code | Sev | Applies | Rule |
 |---|---|---|---|
-| L001 | ERROR | all | exactly 3 LABEL lines |
-| L002 | ERROR | all | `env-hash > /.env_hash` trailer present |
-| L003 | ERROR | all | `COPY ./ROOT /` present |
-| L004 | ERROR | all | FROM matches class (base via inline pin or `ARG VAST_BASE`) |
-| L010 | ERROR | all w/ ROOT | conf.d ↔ script ↔ program-name triple + PROC_NAME |
+| L001 | ERROR | all | exactly 3 LABEL instructions **with the required keys** |
+| L002 | ERROR | all | `env-hash > /.env_hash` is the **final RUN** (not commented/stale) |
+| L003 | ERROR | all | local `COPY ./ROOT /` present |
+| L004 | ERROR | all (not base) | FROM matches class; external: `vast_base_image` **first**, vast base identity, graft present |
+| L010 | ERROR | all w/ ROOT | every `[program:NAME]`: PROC_NAME + `command=/opt/.../NAME.sh` (basename==name); file stem is a program |
 | L011 | ERROR | all w/ ROOT | sourced utils are an ordered subsequence of canonical order |
-| L020 | ERROR | pytorch-nested | torch-drift guard present |
-| L021 | ERROR | pytorch-nested/external | no surviving `--torch-backend auto` |
+| L020 | ERROR | pytorch-nested | torch-drift guard with a real `pre == post` comparison that `exit 1`s |
+| L021 | ERROR | pytorch-nested/external | no `--torch-backend auto` except inside a real `sed` substitution |
 | L022 | WARN | pytorch-nested | prefer `uv pip` over bare `pip install` |
-| L030 | WARN | all | a `build-<name>.yml` workflow exists |
+| L030 | WARN | all (not base) | a `build-<name>.yml` exists (not universal — see invariants §1) |
 
-Documented, verified exceptions live in `EXCEPTIONS` in `imagegen/linter.py`
-(currently `aio-studio` L004/L020 — custom base + per-app venvs).
+The **base image** (repo root) is linted too (class `base`: L001/L002/L003/L010/L011).
+
+Documented exceptions live in `EXCEPTIONS` in `imagegen/linter.py`, **scoped to a
+message substring** (not a whole check) so a different future break of the same
+code is not silently suppressed. `test_no_stale_exceptions` fails if an exception
+stops triggering. Currently: `aio-studio` L004/L020 (custom base + per-app venvs).
+
+## Why "clean baseline" is trustworthy
+The regression net alone is vacuous (would pass if every check were a no-op). The
+suite therefore includes **mutation-against-real-files** tests: each corrupts a
+real image and asserts the matching code fires. Neutering any check breaks its
+mutation test.
 
 ## Not yet covered (deferred)
 - CI **job-shape** parsing (5-job DAG, matrix, MATRIX_ID) — only existence (L030) so far.

--- a/tools/imagegen/README.md
+++ b/tools/imagegen/README.md
@@ -8,6 +8,25 @@ verified rules: [docs/invariants.md](../../docs/invariants.md).
 no build/GPU/registry. The real `docker build` (+ smoke test) is the correctness
 check — green lint means "ready to build", never "correct" (ADR 0001 condition 1).
 
+## Scaffold a new image
+
+The generator emits the mechanical ~80% per class with fenced `>>> FILL: ... <<<`
+markers for the judgment residue (install steps, app launch, base tag). **You pick
+the class** — the generator never guesses it.
+
+```bash
+# from the repo root
+PYTHONPATH=tools/imagegen python3 -m imagegen.cli new \
+  --class pytorch-nested --name myapp --label "My App" --port 7860
+# external images also need --upstream <image:tag>
+```
+
+It scaffolds the Dockerfile, ROOT/ overlay (supervisor script + .conf + capability
++ agent doc), README, and a CI skeleton, then lints the result. Output passes the
+linter by construction (see `tests/test_generate.py` round-trip). Then: fill the
+FILL markers, replace the `CHANGEME` base tag, `lint`, and run the real
+`docker build` (the correctness gate).
+
 ## Run
 
 ```bash

--- a/tools/imagegen/imagegen/__init__.py
+++ b/tools/imagegen/imagegen/__init__.py
@@ -1,0 +1,6 @@
+"""imagegen — static invariant-linter for base-image Docker images.
+
+Scope and rules: see docs/invariants.md (verified) and docs/adr/0001.
+The linter is a FAST gate, not a correctness gate — the real `docker build`
+(+ smoke test) is the correctness check.
+"""

--- a/tools/imagegen/imagegen/cli.py
+++ b/tools/imagegen/imagegen/cli.py
@@ -60,11 +60,15 @@ def cmd_new(args) -> int:
     img = next((i for i in discover(repo) if i.dir.resolve() == d.resolve()), None)
     if img:
         errors = [f for f in lint_image(img, repo) if f.severity == ERROR]
-        print("lint:", "CLEAN ✓" if not errors else f"{len(errors)} errors")
-        for f in errors:
+        struct = [f for f in errors if f.code != "L040"]
+        skel = [f for f in errors if f.code == "L040"]
+        print("structure:", "valid ✓" if not struct else f"{len(struct)} ERRORS:")
+        for f in struct:
             print(f"  ✗ [{f.code}] {f.path}: {f.msg}")
-    print("\nNext: fill the `>>> FILL: ... <<<` markers, set the CHANGEME base tag,"
-          "\nthen run `imagegen lint " + args.name + "` and the real `docker build`.")
+        print(f"skeleton:  {len(skel)} file(s) with FILL/CHANGEME markers to complete"
+              " — NOT buildable yet")
+    print("\nNext: fill the `>>> FILL: ... <<<` markers and CHANGEME tags, then"
+          f"\n`imagegen lint {args.name}` (must be 0 errors) and run the real `docker build`.")
     return 0
 
 

--- a/tools/imagegen/imagegen/cli.py
+++ b/tools/imagegen/imagegen/cli.py
@@ -1,0 +1,64 @@
+"""CLI: `imagegen lint [--all] [paths...]`. Exit non-zero on any ERROR finding."""
+from __future__ import annotations
+import argparse
+import sys
+from pathlib import Path
+
+from .discover import discover, find_repo_root, Image
+from .linter import lint_image, ERROR, WARN, EXCEPTIONS
+
+
+def _gather(args) -> tuple[Path, list[Image]]:
+    repo = find_repo_root(Path(args.repo) if args.repo else Path.cwd())
+    images = discover(repo)
+    if not args.all and args.paths:
+        wanted = {Path(p).resolve() for p in args.paths}
+        images = [i for i in images if i.dir.resolve() in wanted or i.name in args.paths]
+    return repo, images
+
+
+def cmd_lint(args) -> int:
+    repo, images = _gather(args)
+    if not images:
+        print("no images found", file=sys.stderr)
+        return 2
+
+    total_err = total_warn = 0
+    for img in sorted(images, key=lambda i: (i.cls, i.name)):
+        findings = lint_image(img, repo)
+        if not args.warn:
+            findings = [f for f in findings if f.severity == ERROR]
+        if not findings:
+            continue
+        print(f"\n{img.cls}/{img.name}")
+        for f in sorted(findings, key=lambda f: (f.severity != ERROR, f.code)):
+            mark = "✗" if f.severity == ERROR else "·"
+            print(f"  {mark} [{f.code} {f.severity}] {f.path}: {f.msg}")
+        total_err += sum(f.severity == ERROR for f in findings)
+        total_warn += sum(f.severity == WARN for f in findings)
+
+    n_excepted = len(EXCEPTIONS)
+    print(f"\n{'='*60}")
+    print(f"{len(images)} images | {total_err} errors"
+          + (f" | {total_warn} warnings" if args.warn else "")
+          + f" | {n_excepted} documented exceptions suppressed")
+    if total_err == 0:
+        print("baseline CLEAN ✓ (all gated invariants hold across existing images)")
+    return 1 if total_err else 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="imagegen")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    lint = sub.add_parser("lint", help="run invariant checks")
+    lint.add_argument("paths", nargs="*", help="image dirs or names (default: all)")
+    lint.add_argument("--all", action="store_true", help="lint every image")
+    lint.add_argument("--repo", help="repo root (default: autodetect from cwd)")
+    lint.add_argument("--warn", action="store_true", help="also show WARN findings")
+    lint.set_defaults(func=cmd_lint)
+    args = ap.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/imagegen/imagegen/cli.py
+++ b/tools/imagegen/imagegen/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .discover import discover, find_repo_root, Image
 from .linter import lint_image, ERROR, WARN, EXCEPTIONS
+from .generate import generate, CLASSES
 
 
 def _gather(args) -> tuple[Path, list[Image]]:
@@ -47,6 +48,26 @@ def cmd_lint(args) -> int:
     return 1 if total_err else 0
 
 
+def cmd_new(args) -> int:
+    repo = find_repo_root(Path(args.repo) if args.repo else Path.cwd())
+    try:
+        d = generate(repo, name=args.name, cls=args.cls, label=args.label,
+                     port=args.port, upstream=args.upstream)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    print(f"scaffolded {args.cls} image at {d.relative_to(repo)}")
+    img = next((i for i in discover(repo) if i.dir.resolve() == d.resolve()), None)
+    if img:
+        errors = [f for f in lint_image(img, repo) if f.severity == ERROR]
+        print("lint:", "CLEAN ✓" if not errors else f"{len(errors)} errors")
+        for f in errors:
+            print(f"  ✗ [{f.code}] {f.path}: {f.msg}")
+    print("\nNext: fill the `>>> FILL: ... <<<` markers, set the CHANGEME base tag,"
+          "\nthen run `imagegen lint " + args.name + "` and the real `docker build`.")
+    return 0
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(prog="imagegen")
     sub = ap.add_subparsers(dest="cmd", required=True)
@@ -56,6 +77,16 @@ def main(argv=None) -> int:
     lint.add_argument("--repo", help="repo root (default: autodetect from cwd)")
     lint.add_argument("--warn", action="store_true", help="also show WARN findings")
     lint.set_defaults(func=cmd_lint)
+
+    new = sub.add_parser("new", help="scaffold a new image (human picks the class)")
+    new.add_argument("--class", dest="cls", required=True, choices=CLASSES)
+    new.add_argument("--name", required=True)
+    new.add_argument("--label", required=True)
+    new.add_argument("--port", type=int, required=True)
+    new.add_argument("--upstream", help="upstream image:tag (external only)")
+    new.add_argument("--repo", help="repo root (default: autodetect from cwd)")
+    new.set_defaults(func=cmd_new)
+
     args = ap.parse_args(argv)
     return args.func(args)
 

--- a/tools/imagegen/imagegen/cli.py
+++ b/tools/imagegen/imagegen/cli.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 from .discover import discover, find_repo_root, Image
-from .linter import lint_image, ERROR, WARN, EXCEPTIONS
+from .linter import lint_image, ERROR, WARN, EXCEPTIONS, rules_markdown
 from .generate import generate, CLASSES
 
 
@@ -90,6 +90,9 @@ def main(argv=None) -> int:
     new.add_argument("--upstream", help="upstream image:tag (external only)")
     new.add_argument("--repo", help="repo root (default: autodetect from cwd)")
     new.set_defaults(func=cmd_new)
+
+    rules = sub.add_parser("rules", help="print the generated lint-rules reference (docs/lint-rules.md)")
+    rules.set_defaults(func=lambda a: (print(rules_markdown(), end=""), 0)[1])
 
     args = ap.parse_args(argv)
     return args.func(args)

--- a/tools/imagegen/imagegen/discover.py
+++ b/tools/imagegen/imagegen/discover.py
@@ -38,6 +38,11 @@ def _mk(d: Path, cls: str) -> Image:
 
 def discover(repo: Path) -> list[Image]:
     images: list[Image] = []
+
+    # the base image itself (root of the FROM chain) — class "base", limited checks
+    if (repo / "Dockerfile").is_file():
+        images.append(_mk(repo, "base"))
+
     nested_parent = repo / "derivatives" / "pytorch" / "derivatives"
 
     for df in sorted((repo / "external").glob("*/Dockerfile")):

--- a/tools/imagegen/imagegen/discover.py
+++ b/tools/imagegen/imagegen/discover.py
@@ -1,0 +1,53 @@
+"""Find image directories and classify them by path (path == FROM chain)."""
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Image:
+    name: str
+    cls: str  # "derivative" | "pytorch-nested" | "external"
+    dir: Path
+    dockerfile: Path
+    text: str
+    root: Path | None  # the image's ROOT/ overlay, if present
+
+
+def find_repo_root(start: Path) -> Path:
+    """Walk up until we find the monorepo markers."""
+    p = start.resolve()
+    for cand in [p, *p.parents]:
+        if (cand / "derivatives").is_dir() and (cand / "external").is_dir():
+            return cand
+    return start.resolve()
+
+
+def _mk(d: Path, cls: str) -> Image:
+    df = d / "Dockerfile"
+    root = d / "ROOT"
+    return Image(
+        name=d.name,
+        cls=cls,
+        dir=d,
+        dockerfile=df,
+        text=df.read_text(encoding="utf-8", errors="replace"),
+        root=root if root.is_dir() else None,
+    )
+
+
+def discover(repo: Path) -> list[Image]:
+    images: list[Image] = []
+    nested_parent = repo / "derivatives" / "pytorch" / "derivatives"
+
+    for df in sorted((repo / "external").glob("*/Dockerfile")):
+        images.append(_mk(df.parent, "external"))
+
+    for df in sorted(nested_parent.glob("*/Dockerfile")):
+        images.append(_mk(df.parent, "pytorch-nested"))
+
+    # direct children of derivatives/ (non-recursive) — includes the pytorch hub
+    for df in sorted((repo / "derivatives").glob("*/Dockerfile")):
+        images.append(_mk(df.parent, "derivative"))
+
+    return images

--- a/tools/imagegen/imagegen/dockerfile.py
+++ b/tools/imagegen/imagegen/dockerfile.py
@@ -1,0 +1,72 @@
+"""Minimal instruction-aware Dockerfile parser.
+
+Enough structure to stop the linter from being fooled by keywords in comments,
+across line-continuations, or in the wrong position. NOT a full Docker parser.
+"""
+from __future__ import annotations
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class Instruction:
+    cmd: str   # upper-cased, e.g. RUN, FROM, LABEL, COPY
+    value: str # remainder, continuations joined, full-line comments dropped
+    line: int  # 1-based line where the instruction starts
+
+
+def parse(text: str) -> list[Instruction]:
+    lines = text.splitlines()
+    out: list[Instruction] = []
+    i, n = 0, len(lines)
+    while i < n:
+        start = i + 1
+        raw = lines[i]
+        i += 1
+        s = raw.strip()
+        if not s or s.startswith("#"):
+            continue
+        buf = raw
+        # join line continuations; skip comment-only continuation lines
+        while buf.rstrip().endswith("\\") and i < n:
+            buf = buf.rstrip()[:-1] + "\n" + lines[i]
+            i += 1
+        m = re.match(r"\s*(\w+)\s*(.*)", buf, re.S)
+        if not m:
+            continue
+        out.append(Instruction(m.group(1).upper(), m.group(2), start))
+    return out
+
+
+def stages(instrs: list[Instruction]) -> list[tuple[str, str | None]]:
+    """Return [(image_ref, alias|None)] for each FROM, in order."""
+    out: list[tuple[str, str | None]] = []
+    for ins in instrs:
+        if ins.cmd != "FROM":
+            continue
+        parts = ins.value.split()
+        if not parts:
+            continue
+        alias = parts[2] if len(parts) >= 3 and parts[1].upper() == "AS" else None
+        out.append((parts[0], alias))
+    return out
+
+
+def code_text(instrs: list[Instruction]) -> str:
+    """Comment-free reconstruction for substring/regex checks."""
+    return "\n".join(f"{i.cmd} {i.value}" for i in instrs)
+
+
+def ini_sections(text: str) -> dict[str, dict[str, str]]:
+    """Parse a supervisor .conf into {section: {key: value}} (last value wins)."""
+    sections: dict[str, dict[str, str]] = {}
+    cur: str | None = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            cur = s[1:-1]
+            sections.setdefault(cur, {})
+        elif cur and "=" in s and not s.startswith("#"):
+            k, v = s.split("=", 1)
+            sections[cur][k.strip()] = v.strip()
+    return sections

--- a/tools/imagegen/imagegen/dockerfile.py
+++ b/tools/imagegen/imagegen/dockerfile.py
@@ -1,11 +1,14 @@
 """Minimal instruction-aware Dockerfile parser.
 
 Enough structure to stop the linter from being fooled by keywords in comments,
-across line-continuations, or in the wrong position. NOT a full Docker parser.
+across line-continuations, in heredoc bodies, or in the wrong position. NOT a
+full Docker parser.
 """
 from __future__ import annotations
 import re
 from dataclasses import dataclass
+
+_HEREDOC = re.compile(r"<<-?\s*([\"']?)(\w+)\1")
 
 
 @dataclass
@@ -27,10 +30,23 @@ def parse(text: str) -> list[Instruction]:
         if not s or s.startswith("#"):
             continue
         buf = raw
-        # join line continuations; skip comment-only continuation lines
-        while buf.rstrip().endswith("\\") and i < n:
-            buf = buf.rstrip()[:-1] + "\n" + lines[i]
+        # join line continuations, skipping comment-only continuation lines
+        while buf.rstrip().endswith("\\"):
+            buf = buf.rstrip()[:-1]
+            while i < n and lines[i].strip().startswith("#"):
+                i += 1  # Docker drops comment lines inside a continuation
+            if i >= n:
+                break
+            buf += "\n" + lines[i]
             i += 1
+        # consume heredoc bodies so their lines aren't parsed as instructions
+        pending = [m.group(2) for m in _HEREDOC.finditer(buf)]
+        while i < n and pending:
+            body = lines[i]
+            i += 1
+            buf += "\n" + body
+            if body.strip() in pending:
+                pending.remove(body.strip())
         m = re.match(r"\s*(\w+)\s*(.*)", buf, re.S)
         if not m:
             continue
@@ -52,6 +68,29 @@ def stages(instrs: list[Instruction]) -> list[tuple[str, str | None]]:
     return out
 
 
+def arg_defaults(instrs: list[Instruction]) -> dict[str, str | None]:
+    """Map ARG name -> default value (None if declared with no default)."""
+    d: dict[str, str | None] = {}
+    for ins in instrs:
+        if ins.cmd != "ARG":
+            continue
+        m = re.match(r"(\w+)=(.+)", ins.value.strip(), re.S)
+        if m:
+            d[m.group(1)] = m.group(2).strip().strip('"').strip("'")
+        else:
+            d.setdefault(ins.value.strip().split()[0] if ins.value.strip() else "", None)
+    return d
+
+
+def resolve(ref: str, defaults: dict[str, str | None]) -> str:
+    """Substitute ${VAR}/$VAR in a FROM ref with known ARG defaults."""
+    def sub(m: re.Match) -> str:
+        name = m.group(1) or m.group(2)
+        val = defaults.get(name)
+        return val if val else m.group(0)
+    return re.sub(r"\$\{(\w+)\}|\$(\w+)", sub, ref)
+
+
 def code_text(instrs: list[Instruction]) -> str:
     """Comment-free reconstruction for substring/regex checks."""
     return "\n".join(f"{i.cmd} {i.value}" for i in instrs)
@@ -63,8 +102,8 @@ def ini_sections(text: str) -> dict[str, dict[str, str]]:
     cur: str | None = None
     for line in text.splitlines():
         s = line.strip()
-        if s.startswith("[") and s.endswith("]"):
-            cur = s[1:-1]
+        if s.startswith("[") and "]" in s:  # tolerate trailing comment after ]
+            cur = s[1:s.index("]")]
             sections.setdefault(cur, {})
         elif cur and "=" in s and not s.startswith("#"):
             k, v = s.split("=", 1)

--- a/tools/imagegen/imagegen/dockerfile.py
+++ b/tools/imagegen/imagegen/dockerfile.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-_HEREDOC = re.compile(r"<<-?\s*([\"']?)(\w+)\1")
+_HEREDOC = re.compile(r"<<(-?)\s*([\"']?)(\w+)\2")
 
 
 @dataclass
@@ -39,14 +39,17 @@ def parse(text: str) -> list[Instruction]:
                 break
             buf += "\n" + lines[i]
             i += 1
-        # consume heredoc bodies so their lines aren't parsed as instructions
-        pending = [m.group(2) for m in _HEREDOC.finditer(buf)]
+        # consume heredoc bodies so their lines aren't parsed as instructions.
+        # plain <<EOF terminates only at a column-0 EOF; <<-EOF allows leading tabs.
+        pending = [(m.group(3), bool(m.group(1))) for m in _HEREDOC.finditer(buf)]
         while i < n and pending:
             body = lines[i]
             i += 1
             buf += "\n" + body
-            if body.strip() in pending:
-                pending.remove(body.strip())
+            for idx, (term, dashed) in enumerate(pending):
+                if (body.strip() == term) if dashed else (body.rstrip() == term):
+                    pending.pop(idx)
+                    break
         m = re.match(r"\s*(\w+)\s*(.*)", buf, re.S)
         if not m:
             continue
@@ -82,13 +85,41 @@ def arg_defaults(instrs: list[Instruction]) -> dict[str, str | None]:
     return d
 
 
+def _expand(content: str, defaults: dict[str, str | None]) -> str:
+    # handle ${VAR}, ${VAR:-def}, ${VAR-def}, ${VAR:=def}. The ARG value wins when
+    # set (the inline `:-` default is dead once the build-arg/ARG is set).
+    m = re.match(r"(\w+):?[-=](.*)$", content, re.S)
+    if m:
+        val = defaults.get(m.group(1))
+        return val if val else m.group(2)
+    val = defaults.get(content)
+    return val if val else "${" + content + "}"
+
+
 def resolve(ref: str, defaults: dict[str, str | None]) -> str:
-    """Substitute ${VAR}/$VAR in a FROM ref with known ARG defaults."""
+    """Substitute ${VAR}/${VAR:-def}/$VAR in a FROM ref with known ARG defaults."""
     def sub(m: re.Match) -> str:
-        name = m.group(1) or m.group(2)
+        if m.group(1) is not None:
+            return _expand(m.group(1), defaults)
+        name = m.group(2)
         val = defaults.get(name)
         return val if val else m.group(0)
-    return re.sub(r"\$\{(\w+)\}|\$(\w+)", sub, ref)
+    return re.sub(r"\$\{([^}]*)\}|\$(\w+)", sub, ref)
+
+
+def parse_ref(ref: str) -> tuple[str | None, str, str | None]:
+    """Split an image ref into (registry, repo, tag). registry=None means Docker Hub."""
+    ref = ref.strip().split("@", 1)[0]
+    parts = ref.split("/")
+    registry: str | None = None
+    if len(parts) > 1 and ("." in parts[0] or ":" in parts[0] or parts[0] == "localhost"):
+        registry, parts = parts[0], parts[1:]
+    last = parts[-1]
+    tag: str | None = None
+    if ":" in last:
+        name, tag = last.rsplit(":", 1)
+        parts = parts[:-1] + [name]
+    return registry, "/".join(parts), tag
 
 
 def code_text(instrs: list[Instruction]) -> str:

--- a/tools/imagegen/imagegen/dockerfile.py
+++ b/tools/imagegen/imagegen/dockerfile.py
@@ -16,6 +16,7 @@ class Instruction:
     cmd: str   # upper-cased, e.g. RUN, FROM, LABEL, COPY
     value: str # remainder, continuations joined, full-line comments dropped
     line: int  # 1-based line where the instruction starts
+    exec: str = ""  # executed-shell text: excludes heredoc bodies used as command stdin
 
 
 def parse(text: str) -> list[Instruction]:
@@ -41,7 +42,9 @@ def parse(text: str) -> list[Instruction]:
             i += 1
         # consume heredoc bodies so their lines aren't parsed as instructions.
         # plain <<EOF terminates only at a column-0 EOF; <<-EOF allows leading tabs.
-        pending = [(m.group(3), bool(m.group(1))) for m in _HEREDOC.finditer(buf)]
+        cmd_line = buf  # the command portion, before any heredoc body
+        has_heredoc = bool(_HEREDOC.search(cmd_line))
+        pending = [(m.group(3), bool(m.group(1))) for m in _HEREDOC.finditer(cmd_line)]
         while i < n and pending:
             body = lines[i]
             i += 1
@@ -53,7 +56,19 @@ def parse(text: str) -> list[Instruction]:
         m = re.match(r"\s*(\w+)\s*(.*)", buf, re.S)
         if not m:
             continue
-        out.append(Instruction(m.group(1).upper(), m.group(2), start))
+        cmd, value = m.group(1).upper(), m.group(2)
+        # executed-shell text: a heredoc body is executed only when the heredoc IS the
+        # script (`RUN <<EOF`); if a command precedes it (`RUN cat <<EOF`) the body is
+        # that command's stdin (data) and must be excluded from regex checks.
+        exec_text = value
+        if has_heredoc:
+            rem = _HEREDOC.sub("", cmd_line)
+            rem = re.sub(r"^\s*\w+\s*", "", rem, count=1)   # drop the instruction keyword
+            rem = re.sub(r"[><|&;].*$", "", rem, flags=re.S)  # drop redirections/operators
+            if rem.strip():  # a real command precedes the heredoc -> body is data
+                cl = re.match(r"\s*\w+\s*(.*)", cmd_line, re.S)
+                exec_text = cl.group(1) if cl else cmd_line
+        out.append(Instruction(cmd, value, start, exec_text))
     return out
 
 
@@ -123,8 +138,9 @@ def parse_ref(ref: str) -> tuple[str | None, str, str | None]:
 
 
 def code_text(instrs: list[Instruction]) -> str:
-    """Comment-free reconstruction for substring/regex checks."""
-    return "\n".join(f"{i.cmd} {i.value}" for i in instrs)
+    """Comment-free, executed-shell reconstruction for substring/regex checks
+    (heredoc data bodies excluded — see Instruction.exec)."""
+    return "\n".join(f"{i.cmd} {i.exec}" for i in instrs)
 
 
 def ini_sections(text: str) -> dict[str, dict[str, str]]:

--- a/tools/imagegen/imagegen/dockerfile.py
+++ b/tools/imagegen/imagegen/dockerfile.py
@@ -9,6 +9,8 @@ import re
 from dataclasses import dataclass
 
 _HEREDOC = re.compile(r"<<(-?)\s*([\"']?)(\w+)\2")
+# commands that execute their stdin, so a heredoc fed to them IS executed shell
+_SHELL_INTERPRETERS = {"bash", "sh", "dash", "ash", "ksh", "zsh", ".", "source"}
 
 
 @dataclass
@@ -65,7 +67,10 @@ def parse(text: str) -> list[Instruction]:
             rem = _HEREDOC.sub("", cmd_line)
             rem = re.sub(r"^\s*\w+\s*", "", rem, count=1)   # drop the instruction keyword
             rem = re.sub(r"[><|&;].*$", "", rem, flags=re.S)  # drop redirections/operators
-            if rem.strip():  # a real command precedes the heredoc -> body is data
+            lead = rem.strip().split()[0].rsplit("/", 1)[-1] if rem.strip() else ""
+            # a command before the heredoc => body is its stdin (data), UNLESS that
+            # command is a shell interpreter that EXECUTES its stdin (bash/sh/. /source).
+            if rem.strip() and lead not in _SHELL_INTERPRETERS:
                 cl = re.match(r"\s*\w+\s*(.*)", cmd_line, re.S)
                 exec_text = cl.group(1) if cl else cmd_line
         out.append(Instruction(cmd, value, start, exec_text))

--- a/tools/imagegen/imagegen/generate.py
+++ b/tools/imagegen/imagegen/generate.py
@@ -53,9 +53,10 @@ COPY ./ROOT /
 
 ARG @@NAME_UPPER@@_REF
 RUN set -euo pipefail; \\
+    [[ -n "${@@NAME_UPPER@@_REF}" ]] || { echo "Must specify @@NAME_UPPER@@_REF"; exit 1; }; \\
     . /venv/main/bin/activate; \\
     torch_versions_pre=@@SNAP@@; \\
-    : '>>> FILL: install @@NAME@@ — git clone @@NAME_UPPER@@_REF, strip torch pins, uv pip install <<<'; \\
+    : '>>> FILL: install @@NAME@@ HERE, in THIS SAME RUN, between the two snapshots — git clone @@NAME_UPPER@@_REF, strip torch pins, uv pip install. Do NOT move this into a separate RUN: that makes the drift guard a no-op the linter cannot catch. <<<'; \\
     torch_versions_post=@@SNAP@@; \\
     [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem drift for @@NAME@@"; exit 1; }
 
@@ -69,8 +70,14 @@ FROM ${@@NAME_UPPER@@_BASE} AS @@NAME@@_build
 
 @@LABELS@@
 
+SHELL ["/bin/bash", "-c"]
+WORKDIR /
 ENV DATA_DIRECTORY=/workspace \\
     WORKSPACE=/workspace \\
+    DEBIAN_FRONTEND=noninteractive \\
+    PYTHONUNBUFFERED=1 \\
+    PIP_BREAK_SYSTEM_PACKAGES=1 \\
+    UV_LINK_MODE=copy \\
     PATH=/opt/instance-tools/bin:$PATH
 
 # NOTE: the `base_image_source` stage is supplied at build time via

--- a/tools/imagegen/imagegen/generate.py
+++ b/tools/imagegen/imagegen/generate.py
@@ -1,10 +1,12 @@
 """Deterministic generator for the mechanical ~80% of a new image.
 
+Templates are modelled on the REAL repo images (comfyui, vllm), not invented.
 Emits Dockerfile + ROOT/ overlay + README + CI skeleton per class, with fenced
-fill-markers (`>>> FILL: ... <<<`) for the judgment residue a human/LLM completes.
-Output is designed to pass the linter by construction (see test_generate round-trip).
-Templating is stdlib @@TOKEN@@ substitution (no Jinja2) to keep deps minimal and
-avoid brace clashes with shell `${...}`.
+fill-markers (`>>> FILL: ... <<<`, `CHANGEME`, `FIXME:`) for the judgment residue.
+A generated image passes the STRUCTURAL linter but L040 flags it as an incomplete
+skeleton until the markers are resolved (so "lint clean" never means "ready" by
+accident). Templating is stdlib @@TOKEN@@ substitution (no Jinja2) to keep deps
+minimal and avoid brace clashes with shell `${...}`.
 """
 from __future__ import annotations
 from pathlib import Path
@@ -21,7 +23,7 @@ _LABELS = '''LABEL org.opencontainers.image.source="https://github.com/vastai/"
 LABEL org.opencontainers.image.description="@@LABEL@@ suitable for Vast.ai."
 LABEL maintainer="Vast.ai Inc <contact@vast.ai>"'''
 
-_TORCH_SNAP = (
+_SNAP = (
     '''"$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)"'''
 )
 
@@ -60,7 +62,7 @@ RUN env-hash > /.env_hash
 _DF_EXTERNAL = '''ARG VAST_BASE=vastai/base-image:CHANGEME
 ARG @@NAME_UPPER@@_BASE=@@UPSTREAM@@
 FROM ${VAST_BASE} AS vast_base_image
-FROM ${@@NAME_UPPER@@_BASE}
+FROM ${@@NAME_UPPER@@_BASE} AS @@NAME@@_build
 
 @@LABELS@@
 
@@ -70,6 +72,7 @@ ENV DATA_DIRECTORY=/workspace \\
 
 COPY --from=base_image_source /ROOT /
 COPY --from=base_image_source /portal-aio /opt/portal-aio
+COPY --from=vast_base_image /opt/portal-aio/caddy_manager/caddy /opt/portal-aio/caddy_manager/caddy
 COPY --from=base_image_source tools/convert-non-vast-image.sh /tmp/convert-non-vast-image.sh
 RUN set -euo pipefail; \\
     chmod +x /tmp/convert-non-vast-image.sh; \\
@@ -86,22 +89,33 @@ ENTRYPOINT ["/opt/instance-tools/bin/entrypoint.sh"]
 CMD []
 '''
 
+# Modelled on the real comfyui.sh: utils sourced in order; exit_portal.sh is SOURCED
+# WITH the label as $1, inside a SERVERLESS guard (it is NOT a function).
 _SUPERVISOR_SH = '''#!/bin/bash
-# Port hint: PORTAL_CONFIG entry "localhost:@@PORT@@:@@EXTPORT@@:/:@@LABEL@@"
-# (+10000 external offset is the common convention, not a hard rule.)
-utils="/opt/supervisor-scripts/utils"
+
+utils=/opt/supervisor-scripts/utils
 . "${utils}/logging.sh"
 . "${utils}/cleanup_generic.sh"
 . "${utils}/environment.sh"
-. "${utils}/exit_portal.sh"
 
-exit_portal "@@LABEL@@"
+# Serverless: skip the portal-config gate when running serverless
+if [[ "${SERVERLESS:-false}" != "true" ]]; then
+    . "${utils}/exit_portal.sh" "@@LABEL@@"
+fi
+
 . /venv/main/bin/activate
-while [ -f "/.provisioning" ]; do sleep 5; done
+
+# Wait for provisioning to complete before starting
+while [ -f "/.provisioning" ]; do
+    echo "$PROC_NAME startup paused until provisioning completes (/.provisioning present)"
+    sleep 5
+done
+
 cd "${WORKSPACE}/@@NAME@@" 2>/dev/null || cd "${WORKSPACE}"
 
-# >>> FILL: launch command for @@NAME@@ <<<
-exec true
+# >>> FILL: launch @@NAME@@ using `pty` like real images, e.g. `pty python main.py ...` <<<
+echo "FIXME: @@NAME@@ launch command not implemented" >&2
+exit 1
 '''
 
 _CONF = '''[program:@@NAME@@]
@@ -113,10 +127,12 @@ stdout_logfile=/dev/stdout
 redirect_stderr=true
 '''
 
-_CAP = '''# Capability manifest fragment for @@NAME@@
-name: @@NAME@@
-readme: README.md
-# >>> FILL: preinstalled, python_environments, etc. <<<
+# Modelled on real 50-comfyui.yaml: top-level `image:` mapping overriding the base block.
+_CAP = '''# @@LABEL@@ — image identity (overrides the base image block).
+image:
+  name: @@LABEL@@
+  readme: ">>> FILL: GitHub URL to this image's directory <<<"
+  preinstalled: ">>> FILL: e.g. PyTorch + @@LABEL@@ <<<"
 '''
 
 _AGENT = '''# @@LABEL@@
@@ -125,28 +141,42 @@ _AGENT = '''# @@LABEL@@
 > ports, where models/data live, common tasks.
 '''
 
-_README = '''# @@LABEL@@
+# README.md = developer docs; README.template.md = Vast.ai marketplace listing.
+# These are DISTINCT artifacts (see real vllm/README.md vs README.template.md).
+_README_DEV = '''# @@LABEL@@ Image
 
-Vast.ai image for @@NAME@@.
+A Vast.ai image for @@NAME@@. Includes the Instance Portal, Supervisor process
+management, and other conveniences from the Vast.ai
+[base image](https://github.com/vast-ai/base-image).
 
-> FILL: description, usage, ports, provisioning notes.
+> FILL: how this image works, available tags, environment variables.
 '''
 
+_README_TEMPLATE = '''# @@LABEL@@
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=@@NAME@@)**
+
+## What is this template?
+
+> FILL: marketplace description of @@LABEL@@ for end users — what it does and why.
+'''
+
+# external only: PORTAL_CONFIG ports are NOT internal+10000 by rule (invariants §3),
+# and must match the app's real bind port (§4) — so they are FILL markers, not baked.
 _BOOT_ENV = '''#!/bin/bash
 if [[ -z $PORTAL_CONFIG ]]; then
-  export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:@@PORT@@:@@EXTPORT@@:/:@@LABEL@@"
+  # >>> FILL: real internal:external ports + path for @@LABEL@@ (ports must match the app's bind port) <<<
+  export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:CHANGEPORT:CHANGEPORT:/:@@LABEL@@"
 fi
 '''
 
-_WORKFLOW = '''# >>> FILL: CI workflow skeleton for @@NAME@@ — complete per .github/AGENTS.md.
-# Real shape is the 5-job pipeline (preflight -> build -> merge-manifests ->
-# collect-tags -> notify); job-shape is NOT linted, so review against a sibling
-# build-*.yml before relying on this. <<<
+# CI job-shape is NOT linted and is complex (5-job pipeline); schedules are staggered,
+# NOT uniform (invariants §3) — so no cron is baked in.
+_WORKFLOW = '''# >>> FILL: CI workflow for @@NAME@@ — complete per .github/AGENTS.md. Real shape is the
+# 5-job pipeline (preflight -> build -> merge-manifests -> collect-tags -> notify);
+# review against a sibling build-*.yml. Set a STAGGERED schedule, not a uniform cron. <<<
 name: Build @@NAME@@
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0,12 * * *"
 jobs:
   preflight:
     runs-on: ubuntu-latest
@@ -170,9 +200,8 @@ def generate(repo: Path, *, name: str, cls: str, label: str, port: int,
         raise ValueError("external images require --upstream <image:tag>")
 
     sub = dict(NAME=name, NAME_UPPER=name.upper().replace("-", "_"), LABEL=label,
-               PORT=str(port), EXTPORT=str(port + 10000), UPSTREAM=upstream or "",
-               LABELS=_render(_LABELS, LABEL=label), SNAP=_TORCH_SNAP)
-
+               PORT=str(port), UPSTREAM=upstream or "",
+               LABELS=_render(_LABELS, LABEL=label), SNAP=_SNAP)
     df_tmpl = {"derivative": _DF_DERIVATIVE, "pytorch-nested": _DF_PYTORCH,
                "external": _DF_EXTERNAL}[cls]
 
@@ -185,8 +214,8 @@ def generate(repo: Path, *, name: str, cls: str, label: str, port: int,
 
     files = {
         d / "Dockerfile": _render(df_tmpl, **sub),
-        d / "README.md": _render(_README, **sub),
-        d / "README.template.md": _render(_README, **sub),
+        d / "README.md": _render(_README_DEV, **sub),
+        d / "README.template.md": _render(_README_TEMPLATE, **sub),
         root / "opt/supervisor-scripts" / f"{name}.sh": _render(_SUPERVISOR_SH, **sub),
         root / "etc/supervisor/conf.d" / f"{name}.conf": _render(_CONF, **sub),
         root / "etc/vast_capabilities.d" / f"{_CAP_NN[cls]}-{name}.yaml": _render(_CAP, **sub),

--- a/tools/imagegen/imagegen/generate.py
+++ b/tools/imagegen/imagegen/generate.py
@@ -5,8 +5,11 @@ Emits Dockerfile + ROOT/ overlay + README + CI skeleton per class, with fenced
 fill-markers (`>>> FILL: ... <<<`, `CHANGEME`, `FIXME:`) for the judgment residue.
 A generated image passes the STRUCTURAL linter but L040 flags it as an incomplete
 skeleton until the markers are resolved (so "lint clean" never means "ready" by
-accident). Templating is stdlib @@TOKEN@@ substitution (no Jinja2) to keep deps
-minimal and avoid brace clashes with shell `${...}`.
+accident). All placeholders use a single marker dialect (`>>> FILL` / `CHANGEME` /
+`CHANGEPORT`) so L040 cannot have dialect gaps; residual stub lines carry the
+marker themselves so they can't be left behind silently. Templating is stdlib
+@@TOKEN@@ substitution (no Jinja2) to keep deps minimal and avoid brace clashes
+with shell `${...}`.
 """
 from __future__ import annotations
 from pathlib import Path
@@ -17,7 +20,7 @@ _CLASS_DIR = {
     "pytorch-nested": "derivatives/pytorch/derivatives",
     "external": "external",
 }
-_CAP_NN = {"derivative": "30", "pytorch-nested": "50", "external": "50"}
+_CAP_NN = {"derivative": "30", "pytorch-nested": "50", "external": "30"}  # external grafts onto base
 
 _LABELS = '''LABEL org.opencontainers.image.source="https://github.com/vastai/"
 LABEL org.opencontainers.image.description="@@LABEL@@ suitable for Vast.ai."
@@ -70,6 +73,8 @@ ENV DATA_DIRECTORY=/workspace \\
     WORKSPACE=/workspace \\
     PATH=/opt/instance-tools/bin:$PATH
 
+# NOTE: the `base_image_source` stage is supplied at build time via
+# `--build-context base_image_source=<repo root>` (see .github/AGENTS.md).
 COPY --from=base_image_source /ROOT /
 COPY --from=base_image_source /portal-aio /opt/portal-aio
 COPY --from=vast_base_image /opt/portal-aio/caddy_manager/caddy /opt/portal-aio/caddy_manager/caddy
@@ -103,7 +108,7 @@ if [[ "${SERVERLESS:-false}" != "true" ]]; then
     . "${utils}/exit_portal.sh" "@@LABEL@@"
 fi
 
-. /venv/main/bin/activate
+[[ -f /venv/main/bin/activate ]] && . /venv/main/bin/activate
 
 # Wait for provisioning to complete before starting
 while [ -f "/.provisioning" ]; do
@@ -113,9 +118,8 @@ done
 
 cd "${WORKSPACE}/@@NAME@@" 2>/dev/null || cd "${WORKSPACE}"
 
-# >>> FILL: launch @@NAME@@ using `pty` like real images, e.g. `pty python main.py ...` <<<
-echo "FIXME: @@NAME@@ launch command not implemented" >&2
-exit 1
+# >>> FILL: launch @@NAME@@ using `pty` (e.g. `pty python main.py ...`) <<<
+exit 1  # >>> FILL: remove this line once the launch command above is in place <<<
 '''
 
 _CONF = '''[program:@@NAME@@]
@@ -137,8 +141,8 @@ image:
 
 _AGENT = '''# @@LABEL@@
 
-> FILL: how an AI agent should operate @@NAME@@ on this image — entrypoints,
-> ports, where models/data live, common tasks.
+>>> FILL: how an AI agent should operate @@NAME@@ on this image — entrypoints,
+ports, where models/data live, common tasks. <<<
 '''
 
 # README.md = developer docs; README.template.md = Vast.ai marketplace listing.
@@ -149,7 +153,7 @@ A Vast.ai image for @@NAME@@. Includes the Instance Portal, Supervisor process
 management, and other conveniences from the Vast.ai
 [base image](https://github.com/vast-ai/base-image).
 
-> FILL: how this image works, available tags, environment variables.
+>>> FILL: how this image works, available tags, environment variables. <<<
 '''
 
 _README_TEMPLATE = '''# @@LABEL@@
@@ -157,7 +161,7 @@ _README_TEMPLATE = '''# @@LABEL@@
 
 ## What is this template?
 
-> FILL: marketplace description of @@LABEL@@ for end users — what it does and why.
+>>> FILL: marketplace description of @@LABEL@@ for end users — what it does and why. <<<
 '''
 
 # external only: PORTAL_CONFIG ports are NOT internal+10000 by rule (invariants §3),

--- a/tools/imagegen/imagegen/generate.py
+++ b/tools/imagegen/imagegen/generate.py
@@ -207,8 +207,13 @@ def generate(repo: Path, *, name: str, cls: str, label: str, port: int,
     """Write the file set for a new image; returns its directory. Human picks `cls`."""
     if cls not in CLASSES:
         raise ValueError(f"unknown class {cls!r}; expected one of {CLASSES}")
+    # class-sanity (ADR cond. #3): the --upstream signal must agree with the class.
+    # (Lint-time path<->FROM class consistency is enforced by L004.)
     if cls == "external" and not upstream:
         raise ValueError("external images require --upstream <image:tag>")
+    if cls != "external" and upstream:
+        raise ValueError(f"--upstream is only valid for external images, not {cls} "
+                         "(did you mean --class external?)")
 
     sub = dict(NAME=name, NAME_UPPER=name.upper().replace("-", "_"), LABEL=label,
                PORT=str(port), UPSTREAM=upstream or "",

--- a/tools/imagegen/imagegen/generate.py
+++ b/tools/imagegen/imagegen/generate.py
@@ -1,0 +1,205 @@
+"""Deterministic generator for the mechanical ~80% of a new image.
+
+Emits Dockerfile + ROOT/ overlay + README + CI skeleton per class, with fenced
+fill-markers (`>>> FILL: ... <<<`) for the judgment residue a human/LLM completes.
+Output is designed to pass the linter by construction (see test_generate round-trip).
+Templating is stdlib @@TOKEN@@ substitution (no Jinja2) to keep deps minimal and
+avoid brace clashes with shell `${...}`.
+"""
+from __future__ import annotations
+from pathlib import Path
+
+CLASSES = ("derivative", "pytorch-nested", "external")
+_CLASS_DIR = {
+    "derivative": "derivatives",
+    "pytorch-nested": "derivatives/pytorch/derivatives",
+    "external": "external",
+}
+_CAP_NN = {"derivative": "30", "pytorch-nested": "50", "external": "50"}
+
+_LABELS = '''LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="@@LABEL@@ suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"'''
+
+_TORCH_SNAP = (
+    '''"$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)"'''
+)
+
+_DF_DERIVATIVE = '''ARG VAST_BASE=vastai/base-image:CHANGEME
+FROM ${VAST_BASE}
+
+@@LABELS@@
+
+COPY ./ROOT /
+
+RUN set -euo pipefail; \\
+    . /venv/main/bin/activate; \\
+    : '>>> FILL: install @@NAME@@ here (apt/uv pip install, build, etc.) <<<'
+
+RUN env-hash > /.env_hash
+'''
+
+_DF_PYTORCH = '''ARG PYTORCH_BASE=vastai/pytorch:CHANGEME
+FROM ${PYTORCH_BASE}
+
+@@LABELS@@
+
+COPY ./ROOT /
+
+ARG @@NAME_UPPER@@_REF
+RUN set -euo pipefail; \\
+    . /venv/main/bin/activate; \\
+    torch_versions_pre=@@SNAP@@; \\
+    : '>>> FILL: install @@NAME@@ — git clone @@NAME_UPPER@@_REF, strip torch pins, uv pip install <<<'; \\
+    torch_versions_post=@@SNAP@@; \\
+    [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem drift for @@NAME@@"; exit 1; }
+
+RUN env-hash > /.env_hash
+'''
+
+_DF_EXTERNAL = '''ARG VAST_BASE=vastai/base-image:CHANGEME
+ARG @@NAME_UPPER@@_BASE=@@UPSTREAM@@
+FROM ${VAST_BASE} AS vast_base_image
+FROM ${@@NAME_UPPER@@_BASE}
+
+@@LABELS@@
+
+ENV DATA_DIRECTORY=/workspace \\
+    WORKSPACE=/workspace \\
+    PATH=/opt/instance-tools/bin:$PATH
+
+COPY --from=base_image_source /ROOT /
+COPY --from=base_image_source /portal-aio /opt/portal-aio
+COPY --from=base_image_source tools/convert-non-vast-image.sh /tmp/convert-non-vast-image.sh
+RUN set -euo pipefail; \\
+    chmod +x /tmp/convert-non-vast-image.sh; \\
+    /tmp/convert-non-vast-image.sh; \\
+    rm /tmp/convert-non-vast-image.sh
+
+COPY ./ROOT /
+
+RUN set -euo pipefail; \\
+    : '>>> FILL: install/configure @@NAME@@ on top of the upstream image <<<'
+
+RUN env-hash > /.env_hash
+ENTRYPOINT ["/opt/instance-tools/bin/entrypoint.sh"]
+CMD []
+'''
+
+_SUPERVISOR_SH = '''#!/bin/bash
+# Port hint: PORTAL_CONFIG entry "localhost:@@PORT@@:@@EXTPORT@@:/:@@LABEL@@"
+# (+10000 external offset is the common convention, not a hard rule.)
+utils="/opt/supervisor-scripts/utils"
+. "${utils}/logging.sh"
+. "${utils}/cleanup_generic.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh"
+
+exit_portal "@@LABEL@@"
+. /venv/main/bin/activate
+while [ -f "/.provisioning" ]; do sleep 5; done
+cd "${WORKSPACE}/@@NAME@@" 2>/dev/null || cd "${WORKSPACE}"
+
+# >>> FILL: launch command for @@NAME@@ <<<
+exec true
+'''
+
+_CONF = '''[program:@@NAME@@]
+environment=PROC_NAME="%(program_name)s"
+command=/opt/supervisor-scripts/@@NAME@@.sh
+autostart=true
+autorestart=unexpected
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+'''
+
+_CAP = '''# Capability manifest fragment for @@NAME@@
+name: @@NAME@@
+readme: README.md
+# >>> FILL: preinstalled, python_environments, etc. <<<
+'''
+
+_AGENT = '''# @@LABEL@@
+
+> FILL: how an AI agent should operate @@NAME@@ on this image — entrypoints,
+> ports, where models/data live, common tasks.
+'''
+
+_README = '''# @@LABEL@@
+
+Vast.ai image for @@NAME@@.
+
+> FILL: description, usage, ports, provisioning notes.
+'''
+
+_BOOT_ENV = '''#!/bin/bash
+if [[ -z $PORTAL_CONFIG ]]; then
+  export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:@@PORT@@:@@EXTPORT@@:/:@@LABEL@@"
+fi
+'''
+
+_WORKFLOW = '''# >>> FILL: CI workflow skeleton for @@NAME@@ — complete per .github/AGENTS.md.
+# Real shape is the 5-job pipeline (preflight -> build -> merge-manifests ->
+# collect-tags -> notify); job-shape is NOT linted, so review against a sibling
+# build-*.yml before relying on this. <<<
+name: Build @@NAME@@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0,12 * * *"
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo ">>> FILL <<<"'
+'''
+
+
+def _render(tmpl: str, **kw: str) -> str:
+    for k, v in kw.items():
+        tmpl = tmpl.replace(f"@@{k}@@", v)
+    return tmpl
+
+
+def generate(repo: Path, *, name: str, cls: str, label: str, port: int,
+             upstream: str | None = None) -> Path:
+    """Write the file set for a new image; returns its directory. Human picks `cls`."""
+    if cls not in CLASSES:
+        raise ValueError(f"unknown class {cls!r}; expected one of {CLASSES}")
+    if cls == "external" and not upstream:
+        raise ValueError("external images require --upstream <image:tag>")
+
+    sub = dict(NAME=name, NAME_UPPER=name.upper().replace("-", "_"), LABEL=label,
+               PORT=str(port), EXTPORT=str(port + 10000), UPSTREAM=upstream or "",
+               LABELS=_render(_LABELS, LABEL=label), SNAP=_TORCH_SNAP)
+
+    df_tmpl = {"derivative": _DF_DERIVATIVE, "pytorch-nested": _DF_PYTORCH,
+               "external": _DF_EXTERNAL}[cls]
+
+    d = repo / _CLASS_DIR[cls] / name
+    root = d / "ROOT"
+    (root / "opt/supervisor-scripts").mkdir(parents=True, exist_ok=True)
+    (root / "etc/supervisor/conf.d").mkdir(parents=True, exist_ok=True)
+    (root / "etc/vast_capabilities.d").mkdir(parents=True, exist_ok=True)
+    (root / "etc/vast_agents").mkdir(parents=True, exist_ok=True)
+
+    files = {
+        d / "Dockerfile": _render(df_tmpl, **sub),
+        d / "README.md": _render(_README, **sub),
+        d / "README.template.md": _render(_README, **sub),
+        root / "opt/supervisor-scripts" / f"{name}.sh": _render(_SUPERVISOR_SH, **sub),
+        root / "etc/supervisor/conf.d" / f"{name}.conf": _render(_CONF, **sub),
+        root / "etc/vast_capabilities.d" / f"{_CAP_NN[cls]}-{name}.yaml": _render(_CAP, **sub),
+        root / "etc/vast_agents" / f"{name}.md": _render(_AGENT, **sub),
+    }
+    if cls == "external":
+        (root / "etc/vast_boot.d").mkdir(parents=True, exist_ok=True)
+        files[root / "etc/vast_boot.d" / f"05-{name}-env.sh"] = _render(_BOOT_ENV, **sub)
+
+    wf = repo / ".github/workflows" / f"build-{name}.yml"
+    wf.parent.mkdir(parents=True, exist_ok=True)
+    files[wf] = _render(_WORKFLOW, **sub)
+
+    for path, content in files.items():
+        path.write_text(content, encoding="utf-8")
+    return d

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -208,6 +208,36 @@ def check_workflow(img: Image, repo: Path) -> Iterable[Finding]:
         yield Finding("L030", WARN, img.name, ".github/workflows", f"no build-{img.name}.yml (may build via a shared workflow)")
 
 
+_SKELETON_MARKERS = ("CHANGEME", "CHANGEPORT", ">>> FILL")
+
+
+def check_skeleton(img: Image, repo: Path) -> Iterable[Finding]:
+    """L040 — unfilled generator markers must not pass as 'clean'. So a scaffold can
+    never be mistaken for a complete, buildable image. Scoped to the image's own files."""
+    if img.cls == "base":
+        return
+    files = [img.dockerfile, img.dir / "README.md", img.dir / "README.template.md"]
+    if img.root:
+        files += [p for p in img.root.rglob("*") if p.is_file()]
+    wf = repo / ".github" / "workflows" / f"build-{img.name}.yml"
+    if wf.exists():
+        files.append(wf)
+    for p in files:
+        if not p.is_file():
+            continue
+        try:
+            t = p.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            continue
+        if any(mk in t for mk in _SKELETON_MARKERS):
+            try:
+                rel = str(p.relative_to(img.dir))
+            except ValueError:
+                rel = str(p.name)
+            yield Finding("L040", ERROR, img.name, rel,
+                          "unfilled skeleton marker (CHANGEME / >>> FILL) — complete before build")
+
+
 IMAGE_CHECKS: list[Callable[[Image], Iterable[Finding]]] = [
     check_labels, check_env_hash, check_copy_root, check_from_class,
     check_torch_guard, check_no_auto_backend, check_uv_pip,
@@ -225,6 +255,7 @@ def lint_image(img: Image, repo: Path, *, apply_exceptions: bool = True) -> list
     for chk in IMAGE_CHECKS:
         out.extend(chk(img))
     out.extend(check_workflow(img, repo))
+    out.extend(check_skeleton(img, repo))
     if apply_exceptions:
         out = [f for f in out if not _suppressed(img.name, f)]
     return out

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -43,6 +43,39 @@ EXCEPTIONS: dict[tuple[str, str], tuple[str, str]] = {
 CANONICAL_UTILS = ["logging", "cleanup_generic", "environment", "exit_serverless", "exit_portal"]
 REQUIRED_LABEL_KEYS = ["org.opencontainers.image.source", "org.opencontainers.image.description", "maintainer"]
 
+# Authoritative rule catalog — the single source of truth. docs/lint-rules.md is
+# GENERATED from this (see rules_markdown / `imagegen rules`), and a test fails if
+# they drift, so the docs can never silently disagree with the enforced checks.
+RULES: list[tuple[str, str, str]] = [
+    ("L001", ERROR, "Exactly 3 LABEL key=value pairs, including the required keys"),
+    ("L002", ERROR, "`env-hash > /.env_hash` is the final RUN (executed shell, not heredoc data)"),
+    ("L003", ERROR, "A local `COPY ./ROOT /` is present"),
+    ("L004", ERROR, "FROM matches the declared class — structural base identity (registry+repo), incl. external stage order"),
+    ("L010", ERROR, "Each [program:NAME]: PROC_NAME + command=/opt/supervisor-scripts/NAME.sh; file stem is a program"),
+    ("L011", ERROR, "Sourced utils appear as an ordered subsequence of the canonical order"),
+    ("L020", ERROR, "torch-drift guard: a pre==post comparison wired to an exit on the same statement"),
+    ("L021", ERROR, "No `--torch-backend auto` except inside a real sed substitution"),
+    ("L022", WARN, "Prefer `uv pip install` over bare `pip install`"),
+    ("L030", WARN, "A build-<name>.yml workflow exists (not universal)"),
+    ("L040", ERROR, "No unfilled generator skeleton markers (CHANGEME / CHANGEPORT / >>> FILL)"),
+]
+
+
+def rules_markdown() -> str:
+    """Render docs/lint-rules.md from RULES. Regenerate with `imagegen rules`."""
+    lines = [
+        "# Lint rules (generated)",
+        "",
+        "> Generated from `tools/imagegen/imagegen/linter.py` (`RULES`). Do not edit by",
+        "> hand — run `imagegen rules > docs/lint-rules.md`. This is the authoritative",
+        "> rule list; `CONTRIBUTING.md` / `.github/AGENTS.md` must not contradict it.",
+        "",
+        "| Code | Severity | Rule |",
+        "|---|---|---|",
+    ]
+    lines += [f"| {code} | {sev} | {summary} |" for code, sev, summary in RULES]
+    return "\n".join(lines) + "\n"
+
 
 # ---- Dockerfile checks ------------------------------------------------------
 

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -1,8 +1,12 @@
 """Invariant checks. Scope = docs/invariants.md §1-2 (the verified gateable set).
 
-Each check is a function (Image) -> Iterable[Finding]. ERROR findings gate;
-WARN findings are advisory. Per-image exceptions (real, documented divergences)
-are suppressed via EXCEPTIONS so the baseline stays clean and honest.
+Checks are instruction-aware (see dockerfile.py) so keywords in comments, across
+continuations, or in the wrong position don't produce false passes. Each check is
+a function (Image) -> Iterable[Finding]. ERROR gates; WARN is advisory.
+
+Per-image exceptions (real, documented divergences) are SCOPED to a message
+substring, not a whole check — so a *different* future break of the same code is
+NOT silently suppressed (tested by test_no_stale_exceptions).
 """
 from __future__ import annotations
 import re
@@ -11,6 +15,7 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 from .discover import Image
+from .dockerfile import parse, stages, code_text, ini_sections
 
 ERROR = "ERROR"
 WARN = "WARN"
@@ -25,152 +30,159 @@ class Finding:
     msg: str
 
 
-# Documented, verified exceptions (docs/invariants.md §2). (image_name, code) -> reason.
-EXCEPTIONS: dict[tuple[str, str], str] = {
-    ("aio-studio", "L004"): "builds on custom robatvastai/aio-studio:base-* (invariants §2)",
-    ("aio-studio", "L020"): "uses per-app venvs, not a single /venv/main torch guard (invariants §2)",
+# Scoped, verified exceptions: (image, code) -> (reason, msg_substring_to_suppress).
+EXCEPTIONS: dict[tuple[str, str], tuple[str, str]] = {
+    ("aio-studio", "L004"): ("builds on custom robatvastai/aio-studio:base-* (invariants §2)",
+                             "must derive from vastai/pytorch"),
+    ("aio-studio", "L020"): ("uses per-app venvs, not a single /venv/main guard (invariants §2)",
+                             "torch-drift guard"),
 }
 
 CANONICAL_UTILS = ["logging", "cleanup_generic", "environment", "exit_serverless", "exit_portal"]
+REQUIRED_LABEL_KEYS = ["org.opencontainers.image.source", "org.opencontainers.image.description", "maintainer"]
 
 
-# ---- Dockerfile checks (all classes) ----------------------------------------
+# ---- Dockerfile checks ------------------------------------------------------
 
 def check_labels(img: Image) -> Iterable[Finding]:
-    """L001 — exactly 3 LABEL instructions."""
-    n = len(re.findall(r"(?im)^\s*LABEL\b", img.text))
-    if n != 3:
-        yield Finding("L001", ERROR, img.name, "Dockerfile", f"expected exactly 3 LABEL lines, found {n}")
+    """L001 — exactly 3 LABEL instructions with the required keys."""
+    labels = [i for i in parse(img.text) if i.cmd == "LABEL"]
+    if len(labels) != 3:
+        yield Finding("L001", ERROR, img.name, "Dockerfile", f"expected exactly 3 LABEL instructions, found {len(labels)}")
+    blob = " ".join(l.value for l in labels)
+    for key in REQUIRED_LABEL_KEYS:
+        if key not in blob:
+            yield Finding("L001", ERROR, img.name, "Dockerfile", f"missing required LABEL key: {key}")
 
 
 def check_env_hash(img: Image) -> Iterable[Finding]:
-    """L002 — env-hash > /.env_hash trailer present."""
-    if "env-hash > /.env_hash" not in img.text:
-        yield Finding("L002", ERROR, img.name, "Dockerfile", "missing `env-hash > /.env_hash` build step")
+    """L002 — env-hash > /.env_hash is the FINAL RUN (not commented, not stale)."""
+    runs = [i for i in parse(img.text) if i.cmd == "RUN"]
+    if not runs or "env-hash > /.env_hash" not in runs[-1].value:
+        yield Finding("L002", ERROR, img.name, "Dockerfile", "`env-hash > /.env_hash` must be the final RUN instruction")
 
 
 def check_copy_root(img: Image) -> Iterable[Finding]:
-    """L003 — COPY ./ROOT / present (trailing slash on ROOT tolerated)."""
-    if not re.search(r"(?im)^\s*COPY\s+\./ROOT/?\s+/\s*$", img.text):
-        yield Finding("L003", ERROR, img.name, "Dockerfile", "missing `COPY ./ROOT /`")
+    """L003 — a local `COPY ./ROOT /` (not the external --from copy)."""
+    copies = [i for i in parse(img.text) if i.cmd == "COPY"]
+    if not any(re.fullmatch(r"\./ROOT/?\s+/", c.value.strip()) for c in copies):
+        yield Finding("L003", ERROR, img.name, "Dockerfile", "missing local `COPY ./ROOT /`")
 
 
 def check_from_class(img: Image) -> Iterable[Finding]:
-    """L004 — FROM matches declared class."""
-    t = img.text
+    """L004 — FROM matches declared class (stage identity + order for external)."""
+    instrs = parse(img.text)
+    ct = code_text(instrs)
     if img.cls == "derivative":
-        # Base is usually pinned inline (vastai/base-image:...). The pytorch hub
-        # instead injects it via build-arg (ARG VAST_BASE, no default) in CI —
-        # the actual value is build-arg-verified, a linter blind spot (invariants §4).
-        inline = "vastai/base-image" in t
-        via_arg = bool(re.search(r"(?im)^\s*ARG\s+VAST_BASE\b", t) and re.search(r"\$\{?VAST_BASE\}?", t))
+        inline = "vastai/base-image" in ct
+        via_arg = bool(any(i.cmd == "ARG" and re.match(r"VAST_BASE\b", i.value) for i in instrs)
+                       and re.search(r"\$\{?VAST_BASE\}?", ct))
         if not (inline or via_arg):
             yield Finding("L004", ERROR, img.name, "Dockerfile", "derivative must derive from vastai/base-image")
     elif img.cls == "pytorch-nested":
-        if "vastai/pytorch" not in t:
+        if "vastai/pytorch" not in ct:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "pytorch-nested must derive from vastai/pytorch")
     elif img.cls == "external":
-        if "vast_base_image" not in t:
+        sts = stages(instrs)
+        aliases = [a for _, a in sts]
+        if "vast_base_image" not in aliases:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "external must have a `FROM ... AS vast_base_image` stage")
-        if "convert-non-vast-image.sh" not in t:
+        elif sts[0][1] != "vast_base_image":
+            yield Finding("L004", ERROR, img.name, "Dockerfile", "external stage order: vast_base_image must be the FIRST FROM")
+        if "vastai/base-image" not in ct:
+            yield Finding("L004", ERROR, img.name, "Dockerfile", "external vast stage must be vastai/base-image")
+        if "convert-non-vast-image.sh" not in ct:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "external must graft via convert-non-vast-image.sh")
 
 
-# ---- pytorch-nested checks --------------------------------------------------
-
 def check_torch_guard(img: Image) -> Iterable[Finding]:
-    """L020 — torch ecosystem drift guard present."""
+    """L020 — torch-drift guard with an actual pre==post comparison that exits."""
     if img.cls != "pytorch-nested":
         return
-    if not ("torch_versions_pre" in img.text and "torch_versions_post" in img.text):
-        yield Finding("L020", ERROR, img.name, "Dockerfile", "missing torch-drift guard (torch_versions_pre/post)")
+    ct = code_text(parse(img.text))
+    has_cmp = re.search(r'\$torch_versions_pre"?\s*=\s*"?\$torch_versions_post', ct)
+    if not has_cmp:
+        yield Finding("L020", ERROR, img.name, "Dockerfile", "missing torch-drift guard comparison (pre == post)")
+    elif "exit 1" not in ct:
+        yield Finding("L020", ERROR, img.name, "Dockerfile", "torch-drift guard does not `exit 1` on drift")
 
 
 def check_no_auto_backend(img: Image) -> Iterable[Finding]:
-    """L021 — no surviving `--torch-backend auto` as an install argument."""
+    """L021 — no `--torch-backend auto` except inside a real sed substitution."""
     if img.cls not in ("pytorch-nested", "external"):
         return
-    for i, line in enumerate(img.text.splitlines(), 1):
-        if re.search(r"--torch-backend[ =]auto", line) and "sed" not in line:
-            yield Finding("L021", ERROR, img.name, "Dockerfile", f"line {i}: `--torch-backend auto` must be a concrete backend")
+    for line in code_text(parse(img.text)).splitlines():
+        if re.search(r"--torch-backend[ =]auto", line) and not re.search(r"sed\b.*s[|/#@].*auto", line):
+            yield Finding("L021", ERROR, img.name, "Dockerfile", "`--torch-backend auto` must be a concrete backend")
 
 
 def check_uv_pip(img: Image) -> Iterable[Finding]:
-    """L022 — prefer `uv pip`, not bare pip (advisory)."""
+    """L022 — prefer `uv pip` over bare pip (advisory)."""
     if img.cls != "pytorch-nested":
         return
-    for i, line in enumerate(img.text.splitlines(), 1):
+    for line in code_text(parse(img.text)).splitlines():
         if re.search(r"(?<![\w/])pip\s+install\b", line) and not re.search(r"\buv\s+pip\s+install\b", line):
-            yield Finding("L022", WARN, img.name, "Dockerfile", f"line {i}: bare `pip install` (prefer `uv pip install`)")
+            yield Finding("L022", WARN, img.name, "Dockerfile", "bare `pip install` (prefer `uv pip install`)")
 
 
 # ---- ROOT/ overlay checks (supervisor) --------------------------------------
 
 def check_conf_triple(img: Image) -> Iterable[Finding]:
-    """L010 — conf.d ↔ script ↔ program-name triple (invariants §1, strongest)."""
+    """L010 — every [program:NAME] has PROC_NAME + command=/opt/.../NAME.sh; file stem is a program."""
     if not img.root:
         return
     confd = img.root / "etc" / "supervisor" / "conf.d"
     if not confd.is_dir():
         return
     for conf in sorted(confd.glob("*.conf")):
-        stem = conf.stem
-        text = conf.read_text(encoding="utf-8", errors="replace")
         rel = str(conf.relative_to(img.dir))
-        names = re.findall(r"(?im)^\s*\[program:([^\]]+)\]", text)
-        if stem not in names:
-            yield Finding("L010", ERROR, img.name, rel, f"[program:{stem}] not found (sections: {names or 'none'})")
-        if not re.search(r'(?im)^\s*environment\s*=.*PROC_NAME', text):
-            yield Finding("L010", ERROR, img.name, rel, 'missing `environment=PROC_NAME="%(program_name)s"`')
-        m = re.search(r"(?im)^\s*command\s*=\s*(\S+)", text)
-        if not m or not re.match(r"/opt/supervisor-scripts/\S+\.sh", m.group(1)):
-            yield Finding("L010", ERROR, img.name, rel, "command must point to /opt/supervisor-scripts/<name>.sh")
-        else:
-            script = img.root / "opt" / "supervisor-scripts" / Path(m.group(1)).name
-            if not script.exists():
-                yield Finding("L010", WARN, img.name, rel, f"command target {Path(m.group(1)).name} not in this image's ROOT (may inherit from base)")
+        secs = ini_sections(conf.read_text(encoding="utf-8", errors="replace"))
+        programs = {name.split(":", 1)[1]: kv for name, kv in secs.items() if name.startswith("program:")}
+        if conf.stem not in programs:
+            yield Finding("L010", ERROR, img.name, rel, f"no [program:{conf.stem}] matching the file name (programs: {sorted(programs) or 'none'})")
+        for pname, kv in programs.items():
+            if "PROC_NAME" not in kv.get("environment", ""):
+                yield Finding("L010", ERROR, img.name, rel, f"[program:{pname}] missing environment PROC_NAME")
+            m = re.match(r"/opt/supervisor-scripts/(\S+)\.sh", kv.get("command", ""))
+            if not m:
+                yield Finding("L010", ERROR, img.name, rel, f"[program:{pname}] command must be /opt/supervisor-scripts/*.sh")
+            elif m.group(1) != pname:
+                yield Finding("L010", ERROR, img.name, rel, f"[program:{pname}] command targets {m.group(1)}.sh (basename != program name)")
+            elif not (img.root / "opt" / "supervisor-scripts" / f"{pname}.sh").exists():
+                yield Finding("L010", WARN, img.name, rel, f"{pname}.sh not in this image's ROOT (may inherit from base)")
 
 
 def check_util_order(img: Image) -> Iterable[Finding]:
     """L011 — sourced utils appear as an ordered subsequence of CANONICAL_UTILS."""
     if not img.root:
         return
-    scripts_dir = img.root / "opt" / "supervisor-scripts"
-    if not scripts_dir.is_dir():
+    sdir = img.root / "opt" / "supervisor-scripts"
+    if not sdir.is_dir():
         return
-    for script in sorted(scripts_dir.glob("*.sh")):
-        text = script.read_text(encoding="utf-8", errors="replace")
+    for script in sorted(sdir.glob("*.sh")):
         rel = str(script.relative_to(img.dir))
-        seq: list[tuple[int, str]] = []  # (canonical_index, name) in file order
-        for line in text.splitlines():
-            if "utils" not in line:
+        seq: list[str] = []
+        for line in script.read_text(encoding="utf-8", errors="replace").splitlines():
+            if not re.match(r"\s*(\.|source)\s", line):  # only `source`/`.` lines
                 continue
-            # matches both `${utils}/name.sh` and `/opt/supervisor-scripts/utils/name.sh`
-            for idx, name in enumerate(CANONICAL_UTILS):
-                if re.search(rf"utils[^/]*/{re.escape(name)}\.sh", line):
-                    seq.append((idx, name))
-        last = -1
-        for idx, name in seq:
-            if idx < last:
-                ordered = [n for _, n in seq]
-                yield Finding("L011", ERROR, img.name, rel,
-                              f"util source order violates canonical order at {name}: {ordered}")
-                break
-            last = idx
+            for name in CANONICAL_UTILS:
+                if re.search(rf"""(?:^|[/"'\s]){re.escape(name)}\.sh\b""", line):
+                    seq.append(name)
+        idxs = [CANONICAL_UTILS.index(n) for n in seq]
+        if any(b < a for a, b in zip(idxs, idxs[1:])):
+            yield Finding("L011", ERROR, img.name, rel, f"util source order violates canonical order: {seq}")
 
 
-# ---- CI workflow checks (advisory in v1) ------------------------------------
+# ---- CI workflow (advisory) -------------------------------------------------
 
 def check_workflow(img: Image, repo: Path) -> Iterable[Finding]:
-    """L030 — a build-<name>.yml workflow exists (advisory)."""
-    wf = repo / ".github" / "workflows" / f"build-{img.name}.yml"
-    if not wf.exists():
-        yield Finding("L030", WARN, img.name, ".github/workflows", f"no build-{img.name}.yml (CI job-shape check deferred)")
+    """L030 — a build-<name>.yml workflow exists (advisory; not all images have one)."""
+    if img.cls == "base":
+        return
+    if not (repo / ".github" / "workflows" / f"build-{img.name}.yml").exists():
+        yield Finding("L030", WARN, img.name, ".github/workflows", f"no build-{img.name}.yml (may build via a shared workflow)")
 
 
-# -----------------------------------------------------------------------------
-
-# checks that only need the Image
 IMAGE_CHECKS: list[Callable[[Image], Iterable[Finding]]] = [
     check_labels, check_env_hash, check_copy_root, check_from_class,
     check_torch_guard, check_no_auto_backend, check_uv_pip,
@@ -178,10 +190,16 @@ IMAGE_CHECKS: list[Callable[[Image], Iterable[Finding]]] = [
 ]
 
 
-def lint_image(img: Image, repo: Path) -> list[Finding]:
+def _suppressed(img_name: str, f: Finding) -> bool:
+    ex = EXCEPTIONS.get((img_name, f.code))
+    return bool(ex and ex[1] in f.msg)
+
+
+def lint_image(img: Image, repo: Path, *, apply_exceptions: bool = True) -> list[Finding]:
     out: list[Finding] = []
     for chk in IMAGE_CHECKS:
         out.extend(chk(img))
     out.extend(check_workflow(img, repo))
-    # drop documented exceptions
-    return [f for f in out if (img.name, f.code) not in EXCEPTIONS]
+    if apply_exceptions:
+        out = [f for f in out if not _suppressed(img.name, f)]
+    return out

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -1,0 +1,187 @@
+"""Invariant checks. Scope = docs/invariants.md §1-2 (the verified gateable set).
+
+Each check is a function (Image) -> Iterable[Finding]. ERROR findings gate;
+WARN findings are advisory. Per-image exceptions (real, documented divergences)
+are suppressed via EXCEPTIONS so the baseline stays clean and honest.
+"""
+from __future__ import annotations
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+from .discover import Image
+
+ERROR = "ERROR"
+WARN = "WARN"
+
+
+@dataclass
+class Finding:
+    code: str
+    severity: str
+    image: str
+    path: str
+    msg: str
+
+
+# Documented, verified exceptions (docs/invariants.md §2). (image_name, code) -> reason.
+EXCEPTIONS: dict[tuple[str, str], str] = {
+    ("aio-studio", "L004"): "builds on custom robatvastai/aio-studio:base-* (invariants §2)",
+    ("aio-studio", "L020"): "uses per-app venvs, not a single /venv/main torch guard (invariants §2)",
+}
+
+CANONICAL_UTILS = ["logging", "cleanup_generic", "environment", "exit_serverless", "exit_portal"]
+
+
+# ---- Dockerfile checks (all classes) ----------------------------------------
+
+def check_labels(img: Image) -> Iterable[Finding]:
+    """L001 — exactly 3 LABEL instructions."""
+    n = len(re.findall(r"(?im)^\s*LABEL\b", img.text))
+    if n != 3:
+        yield Finding("L001", ERROR, img.name, "Dockerfile", f"expected exactly 3 LABEL lines, found {n}")
+
+
+def check_env_hash(img: Image) -> Iterable[Finding]:
+    """L002 — env-hash > /.env_hash trailer present."""
+    if "env-hash > /.env_hash" not in img.text:
+        yield Finding("L002", ERROR, img.name, "Dockerfile", "missing `env-hash > /.env_hash` build step")
+
+
+def check_copy_root(img: Image) -> Iterable[Finding]:
+    """L003 — COPY ./ROOT / present (trailing slash on ROOT tolerated)."""
+    if not re.search(r"(?im)^\s*COPY\s+\./ROOT/?\s+/\s*$", img.text):
+        yield Finding("L003", ERROR, img.name, "Dockerfile", "missing `COPY ./ROOT /`")
+
+
+def check_from_class(img: Image) -> Iterable[Finding]:
+    """L004 — FROM matches declared class."""
+    t = img.text
+    if img.cls == "derivative":
+        # Base is usually pinned inline (vastai/base-image:...). The pytorch hub
+        # instead injects it via build-arg (ARG VAST_BASE, no default) in CI —
+        # the actual value is build-arg-verified, a linter blind spot (invariants §4).
+        inline = "vastai/base-image" in t
+        via_arg = bool(re.search(r"(?im)^\s*ARG\s+VAST_BASE\b", t) and re.search(r"\$\{?VAST_BASE\}?", t))
+        if not (inline or via_arg):
+            yield Finding("L004", ERROR, img.name, "Dockerfile", "derivative must derive from vastai/base-image")
+    elif img.cls == "pytorch-nested":
+        if "vastai/pytorch" not in t:
+            yield Finding("L004", ERROR, img.name, "Dockerfile", "pytorch-nested must derive from vastai/pytorch")
+    elif img.cls == "external":
+        if "vast_base_image" not in t:
+            yield Finding("L004", ERROR, img.name, "Dockerfile", "external must have a `FROM ... AS vast_base_image` stage")
+        if "convert-non-vast-image.sh" not in t:
+            yield Finding("L004", ERROR, img.name, "Dockerfile", "external must graft via convert-non-vast-image.sh")
+
+
+# ---- pytorch-nested checks --------------------------------------------------
+
+def check_torch_guard(img: Image) -> Iterable[Finding]:
+    """L020 — torch ecosystem drift guard present."""
+    if img.cls != "pytorch-nested":
+        return
+    if not ("torch_versions_pre" in img.text and "torch_versions_post" in img.text):
+        yield Finding("L020", ERROR, img.name, "Dockerfile", "missing torch-drift guard (torch_versions_pre/post)")
+
+
+def check_no_auto_backend(img: Image) -> Iterable[Finding]:
+    """L021 — no surviving `--torch-backend auto` as an install argument."""
+    if img.cls not in ("pytorch-nested", "external"):
+        return
+    for i, line in enumerate(img.text.splitlines(), 1):
+        if re.search(r"--torch-backend[ =]auto", line) and "sed" not in line:
+            yield Finding("L021", ERROR, img.name, "Dockerfile", f"line {i}: `--torch-backend auto` must be a concrete backend")
+
+
+def check_uv_pip(img: Image) -> Iterable[Finding]:
+    """L022 — prefer `uv pip`, not bare pip (advisory)."""
+    if img.cls != "pytorch-nested":
+        return
+    for i, line in enumerate(img.text.splitlines(), 1):
+        if re.search(r"(?<![\w/])pip\s+install\b", line) and not re.search(r"\buv\s+pip\s+install\b", line):
+            yield Finding("L022", WARN, img.name, "Dockerfile", f"line {i}: bare `pip install` (prefer `uv pip install`)")
+
+
+# ---- ROOT/ overlay checks (supervisor) --------------------------------------
+
+def check_conf_triple(img: Image) -> Iterable[Finding]:
+    """L010 — conf.d ↔ script ↔ program-name triple (invariants §1, strongest)."""
+    if not img.root:
+        return
+    confd = img.root / "etc" / "supervisor" / "conf.d"
+    if not confd.is_dir():
+        return
+    for conf in sorted(confd.glob("*.conf")):
+        stem = conf.stem
+        text = conf.read_text(encoding="utf-8", errors="replace")
+        rel = str(conf.relative_to(img.dir))
+        names = re.findall(r"(?im)^\s*\[program:([^\]]+)\]", text)
+        if stem not in names:
+            yield Finding("L010", ERROR, img.name, rel, f"[program:{stem}] not found (sections: {names or 'none'})")
+        if not re.search(r'(?im)^\s*environment\s*=.*PROC_NAME', text):
+            yield Finding("L010", ERROR, img.name, rel, 'missing `environment=PROC_NAME="%(program_name)s"`')
+        m = re.search(r"(?im)^\s*command\s*=\s*(\S+)", text)
+        if not m or not re.match(r"/opt/supervisor-scripts/\S+\.sh", m.group(1)):
+            yield Finding("L010", ERROR, img.name, rel, "command must point to /opt/supervisor-scripts/<name>.sh")
+        else:
+            script = img.root / "opt" / "supervisor-scripts" / Path(m.group(1)).name
+            if not script.exists():
+                yield Finding("L010", WARN, img.name, rel, f"command target {Path(m.group(1)).name} not in this image's ROOT (may inherit from base)")
+
+
+def check_util_order(img: Image) -> Iterable[Finding]:
+    """L011 — sourced utils appear as an ordered subsequence of CANONICAL_UTILS."""
+    if not img.root:
+        return
+    scripts_dir = img.root / "opt" / "supervisor-scripts"
+    if not scripts_dir.is_dir():
+        return
+    for script in sorted(scripts_dir.glob("*.sh")):
+        text = script.read_text(encoding="utf-8", errors="replace")
+        rel = str(script.relative_to(img.dir))
+        seq: list[tuple[int, str]] = []  # (canonical_index, name) in file order
+        for line in text.splitlines():
+            if "utils" not in line:
+                continue
+            # matches both `${utils}/name.sh` and `/opt/supervisor-scripts/utils/name.sh`
+            for idx, name in enumerate(CANONICAL_UTILS):
+                if re.search(rf"utils[^/]*/{re.escape(name)}\.sh", line):
+                    seq.append((idx, name))
+        last = -1
+        for idx, name in seq:
+            if idx < last:
+                ordered = [n for _, n in seq]
+                yield Finding("L011", ERROR, img.name, rel,
+                              f"util source order violates canonical order at {name}: {ordered}")
+                break
+            last = idx
+
+
+# ---- CI workflow checks (advisory in v1) ------------------------------------
+
+def check_workflow(img: Image, repo: Path) -> Iterable[Finding]:
+    """L030 — a build-<name>.yml workflow exists (advisory)."""
+    wf = repo / ".github" / "workflows" / f"build-{img.name}.yml"
+    if not wf.exists():
+        yield Finding("L030", WARN, img.name, ".github/workflows", f"no build-{img.name}.yml (CI job-shape check deferred)")
+
+
+# -----------------------------------------------------------------------------
+
+# checks that only need the Image
+IMAGE_CHECKS: list[Callable[[Image], Iterable[Finding]]] = [
+    check_labels, check_env_hash, check_copy_root, check_from_class,
+    check_torch_guard, check_no_auto_backend, check_uv_pip,
+    check_conf_triple, check_util_order,
+]
+
+
+def lint_image(img: Image, repo: Path) -> list[Finding]:
+    out: list[Finding] = []
+    for chk in IMAGE_CHECKS:
+        out.extend(chk(img))
+    out.extend(check_workflow(img, repo))
+    # drop documented exceptions
+    return [f for f in out if (img.name, f.code) not in EXCEPTIONS]

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 from .discover import Image
-from .dockerfile import parse, stages, code_text, ini_sections, arg_defaults, resolve
+from .dockerfile import parse, stages, code_text, ini_sections, arg_defaults, resolve, parse_ref
+
+_DOCKER_HUB = (None, "docker.io", "index.docker.io", "registry-1.docker.io")
 
 ERROR = "ERROR"
 WARN = "WARN"
@@ -44,12 +46,17 @@ REQUIRED_LABEL_KEYS = ["org.opencontainers.image.source", "org.opencontainers.im
 
 # ---- Dockerfile checks ------------------------------------------------------
 
+def _label_keys(value: str) -> list[str]:
+    # quote-aware: key="quoted value with = inside" | key=bareword
+    return [k for k, _ in re.findall(r'([\w.]+)=("(?:[^"\\]|\\.)*"|\S+)', value)]
+
+
 def check_labels(img: Image) -> Iterable[Finding]:
     """L001 — exactly 3 LABEL key=value pairs (any line layout) with the required keys."""
     labels = [i for i in parse(img.text) if i.cmd == "LABEL"]
     keys: list[str] = []
     for l in labels:
-        keys += re.findall(r"(?:^|\s)([\w.]+)=", l.value)
+        keys += _label_keys(l.value)
     if len(keys) != 3:
         yield Finding("L001", ERROR, img.name, "Dockerfile", f"expected exactly 3 LABEL key=value pairs, found {len(keys)}")
     for key in REQUIRED_LABEL_KEYS:
@@ -78,17 +85,21 @@ def check_from_class(img: Image) -> Iterable[Finding]:
     ct = code_text(instrs)
     defs = arg_defaults(instrs)
     sts = stages(instrs)
+
+    def is_base(ref: str, repo: str) -> bool:
+        reg, r, _ = parse_ref(resolve(ref, defs))
+        return reg in _DOCKER_HUB and r == repo  # structural: registry + repo path, not substring
+
     if img.cls == "derivative":
-        ok = any("vastai/base-image" in resolve(ref, defs) for ref, _ in sts)
+        ok = any(is_base(ref, "vastai/base-image") for ref, _ in sts)
         if not ok:
             # base injected via build-arg (pytorch hub): ARG VAST_BASE w/ no default
-            inj = (defs.get("VAST_BASE", "x") is None
-                   and any(re.fullmatch(r"\$\{?VAST_BASE\}?", ref.strip()) for ref, _ in sts))
-            ok = inj
+            ok = (defs.get("VAST_BASE", "x") is None
+                  and any(re.fullmatch(r"\$\{?VAST_BASE\}?", ref.strip()) for ref, _ in sts))
         if not ok:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "derivative must derive from vastai/base-image")
     elif img.cls == "pytorch-nested":
-        if not any("vastai/pytorch" in resolve(ref, defs) for ref, _ in sts):
+        if not any(is_base(ref, "vastai/pytorch") for ref, _ in sts):
             yield Finding("L004", ERROR, img.name, "Dockerfile", "pytorch-nested must derive from vastai/pytorch")
     elif img.cls == "external":
         vast = [ref for ref, alias in sts if alias == "vast_base_image"]
@@ -97,7 +108,7 @@ def check_from_class(img: Image) -> Iterable[Finding]:
         else:
             if sts[0][1] != "vast_base_image":
                 yield Finding("L004", ERROR, img.name, "Dockerfile", "external stage order: vast_base_image must be the FIRST FROM")
-            if "vastai/base-image" not in resolve(vast[0], defs):
+            if not is_base(vast[0], "vastai/base-image"):
                 yield Finding("L004", ERROR, img.name, "Dockerfile", "external vast_base_image stage must resolve to vastai/base-image")
         if "convert-non-vast-image.sh" not in ct:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "external must graft via convert-non-vast-image.sh")
@@ -109,9 +120,11 @@ def check_torch_guard(img: Image) -> Iterable[Finding]:
     if img.cls != "pytorch-nested":
         return
     ct = code_text(parse(img.text))
-    # [[ "$pre" = "$post" ]] || { ... exit ... }   OR   [ "$pre" = "$post" ] || exit 1
+    # a [[ ... ]] test mentioning BOTH pre and post (either order, = or !=) wired to an
+    # exit via || or && on the same statement. A stray exit elsewhere does not satisfy it.
     wired = re.search(
-        r'\[\[?\s*"\$torch_versions_pre"\s*=\s*"\$torch_versions_post"\s*\]\]?\s*\|\|\s*\{?[^}\n]*\bexit\b',
+        r"\[\[?.*?\$torch_versions_(?:pre|post).*?\$torch_versions_(?:pre|post).*?\]\]?"
+        r"\s*(?:\|\||&&)\s*\{?[^}\n]*\bexit\b",
         ct,
     )
     if not wired:

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 from .discover import Image
-from .dockerfile import parse, stages, code_text, ini_sections
+from .dockerfile import parse, stages, code_text, ini_sections, arg_defaults, resolve
 
 ERROR = "ERROR"
 WARN = "WARN"
@@ -45,13 +45,15 @@ REQUIRED_LABEL_KEYS = ["org.opencontainers.image.source", "org.opencontainers.im
 # ---- Dockerfile checks ------------------------------------------------------
 
 def check_labels(img: Image) -> Iterable[Finding]:
-    """L001 — exactly 3 LABEL instructions with the required keys."""
+    """L001 — exactly 3 LABEL key=value pairs (any line layout) with the required keys."""
     labels = [i for i in parse(img.text) if i.cmd == "LABEL"]
-    if len(labels) != 3:
-        yield Finding("L001", ERROR, img.name, "Dockerfile", f"expected exactly 3 LABEL instructions, found {len(labels)}")
-    blob = " ".join(l.value for l in labels)
+    keys: list[str] = []
+    for l in labels:
+        keys += re.findall(r"(?:^|\s)([\w.]+)=", l.value)
+    if len(keys) != 3:
+        yield Finding("L001", ERROR, img.name, "Dockerfile", f"expected exactly 3 LABEL key=value pairs, found {len(keys)}")
     for key in REQUIRED_LABEL_KEYS:
-        if key not in blob:
+        if key not in keys:
             yield Finding("L001", ERROR, img.name, "Dockerfile", f"missing required LABEL key: {key}")
 
 
@@ -70,41 +72,51 @@ def check_copy_root(img: Image) -> Iterable[Finding]:
 
 
 def check_from_class(img: Image) -> Iterable[Finding]:
-    """L004 — FROM matches declared class (stage identity + order for external)."""
+    """L004 — FROM matches declared class. Resolves the actual base ref via ARG
+    defaults (not a global substring), so a decoy `vastai/...` elsewhere can't fool it."""
     instrs = parse(img.text)
     ct = code_text(instrs)
+    defs = arg_defaults(instrs)
+    sts = stages(instrs)
     if img.cls == "derivative":
-        inline = "vastai/base-image" in ct
-        via_arg = bool(any(i.cmd == "ARG" and re.match(r"VAST_BASE\b", i.value) for i in instrs)
-                       and re.search(r"\$\{?VAST_BASE\}?", ct))
-        if not (inline or via_arg):
+        ok = any("vastai/base-image" in resolve(ref, defs) for ref, _ in sts)
+        if not ok:
+            # base injected via build-arg (pytorch hub): ARG VAST_BASE w/ no default
+            inj = (defs.get("VAST_BASE", "x") is None
+                   and any(re.fullmatch(r"\$\{?VAST_BASE\}?", ref.strip()) for ref, _ in sts))
+            ok = inj
+        if not ok:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "derivative must derive from vastai/base-image")
     elif img.cls == "pytorch-nested":
-        if "vastai/pytorch" not in ct:
+        if not any("vastai/pytorch" in resolve(ref, defs) for ref, _ in sts):
             yield Finding("L004", ERROR, img.name, "Dockerfile", "pytorch-nested must derive from vastai/pytorch")
     elif img.cls == "external":
-        sts = stages(instrs)
-        aliases = [a for _, a in sts]
-        if "vast_base_image" not in aliases:
+        vast = [ref for ref, alias in sts if alias == "vast_base_image"]
+        if not vast:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "external must have a `FROM ... AS vast_base_image` stage")
-        elif sts[0][1] != "vast_base_image":
-            yield Finding("L004", ERROR, img.name, "Dockerfile", "external stage order: vast_base_image must be the FIRST FROM")
-        if "vastai/base-image" not in ct:
-            yield Finding("L004", ERROR, img.name, "Dockerfile", "external vast stage must be vastai/base-image")
+        else:
+            if sts[0][1] != "vast_base_image":
+                yield Finding("L004", ERROR, img.name, "Dockerfile", "external stage order: vast_base_image must be the FIRST FROM")
+            if "vastai/base-image" not in resolve(vast[0], defs):
+                yield Finding("L004", ERROR, img.name, "Dockerfile", "external vast_base_image stage must resolve to vastai/base-image")
         if "convert-non-vast-image.sh" not in ct:
             yield Finding("L004", ERROR, img.name, "Dockerfile", "external must graft via convert-non-vast-image.sh")
 
 
 def check_torch_guard(img: Image) -> Iterable[Finding]:
-    """L020 — torch-drift guard with an actual pre==post comparison that exits."""
+    """L020 — torch-drift guard: the pre==post comparison must be wired to an exit
+    on the SAME statement (a stray `exit 1` elsewhere, e.g. the REF guard, must not satisfy it)."""
     if img.cls != "pytorch-nested":
         return
     ct = code_text(parse(img.text))
-    has_cmp = re.search(r'\$torch_versions_pre"?\s*=\s*"?\$torch_versions_post', ct)
-    if not has_cmp:
-        yield Finding("L020", ERROR, img.name, "Dockerfile", "missing torch-drift guard comparison (pre == post)")
-    elif "exit 1" not in ct:
-        yield Finding("L020", ERROR, img.name, "Dockerfile", "torch-drift guard does not `exit 1` on drift")
+    # [[ "$pre" = "$post" ]] || { ... exit ... }   OR   [ "$pre" = "$post" ] || exit 1
+    wired = re.search(
+        r'\[\[?\s*"\$torch_versions_pre"\s*=\s*"\$torch_versions_post"\s*\]\]?\s*\|\|\s*\{?[^}\n]*\bexit\b',
+        ct,
+    )
+    if not wired:
+        yield Finding("L020", ERROR, img.name, "Dockerfile",
+                      "torch-drift guard not wired to exit on drift (pre==post comparison must `|| ... exit`)")
 
 
 def check_no_auto_backend(img: Image) -> Iterable[Finding]:

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -67,7 +67,7 @@ def check_labels(img: Image) -> Iterable[Finding]:
 def check_env_hash(img: Image) -> Iterable[Finding]:
     """L002 — env-hash > /.env_hash is the FINAL RUN (not commented, not stale)."""
     runs = [i for i in parse(img.text) if i.cmd == "RUN"]
-    if not runs or "env-hash > /.env_hash" not in runs[-1].value:
+    if not runs or "env-hash > /.env_hash" not in runs[-1].exec:
         yield Finding("L002", ERROR, img.name, "Dockerfile", "`env-hash > /.env_hash` must be the final RUN instruction")
 
 

--- a/tools/imagegen/pyproject.toml
+++ b/tools/imagegen/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "imagegen"
+version = "0.1.0"
+description = "Static invariant-linter (and, later, generator) for base-image Docker images. See docs/adr/0001 + docs/invariants.md."
+requires-python = ">=3.10"
+dependencies = ["pyyaml>=6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[project.scripts]
+imagegen = "imagegen.cli:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["imagegen"]

--- a/tools/imagegen/tests/test_generate.py
+++ b/tools/imagegen/tests/test_generate.py
@@ -3,6 +3,7 @@
 This closes the loop — the trustworthy oracle (the linter, with its mutation
 tests) validates the generator. Run via pytest or the stdlib fallback below.
 """
+import re
 from pathlib import Path
 
 from imagegen.generate import generate, CLASSES
@@ -19,13 +20,34 @@ def _gen_repo(repo: Path):
              upstream="someupstream/img:1.0")
 
 
-def test_generated_images_lint_clean(tmp_path):
+def test_generated_images_structurally_valid_but_flagged_skeleton(tmp_path):
+    """Generated output passes every STRUCTURAL check, and L040 flags it as an
+    incomplete skeleton — so it is never mistaken for a complete image."""
     _gen_repo(tmp_path)
     imgs = {i.name: i for i in discover(tmp_path)}
     assert set(imgs) == {"mytool", "myapp", "myext"}
     for name, img in imgs.items():
-        errors = [(f.code, f.msg) for f in lint_image(img, tmp_path) if f.severity == ERROR]
-        assert not errors, f"{img.cls}/{name} should lint clean, got: {errors}"
+        errors = [f for f in lint_image(img, tmp_path) if f.severity == ERROR]
+        structural = [(f.code, f.msg) for f in errors if f.code != "L040"]
+        assert not structural, f"{img.cls}/{name} structural errors: {structural}"
+        assert any(f.code == "L040" for f in errors), f"{name}: skeleton not flagged by L040"
+
+
+def test_filled_image_lints_clean(tmp_path):
+    """Once the markers are resolved, the image lints fully clean (no L040)."""
+    _gen_repo(tmp_path)
+    repo = tmp_path
+    # resolve every skeleton marker across the pytorch-nested image's files
+    img_dir = repo / "derivatives/pytorch/derivatives/myapp"
+    for p in list(img_dir.rglob("*")) + [repo / ".github/workflows/build-myapp.yml"]:
+        if p.is_file():
+            t = p.read_text()
+            for mk, repl in (("CHANGEME", "1.0.0"), ("CHANGEPORT", "7861"), (">>> FILL", "done")):
+                t = t.replace(mk, repl)
+            p.write_text(t)
+    img = next(i for i in discover(repo) if i.name == "myapp")
+    errors = [(f.code, f.msg) for f in lint_image(img, repo) if f.severity == ERROR]
+    assert not errors, f"filled image should lint clean, got: {errors}"
 
 
 def test_generated_classes_are_correct(tmp_path):
@@ -52,6 +74,37 @@ def test_fill_markers_present(tmp_path):
                       ("myext", "external")):
         df = (tmp_path / cls / name / "Dockerfile").read_text()
         assert ">>> FILL:" in df, f"{name} Dockerfile missing a FILL marker"
+
+
+def test_supervisor_sources_exit_portal_with_label(tmp_path):
+    """Correctness (not just lint): exit_portal.sh must be SOURCED WITH the label arg,
+    and there must be no bogus `exit_portal "..."` function call (the round-4 fatal bug)."""
+    _gen_repo(tmp_path)
+    sh = (tmp_path / "derivatives/pytorch/derivatives/myapp/ROOT/opt/supervisor-scripts/myapp.sh").read_text()
+    assert '. "${utils}/exit_portal.sh" "My App"' in sh
+    assert not re.search(r'^\s*exit_portal\s+"', sh, re.M), "bogus exit_portal function call present"
+
+
+def test_readmes_are_distinct(tmp_path):
+    _gen_repo(tmp_path)
+    d = tmp_path / "external/myext"
+    assert (d / "README.md").read_text() != (d / "README.template.md").read_text()
+    assert "Create an Instance" in (d / "README.template.md").read_text()
+
+
+def test_capability_yaml_has_image_mapping(tmp_path):
+    _gen_repo(tmp_path)
+    cap = (tmp_path / "derivatives/pytorch/derivatives/myapp/ROOT/etc/vast_capabilities.d/50-myapp.yaml").read_text()
+    assert re.search(r"^image:\s*$", cap, re.M) and "name:" in cap
+
+
+def test_no_baked_false_conventions(tmp_path):
+    """Generator must not hardcode +10000 ports or a uniform cron (invariants §3)."""
+    _gen_repo(tmp_path)
+    env = (tmp_path / "external/myext/ROOT/etc/vast_boot.d/05-myext-env.sh").read_text()
+    assert "17862" not in env  # no baked internal+10000
+    wf = (tmp_path / ".github/workflows/build-myapp.yml").read_text()
+    assert "0 0,12 * * *" not in wf  # no baked uniform cron
 
 
 if __name__ == "__main__":

--- a/tools/imagegen/tests/test_generate.py
+++ b/tools/imagegen/tests/test_generate.py
@@ -41,9 +41,10 @@ def test_filled_image_lints_clean(tmp_path):
     img_dir = repo / "derivatives/pytorch/derivatives/myapp"
     for p in list(img_dir.rglob("*")) + [repo / ".github/workflows/build-myapp.yml"]:
         if p.is_file():
-            t = p.read_text()
-            for mk, repl in (("CHANGEME", "1.0.0"), ("CHANGEPORT", "7861"), (">>> FILL", "done")):
-                t = t.replace(mk, repl)
+            # simulate a good-faith fill: REMOVE stub lines (incl. the `exit 1` stub),
+            # resolve CHANGE* tokens. No `>>> FILL` may survive.
+            kept = [ln for ln in p.read_text().splitlines(keepends=True) if ">>> FILL" not in ln]
+            t = "".join(kept).replace("CHANGEME", "1.0.0").replace("CHANGEPORT", "7861")
             p.write_text(t)
     img = next(i for i in discover(repo) if i.name == "myapp")
     errors = [(f.code, f.msg) for f in lint_image(img, repo) if f.severity == ERROR]
@@ -74,6 +75,27 @@ def test_fill_markers_present(tmp_path):
                       ("myext", "external")):
         df = (tmp_path / cls / name / "Dockerfile").read_text()
         assert ">>> FILL:" in df, f"{name} Dockerfile missing a FILL marker"
+
+
+def test_l040_flags_all_placeholder_files(tmp_path):
+    """Every generated file with a placeholder — incl. the agent doc, both READMEs,
+    and the launch-stub line — must be L040-flagged (no single-> / FIXME gaps)."""
+    _gen_repo(tmp_path)
+    img = next(i for i in discover(tmp_path) if i.name == "myext")
+    flagged = {f.path for f in lint_image(img, tmp_path) if f.code == "L040"}
+    assert any("vast_agents" in p for p in flagged), "agent doc not flagged"
+    assert "README.md" in flagged and "README.template.md" in flagged, "READMEs not flagged"
+    assert any("supervisor-scripts" in p for p in flagged), "launch stub not flagged"
+
+
+def test_no_single_marker_dialect_leaks(tmp_path):
+    """All placeholders use the `>>> FILL` dialect L040 knows — no bare `> FILL`/`FIXME:`."""
+    _gen_repo(tmp_path)
+    for p in (tmp_path / "external/myext").rglob("*"):
+        if p.is_file():
+            t = p.read_text()
+            assert "> FILL" not in t.replace(">>> FILL", ""), f"{p.name}: stray single-> FILL marker"
+            assert "FIXME" not in t, f"{p.name}: stray FIXME marker L040 won't catch"
 
 
 def test_supervisor_sources_exit_portal_with_label(tmp_path):

--- a/tools/imagegen/tests/test_generate.py
+++ b/tools/imagegen/tests/test_generate.py
@@ -68,6 +68,16 @@ def test_external_requires_upstream(tmp_path):
     raise AssertionError("external without upstream should raise ValueError")
 
 
+def test_upstream_only_for_external(tmp_path):
+    """Class-sanity (ADR cond #3): --upstream on a non-external class is rejected."""
+    (tmp_path / "derivatives/pytorch/derivatives").mkdir(parents=True, exist_ok=True)
+    try:
+        generate(tmp_path, name="x", cls="pytorch-nested", label="X", port=8000, upstream="foo/bar:1")
+    except ValueError:
+        return
+    raise AssertionError("--upstream on non-external should raise ValueError")
+
+
 def test_fill_markers_present(tmp_path):
     """The judgment residue must be clearly fenced for the human/LLM to complete."""
     _gen_repo(tmp_path)

--- a/tools/imagegen/tests/test_generate.py
+++ b/tools/imagegen/tests/test_generate.py
@@ -98,6 +98,26 @@ def test_no_single_marker_dialect_leaks(tmp_path):
             assert "FIXME" not in t, f"{p.name}: stray FIXME marker L040 won't catch"
 
 
+def test_pytorch_has_ref_guard_and_install_between_snapshots(tmp_path):
+    """The pytorch Dockerfile must guard the ref AND place the install marker between
+    the pre/post snapshots (so a faithful fill keeps the drift guard meaningful)."""
+    _gen_repo(tmp_path)
+    df = (tmp_path / "derivatives/pytorch/derivatives/myapp/Dockerfile").read_text()
+    assert re.search(r'\[\[ -n "\$\{MYAPP_REF\}" \]\] \|\|', df), "missing ref-presence guard"
+    pre = df.index("torch_versions_pre=")
+    post = df.index("torch_versions_post=")
+    fill = df.index(">>> FILL: install myapp")
+    assert pre < fill < post, "install marker must sit between the pre/post snapshots"
+
+
+def test_external_has_shell_and_env(tmp_path):
+    """External must declare bash SHELL (it uses bashisms) and the convert ENV block."""
+    _gen_repo(tmp_path)
+    df = (tmp_path / "external/myext/Dockerfile").read_text()
+    assert 'SHELL ["/bin/bash", "-c"]' in df
+    assert "UV_LINK_MODE=copy" in df and "PIP_BREAK_SYSTEM_PACKAGES=1" in df
+
+
 def test_supervisor_sources_exit_portal_with_label(tmp_path):
     """Correctness (not just lint): exit_portal.sh must be SOURCED WITH the label arg,
     and there must be no bogus `exit_portal "..."` function call (the round-4 fatal bug)."""

--- a/tools/imagegen/tests/test_generate.py
+++ b/tools/imagegen/tests/test_generate.py
@@ -1,0 +1,74 @@
+"""Round-trip: the generator's output must pass the linter, for every class.
+
+This closes the loop — the trustworthy oracle (the linter, with its mutation
+tests) validates the generator. Run via pytest or the stdlib fallback below.
+"""
+from pathlib import Path
+
+from imagegen.generate import generate, CLASSES
+from imagegen.discover import discover
+from imagegen.linter import lint_image, ERROR
+
+
+def _gen_repo(repo: Path):
+    for d in ("external", "derivatives/pytorch/derivatives", "derivatives", ".github/workflows"):
+        (repo / d).mkdir(parents=True, exist_ok=True)
+    generate(repo, name="mytool", cls="derivative", label="My Tool", port=7860)
+    generate(repo, name="myapp", cls="pytorch-nested", label="My App", port=7861)
+    generate(repo, name="myext", cls="external", label="My Ext", port=7862,
+             upstream="someupstream/img:1.0")
+
+
+def test_generated_images_lint_clean(tmp_path):
+    _gen_repo(tmp_path)
+    imgs = {i.name: i for i in discover(tmp_path)}
+    assert set(imgs) == {"mytool", "myapp", "myext"}
+    for name, img in imgs.items():
+        errors = [(f.code, f.msg) for f in lint_image(img, tmp_path) if f.severity == ERROR]
+        assert not errors, f"{img.cls}/{name} should lint clean, got: {errors}"
+
+
+def test_generated_classes_are_correct(tmp_path):
+    _gen_repo(tmp_path)
+    imgs = {i.name: i for i in discover(tmp_path)}
+    assert imgs["mytool"].cls == "derivative"
+    assert imgs["myapp"].cls == "pytorch-nested"
+    assert imgs["myext"].cls == "external"
+
+
+def test_external_requires_upstream(tmp_path):
+    (tmp_path / "external").mkdir(parents=True, exist_ok=True)
+    try:
+        generate(tmp_path, name="x", cls="external", label="X", port=8000)
+    except ValueError:
+        return
+    raise AssertionError("external without upstream should raise ValueError")
+
+
+def test_fill_markers_present(tmp_path):
+    """The judgment residue must be clearly fenced for the human/LLM to complete."""
+    _gen_repo(tmp_path)
+    for name, cls in (("mytool", "derivatives"), ("myapp", "derivatives/pytorch/derivatives"),
+                      ("myext", "external")):
+        df = (tmp_path / cls / name / "Dockerfile").read_text()
+        assert ">>> FILL:" in df, f"{name} Dockerfile missing a FILL marker"
+
+
+if __name__ == "__main__":
+    import inspect, tempfile, traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in tests:
+        try:
+            if inspect.signature(fn).parameters:
+                with tempfile.TemporaryDirectory() as d:
+                    fn(Path(d))
+            else:
+                fn()
+            print("PASS", fn.__name__)
+        except Exception:
+            failed += 1
+            print("FAIL", fn.__name__)
+            traceback.print_exc()
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -1,0 +1,133 @@
+"""Linter tests: a regression net over the real repo + one mutant per invariant.
+
+Run: cd tools/imagegen && PYTHONPATH=. python -m pytest -q
+"""
+from pathlib import Path
+
+from imagegen.discover import Image, discover, find_repo_root
+from imagegen.linter import lint_image, ERROR
+
+VALID_DF = """\
+ARG PYTORCH_BASE=vastai/pytorch:test
+FROM ${PYTORCH_BASE}
+LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="Test suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
+COPY ./ROOT /
+RUN torch_versions_pre=$(pip list); \\
+    uv pip install foo; \\
+    torch_versions_post=$(pip list); \\
+    [ "$torch_versions_pre" = "$torch_versions_post" ] || exit 1
+RUN env-hash > /.env_hash
+"""
+
+VALID_CONF = """\
+[program:foo]
+command=/opt/supervisor-scripts/foo.sh
+environment=PROC_NAME="%(program_name)s"
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+"""
+
+VALID_SCRIPT = """\
+#!/bin/bash
+. "${utils}/logging.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh"
+exec foo
+"""
+
+
+def make(tmp: Path, *, cls="pytorch-nested", df=VALID_DF, confs=None, scripts=None) -> Image:
+    d = tmp / "img"
+    (d / "ROOT/etc/supervisor/conf.d").mkdir(parents=True, exist_ok=True)
+    (d / "ROOT/opt/supervisor-scripts").mkdir(parents=True, exist_ok=True)
+    (d / "Dockerfile").write_text(df)
+    for name, body in (confs or {"foo": VALID_CONF}).items():
+        (d / "ROOT/etc/supervisor/conf.d" / f"{name}.conf").write_text(body)
+    for name, body in (scripts or {"foo.sh": VALID_SCRIPT}).items():
+        (d / "ROOT/opt/supervisor-scripts" / name).write_text(body)
+    return Image(name="img", cls=cls, dir=d, dockerfile=d / "Dockerfile", text=df, root=d / "ROOT")
+
+
+def errs(img: Image, repo: Path) -> set[str]:
+    return {f.code for f in lint_image(img, repo) if f.severity == ERROR}
+
+
+def test_valid_image_is_clean(tmp_path):
+    assert errs(make(tmp_path), tmp_path) == set()
+
+
+def test_L001_label_count(tmp_path):
+    df = VALID_DF.replace('LABEL maintainer="Vast.ai Inc <contact@vast.ai>"\n', "")
+    assert "L001" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_L002_env_hash(tmp_path):
+    df = VALID_DF.replace("RUN env-hash > /.env_hash\n", "")
+    assert "L002" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_L003_copy_root(tmp_path):
+    df = VALID_DF.replace("COPY ./ROOT /\n", "")
+    assert "L003" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_L004_from_class(tmp_path):
+    df = VALID_DF.replace("vastai/pytorch:test", "somethingelse:test")
+    assert "L004" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_L020_torch_guard(tmp_path):
+    df = VALID_DF.replace("torch_versions_pre", "x").replace("torch_versions_post", "y")
+    assert "L020" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_L021_no_auto_backend(tmp_path):
+    df = VALID_DF.replace("uv pip install foo", "uv pip install foo --torch-backend auto")
+    assert "L021" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_L010_program_name_mismatch(tmp_path):
+    # conf file is foo.conf but section says [program:bar]
+    bad = VALID_CONF.replace("[program:foo]", "[program:bar]")
+    assert "L010" in errs(make(tmp_path, confs={"foo": bad}), tmp_path)
+
+
+def test_L011_util_order_inversion(tmp_path):
+    bad = '. "${utils}/exit_portal.sh"\n. "${utils}/logging.sh"\n'
+    assert "L011" in errs(make(tmp_path, scripts={"foo.sh": bad}), tmp_path)
+
+
+def test_regression_net_real_repo_is_clean():
+    """The real repo must lint clean — proves the invariants are real, not aspirational."""
+    repo = find_repo_root(Path(__file__).resolve().parent)
+    images = discover(repo)
+    assert images, "no images discovered — wrong repo root?"
+    offenders = {
+        f"{i.cls}/{i.name}": [f"{f.code}:{f.msg}" for f in lint_image(i, repo) if f.severity == ERROR]
+        for i in images
+    }
+    offenders = {k: v for k, v in offenders.items() if v}
+    assert not offenders, f"existing images violate gated invariants: {offenders}"
+
+
+if __name__ == "__main__":
+    # stdlib fallback runner (this environment has no pytest); CI uses pytest.
+    import inspect, tempfile, traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in tests:
+        try:
+            if inspect.signature(fn).parameters:
+                with tempfile.TemporaryDirectory() as d:
+                    fn(Path(d))
+            else:
+                fn()
+            print("PASS", fn.__name__)
+        except Exception:
+            failed += 1
+            print("FAIL", fn.__name__)
+            traceback.print_exc()
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from imagegen.discover import Image, discover, find_repo_root
+from imagegen.dockerfile import parse
 from imagegen.linter import lint_image, ERROR, EXCEPTIONS
 
 VALID_DF = """\
@@ -248,6 +249,45 @@ def test_parser_comment_in_continuation(tmp_path):
     df = VALID_DF.replace("COPY ./ROOT /\n",
                           "RUN echo a \\\n# a comment\n    && echo b\nCOPY ./ROOT /\n")
     assert errs(make(tmp_path, df=df), tmp_path) == set()
+
+
+def test_mut_external_base_wrong_registry():
+    """A look-alike on a different registry (canonical substring IN the ref) must fail L004."""
+    repo, img = _real("vllm")
+    t = re.sub(r"ARG VAST_BASE=\S+", "ARG VAST_BASE=evilregistry.io/vastai/base-image:latest", img.text)
+    assert has(replace(img, text=t), repo, "L004", "must resolve to vastai/base-image")
+
+
+def test_mut_external_base_shell_default_form():
+    """`${VAST_BASE:-vastai/base-image}` with an evil ARG default must fail L004."""
+    repo, img = _real("vllm")
+    t = img.text.replace("FROM ${VAST_BASE} AS vast_base_image",
+                         "FROM ${VAST_BASE:-vastai/base-image} AS vast_base_image")
+    t = re.sub(r"ARG VAST_BASE=\S+", "ARG VAST_BASE=evil/img:latest", t)
+    assert has(replace(img, text=t), repo, "L004", "must resolve to vastai/base-image")
+
+
+def test_L020_accepts_negated_and_swapped(tmp_path):
+    """Valid guard variants (!= with &&, swapped operands) must NOT false-fail L020."""
+    for cmp in ('[[ "$torch_versions_pre" != "$torch_versions_post" ]] && exit 1',
+                '[[ "$torch_versions_post" = "$torch_versions_pre" ]] || exit 1'):
+        df = VALID_DF.replace(
+            '[ "$torch_versions_pre" = "$torch_versions_post" ] || exit 1', cmp)
+        assert "L020" not in errs(make(tmp_path, df=df), tmp_path), cmp
+
+
+def test_L001_equals_in_value_not_miscounted(tmp_path):
+    """A `word=` inside a quoted LABEL value must not inflate the pair count."""
+    df = VALID_DF.replace(
+        'LABEL org.opencontainers.image.description="Test suitable for Vast.ai."\n',
+        'LABEL org.opencontainers.image.description="Test sigma=0.7 res=512 suitable for Vast.ai."\n')
+    assert "L001" not in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_parser_plain_heredoc_indented_terminator_not_early():
+    """Plain <<EOF must NOT terminate on an indented EOF (Docker requires column 0)."""
+    text = "FROM x\nRUN cat <<EOF >/dev/null\n    EOF\necho real\nEOF\nCOPY ./ROOT /\n"
+    assert [i.cmd for i in parse(text)] == ["FROM", "RUN", "COPY"]  # `echo real` stayed inside
 
 
 def test_no_stale_exceptions():

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -318,6 +318,22 @@ def test_heredoc_data_env_hash_does_not_satisfy_L002(tmp_path):
     assert "L002" in errs(make(tmp_path, df=df), tmp_path)
 
 
+def test_heredoc_fed_to_shell_is_executed_L021(tmp_path):
+    """`RUN bash <<EOF` executes its body, so a forbidden auto-backend there must fire L021."""
+    df = VALID_DF.replace(
+        "RUN env-hash > /.env_hash\n",
+        "RUN bash <<EOF\nuv pip install x --torch-backend auto\nEOF\nRUN env-hash > /.env_hash\n")
+    assert "L021" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_heredoc_fed_to_dot_stdin_is_executed_L021(tmp_path):
+    """`. /dev/stdin <<EOF` also executes the body — the stealthier variant."""
+    df = VALID_DF.replace(
+        "RUN env-hash > /.env_hash\n",
+        "RUN . /dev/stdin <<EOF\nuv pip install x --torch-backend auto\nEOF\nRUN env-hash > /.env_hash\n")
+    assert "L021" in errs(make(tmp_path, df=df), tmp_path)
+
+
 def test_no_stale_exceptions():
     """Every EXCEPTION must still be triggered by its image (scoped to its msg)."""
     by_name = {i.name: i for i in discover(find_repo_root(Path(__file__).resolve().parent))}

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -57,6 +57,11 @@ def errs(img: Image, repo: Path) -> set[str]:
     return {f.code for f in lint_image(img, repo) if f.severity == ERROR}
 
 
+def has(img: Image, repo: Path, code: str, sub: str = "") -> bool:
+    return any(f.code == code and sub in f.msg
+               for f in lint_image(img, repo) if f.severity == ERROR)
+
+
 def test_valid_image_is_clean(tmp_path):
     assert errs(make(tmp_path), tmp_path) == set()
 
@@ -179,6 +184,70 @@ def test_mut_conf_command_basename_mismatch(tmp_path):
     mut = replace(img, dir=dst, root=dst / "ROOT", dockerfile=dst / "Dockerfile",
                   text=(dst / "Dockerfile").read_text())
     assert "L010" in errs(mut, repo)
+
+
+def test_mut_torch_guard_action_removed():
+    """Keep the [[ pre = post ]] comparison but delete its `|| {...exit}` action.
+    The unrelated REF-guard `exit 1` must NOT satisfy L020 (the prior cosmetic bug)."""
+    repo, img = _real("comfyui")
+    mut_text = re.sub(
+        r'(\[\[ "\$torch_versions_pre" = "\$torch_versions_post" \]\])\s*\|\|\s*\{[^}]*\}',
+        r"\1", img.text)
+    assert mut_text != img.text and "torch_versions_pre" in mut_text  # comparison kept
+    assert has(replace(img, text=mut_text), repo, "L020")
+
+
+def test_mut_external_base_identity_decoy():
+    """Wrong base + a decoy `vastai/base-image` elsewhere must still fail L004."""
+    repo, img = _real("vllm")
+    assert "ARG VAST_BASE=" in img.text
+    t = re.sub(r"ARG VAST_BASE=\S+", "ARG VAST_BASE=evil/img:latest", img.text)
+    t += "\nENV DECOY=vastai/base-image\n"
+    assert has(replace(img, text=t), repo, "L004", "must resolve to vastai/base-image")
+
+
+def test_mut_copy_root_removed():
+    repo, img = _real("comfyui")
+    mut = replace(img, text=re.sub(r"(?m)^\s*COPY \./ROOT/? /\s*$", "", img.text))
+    assert "L003" in errs(mut, repo)
+
+
+def test_mut_util_order_real(tmp_path):
+    repo, img = _real("comfyui")
+    dst = tmp_path / "comfyui"
+    shutil.copytree(img.dir, dst)
+    sdir = dst / "ROOT/opt/supervisor-scripts"
+    target = next(s for s in sorted(sdir.glob("*.sh")) if "logging.sh" in s.read_text())
+    target.write_text('. "${utils}/exit_portal.sh"\n' + target.read_text())  # inversion
+    mut = replace(img, dir=dst, root=dst / "ROOT", dockerfile=dst / "Dockerfile",
+                  text=(dst / "Dockerfile").read_text())
+    assert "L011" in errs(mut, repo)
+
+
+def test_L001_consolidated_label_not_false_fail(tmp_path):
+    """One LABEL with 3 key=value pairs is legal Docker and must NOT trip L001."""
+    df = VALID_DF.replace(
+        'LABEL org.opencontainers.image.source="https://github.com/vastai/"\n'
+        'LABEL org.opencontainers.image.description="Test suitable for Vast.ai."\n'
+        'LABEL maintainer="Vast.ai Inc <contact@vast.ai>"\n',
+        'LABEL org.opencontainers.image.source="https://github.com/vastai/" '
+        'org.opencontainers.image.description="Test suitable for Vast.ai." '
+        'maintainer="Vast.ai Inc <contact@vast.ai>"\n')
+    assert "L001" not in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_parser_heredoc_final_run(tmp_path):
+    """env-hash via a heredoc final RUN must be recognised (no false L002, no leaked fake instrs)."""
+    df = VALID_DF.replace("RUN env-hash > /.env_hash\n",
+                          "RUN <<EOF\nenv-hash > /.env_hash\nEOF\n")
+    assert errs(make(tmp_path, df=df), tmp_path) == set()
+
+
+def test_parser_comment_in_continuation(tmp_path):
+    """A # comment inside a \\ continuation must not corrupt the instruction stream."""
+    df = VALID_DF.replace("COPY ./ROOT /\n",
+                          "RUN echo a \\\n# a comment\n    && echo b\nCOPY ./ROOT /\n")
+    assert errs(make(tmp_path, df=df), tmp_path) == set()
 
 
 def test_no_stale_exceptions():

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -290,6 +290,34 @@ def test_parser_plain_heredoc_indented_terminator_not_early():
     assert [i.cmd for i in parse(text)] == ["FROM", "RUN", "COPY"]  # `echo real` stayed inside
 
 
+_GUARD_IN_DISCARDED_HEREDOC = """\
+ARG PYTORCH_BASE=vastai/pytorch:test
+FROM ${PYTORCH_BASE}
+LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="Test suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
+COPY ./ROOT /
+RUN cat <<EOF >/dev/null
+[[ "$torch_versions_pre" = "$torch_versions_post" ]] || exit 1
+EOF
+RUN uv pip install foo
+RUN env-hash > /.env_hash
+"""
+
+
+def test_heredoc_data_guard_does_not_satisfy_L020(tmp_path):
+    """A torch guard hidden in a discarded `cat <<EOF >/dev/null` body is not executed,
+    so L020 must still fire (it isn't in the executed shell)."""
+    assert "L020" in errs(make(tmp_path, df=_GUARD_IN_DISCARDED_HEREDOC), tmp_path)
+
+
+def test_heredoc_data_env_hash_does_not_satisfy_L002(tmp_path):
+    df = VALID_DF.replace(
+        "RUN env-hash > /.env_hash\n",
+        "RUN echo done\nRUN cat <<EOF >/dev/null\nenv-hash > /.env_hash\nEOF\n")
+    assert "L002" in errs(make(tmp_path, df=df), tmp_path)
+
+
 def test_no_stale_exceptions():
     """Every EXCEPTION must still be triggered by its image (scoped to its msg)."""
     by_name = {i.name: i for i in discover(find_repo_root(Path(__file__).resolve().parent))}

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -7,6 +7,7 @@ import shutil
 from dataclasses import replace
 from pathlib import Path
 
+import imagegen.linter as L
 from imagegen.discover import Image, discover, find_repo_root
 from imagegen.dockerfile import parse
 from imagegen.linter import lint_image, ERROR, EXCEPTIONS
@@ -332,6 +333,22 @@ def test_heredoc_fed_to_dot_stdin_is_executed_L021(tmp_path):
         "RUN env-hash > /.env_hash\n",
         "RUN . /dev/stdin <<EOF\nuv pip install x --torch-backend auto\nEOF\nRUN env-hash > /.env_hash\n")
     assert "L021" in errs(make(tmp_path, df=df), tmp_path)
+
+
+def test_rules_catalog_matches_emitted_codes():
+    """ADR cond #2: the RULES catalog is authoritative — every code a check emits must
+    be cataloged, and the catalog must not list codes no check emits."""
+    src = Path(L.__file__).read_text()
+    emitted = set(re.findall(r'Finding\("(L\d+)"', src))
+    catalog = {code for code, _, _ in L.RULES}
+    assert emitted == catalog, f"drift: emitted-not-cataloged={emitted - catalog}, cataloged-not-emitted={catalog - emitted}"
+
+
+def test_lint_rules_doc_in_sync():
+    """ADR cond #2: docs/lint-rules.md is generated from the linter; fail on drift."""
+    repo = find_repo_root(Path(__file__).resolve().parent)
+    doc = (repo / "docs" / "lint-rules.md").read_text()
+    assert doc == L.rules_markdown(), "docs/lint-rules.md is stale — run `imagegen rules > docs/lint-rules.md`"
 
 
 def test_no_stale_exceptions():

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -2,10 +2,13 @@
 
 Run: cd tools/imagegen && PYTHONPATH=. python -m pytest -q
 """
+import re
+import shutil
+from dataclasses import replace
 from pathlib import Path
 
 from imagegen.discover import Image, discover, find_repo_root
-from imagegen.linter import lint_image, ERROR
+from imagegen.linter import lint_image, ERROR, EXCEPTIONS
 
 VALID_DF = """\
 ARG PYTORCH_BASE=vastai/pytorch:test
@@ -110,6 +113,84 @@ def test_regression_net_real_repo_is_clean():
     }
     offenders = {k: v for k, v in offenders.items() if v}
     assert not offenders, f"existing images violate gated invariants: {offenders}"
+
+
+# ---- mutation-against-real-files: prove the checks actually bite ----
+# (The regression net alone is vacuous — it would pass if every check were a
+#  no-op. These corrupt REAL images and assert the corresponding code fires.)
+
+def _real(name: str):
+    repo = find_repo_root(Path(__file__).resolve().parent)
+    for img in discover(repo):
+        if img.name == name:
+            return repo, img
+    raise AssertionError(f"image {name!r} not found in repo")
+
+
+def test_mut_env_hash_neutralized():
+    repo, img = _real("comfyui")
+    mut = replace(img, text=img.text.replace("env-hash > /.env_hash", "true"))
+    assert "L002" in errs(mut, repo)
+
+
+def test_mut_label_removed():
+    repo, img = _real("comfyui")
+    mut = replace(img, text=re.sub(r"(?m)^LABEL maintainer=.*\n", "", img.text))
+    assert "L001" in errs(mut, repo)
+
+
+def test_mut_external_stage_order_reversed():
+    repo, img = _real("vllm")
+    a, b = "FROM ${VAST_BASE} AS vast_base_image", "FROM ${VLLM_BASE} AS vllm_build"
+    assert a in img.text and b in img.text
+    mut = replace(img, text=img.text.replace(a, "__A__").replace(b, a).replace("__A__", b))
+    assert "L004" in errs(mut, repo)
+
+
+def test_mut_torch_guard_weakened():
+    repo, img = _real("comfyui")
+    mut = replace(img, text=img.text.replace('[[ "$torch_versions_pre" = "$torch_versions_post" ]]', "true"))
+    assert "L020" in errs(mut, repo)
+
+
+def test_mut_auto_backend_injected():
+    repo, img = _real("comfyui")
+    mut = replace(img, text=img.text + "\nRUN uv pip install x --torch-backend auto\n")
+    assert "L021" in errs(mut, repo)
+
+
+def test_mut_auto_backend_comment_backdoor_does_not_hide():
+    """The old `'sed' in line` backdoor: `--torch-backend auto # sed` must still fire."""
+    repo, img = _real("comfyui")
+    mut = replace(img, text=img.text + "\nRUN uv pip install x --torch-backend auto # sed\n")
+    assert "L021" in errs(mut, repo)
+
+
+def test_mut_conf_command_basename_mismatch(tmp_path):
+    repo, img = _real("comfyui")
+    dst = tmp_path / "comfyui"
+    shutil.copytree(img.dir, dst)
+    conf = sorted((dst / "ROOT/etc/supervisor/conf.d").glob("*.conf"))[0]
+    text = conf.read_text()
+    text2 = re.sub(r"command=/opt/supervisor-scripts/\S+\.sh",
+                   "command=/opt/supervisor-scripts/wrong.sh", text, count=1)
+    assert text2 != text
+    conf.write_text(text2)
+    mut = replace(img, dir=dst, root=dst / "ROOT", dockerfile=dst / "Dockerfile",
+                  text=(dst / "Dockerfile").read_text())
+    assert "L010" in errs(mut, repo)
+
+
+def test_no_stale_exceptions():
+    """Every EXCEPTION must still be triggered by its image (scoped to its msg)."""
+    by_name = {i.name: i for i in discover(find_repo_root(Path(__file__).resolve().parent))}
+    repo = find_repo_root(Path(__file__).resolve().parent)
+    for (name, code), (reason, sub) in EXCEPTIONS.items():
+        img = by_name.get(name)
+        assert img, f"exception references missing image {name!r}"
+        raw = lint_image(img, repo, apply_exceptions=False)
+        assert any(f.code == code and sub in f.msg for f in raw), \
+            f"stale exception {name}/{code}: no longer triggers (suppressing nothing)"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Tooling to add a new image to this repo, decided in ADR 0001: a human picks the
image class, a deterministic generator emits the mechanical ~80%, an agent fills
only the fenced residue, and a **static invariant-linter gates** before a PR.

- **`tools/imagegen/`** — static invariant-linter (the correctness oracle),
  `imagegen new` generator, and `imagegen rules` (generates the rules reference).
- **`.claude/skills/new-image/`** — orchestration skill (pick class → generate →
  study a real sibling → fill markers → lint to zero → PR).
- **`docs/`** — ADR 0001, verified `invariants.md`, `context-map.md`, generated
  `lint-rules.md`, ADR template; plus repo `CLAUDE.md`.

## Approach / guardrails

- **Static lint is the fast gate, not the correctness gate** — the real
  `docker build` (+ smoke test) is the correctness check. Lint-clean means
  *structurally valid*, not *built*. The generator's `L040` makes an unfilled
  skeleton a hard error so it can't masquerade as complete.
- Linter scope is the **verified** invariant set (`docs/invariants.md`); notably
  `external port == internal+10000` is NOT gated (the docs were wrong — see ADR
  revision).
- **Single source of truth:** `RULES` in the linter generates `docs/lint-rules.md`;
  tests fail if they drift.

## Testing

- 50 automated tests (linter + generator), incl. **mutation-against-real-files**
  so the checks provably bite (not vacuous), a stale-exception guard, and
  docs⟷linter drift detection. Dual-mode: pytest, or a stdlib fallback runner.
- **Clean baseline over all 27 existing images.**
- Built and adversarially hardened across multiple red-team passes (linter ×5,
  generator ×2, skill ×1) — each caught real shipping defects.

## Deferred (follow-up)

- CI workflow **job-shape** validation (currently only existence is checked).

Refs CON-1585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)