### PR TITLE
fix(portal): offload blocking GPU/driver probes off the async event loop

### DIFF
--- a/portal-aio/portal/portal.py
+++ b/portal-aio/portal/portal.py
@@ -1593,16 +1593,16 @@ async def _collect_metrics() -> dict:
     nvidia_error = None
     rocm_error = None
     
-    # Try to get NVIDIA GPUs
+    # Try to get NVIDIA GPUs (offloaded — GPUtil shells out to nvidia-smi, blocking)
     try:
-        nvidia_gpus = GPUtil.getGPUs()
+        nvidia_gpus = await asyncio.to_thread(GPUtil.getGPUs)
         all_gpus.extend(nvidia_gpus)
     except Exception as e:
         nvidia_error = str(e)
-    
-    # Try to get ROCm GPUs
+
+    # Try to get ROCm GPUs (offloaded — get_rocm_gpus shells out to rocm-smi, blocking)
     try:
-        rocm_gpus = get_rocm_gpus()
+        rocm_gpus = await asyncio.to_thread(get_rocm_gpus)
         all_gpus.extend(rocm_gpus)
     except Exception as e:
         rocm_error = str(e)
@@ -1697,17 +1697,22 @@ async def get_system_metrics() -> JSONResponse:
 # --------------------------------------------------------------------------- #
 
 async def _build_capabilities(include: set[str]) -> dict:
-    # Supervisor states + GPU summary are cheap; metrics are opt-in.
+    # Supervisor states are already offloaded. The GPU summary and manifest
+    # assembly run blocking subprocesses (nvidia-smi via GPUtil, ldconfig/nvidia-smi
+    # inside assemble_live, each timeout=5), so offload them too — otherwise a single
+    # /capabilities call stalls the event loop and the live pollers. metrics are opt-in.
     try:
         processes = await _collect_supervisor()
     except Exception as e:
         logger.warning(f"capabilities: supervisor unavailable: {e}")
         processes = []
     metrics = await _collect_metrics() if "metrics" in include else None
-    return assemble_live(
+    gpu = await asyncio.to_thread(get_gpu_info)
+    return await asyncio.to_thread(
+        assemble_live,
         processes=processes,
         metrics=metrics,
-        gpu=get_gpu_info(),
+        gpu=gpu,
         include=include,
     )
 


### PR DESCRIPTION
## Problem
`/capabilities` and `/system-metrics` are `async`, but ran blocking subprocesses inline on the event loop — `nvidia-smi` (via GPUtil), `rocm-smi`, and `ldconfig -p`, each with a 5s timeout. A single call could stall the portal event loop and the live UI pollers (`/get-applications`, `/supervisor/processes`, `/system-metrics`).

## Fix
- `_build_capabilities`: offload `get_gpu_info()` and `assemble_live()` via `asyncio.to_thread` (matches the existing `to_thread` offload of supervisor calls).
- `_collect_metrics`: offload `GPUtil.getGPUs()` and `get_rocm_gpus()` the same way. **Only** the GPU subprocess calls — the CPU stat touches a module global (`_cpu_prev`) via a non-atomic read-modify-write, so it stays inline and the event loop keeps serializing it (offloading the whole function would introduce a race).

## Provenance
Surfaced by a `/forge` gate that **rejected** the original idea ("cache the capability manifest" — premature given no poller, and would stale `provisioning.status`, the field agents poll for install completion) and pointed at this real concurrency bug instead. The fix was `/redteam`'d: confirmed correct + thread-safe (`assemble_live`/GPUtil have no shared mutable state, exceptions still propagate), and the red-team found the `_collect_metrics` sibling — closed here too, so this fixes the bug *class*, not one route.

## Not changed
`disk_usage`/cgroup reads in `_collect_metrics` (microsecond-fast, not the multi-second staller); the `vast-capabilities` CLI fallback (runs once per process, nothing to amortize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)