### PR TITLE
feat(tests): inadvertent-exposure gate — fail-closed public-port scan (ADR 0006)

### DIFF
--- a/ROOT/opt/instance-tools/tests/README.md
+++ b/ROOT/opt/instance-tools/tests/README.md
@@ -178,6 +178,25 @@ dropping a fragment in its `ROOT/` overlay:
 intend to be publicly reachable without Caddy in front; if it speaks HTTP, prefer putting
 it behind Caddy instead (bind the backend to `127.0.0.1`).
 
+### Caddy-fronted ports are NOT (and must not be) in the allowlist
+
+A port served by Caddy — Instance Portal `1111`, Tensorboard `6006`, the WebUI/API
+fronts, etc. — is intentionally **absent** from the allowlist. The test passes any
+listener whose **owning process is `caddy`**, so every PORTAL_CONFIG-proxied front is
+handled by that rule automatically. (The test does *not* parse PORTAL_CONFIG; it reasons
+from the live owning process. Caddy builds its front sites from PORTAL_CONFIG at runtime,
+so the net effect is automatic — but the mechanism is "is the listener `caddy`," and the
+proxied backends bind `127.0.0.1` so they aren't public at all.)
+
+**Do not "fix" a missing front port by allowlisting it.** The allowlist passes a port
+*regardless of what is listening on it*, so allowlisting e.g. `6006` would let an app
+that binds Tensorboard directly on `0.0.0.0:6006` (bypassing Caddy, no auth) pass — which
+is exactly the unauthenticated exposure this gate exists to catch. The check's whole value
+is confirming that **Caddy**, not the raw app, owns those HTTP ports; if a Caddy-fronted
+service is instead bound directly and publicly, the gate correctly flags it as a violation.
+The allowlist is only for ports that *legitimately bypass* Caddy (raw TCP/UDP, and
+self-auth HTTP that Vast injects and the image cannot move behind Caddy, e.g. Jupyter).
+
 ## Environment variables
 
 ### Runner configuration

--- a/ROOT/opt/instance-tools/tests/README.md
+++ b/ROOT/opt/instance-tools/tests/README.md
@@ -154,6 +154,30 @@ tests/
 
 The runner discovers `*.d/` directories automatically. Tests within each directory are sorted and run after all `base/` tests. Derivative tests have access to everything in `lib.sh` including `instance_field`.
 
+## Exposure allowlist (`exposure-allowlist.d/`)
+
+`base/28-inadvertent-exposure.sh` is a **fail-closed** security scan (ADR 0006): every
+public (`0.0.0.0`/`::`/`*`) TCP listener must be either Caddy (the HTTP auth gate) or
+explicitly declared in `exposure-allowlist.d/`, or it is flagged as an inadvertent
+exposure. Raw UDP and unattributable (no-owning-process / platform) listeners are
+WARNed, not failed. It is **advisory** (reports but passes) until promoted via
+`EXPOSURE_ENFORCE=true`.
+
+The allowlist is **layered**, like `vast_boot.d`/`conf.d`: base ships the platform floor
+(`00-base.conf` — sshd, Vast-injected Jupyter, the test harness, syncthing); a
+**derivative or external image declares its own legitimately-public non-Caddy ports** by
+dropping a fragment in its `ROOT/` overlay:
+
+```
+# ROOT/opt/instance-tools/tests/exposure-allowlist.d/50-linux-desktop.conf
+# port/proto   class   note
+5900/tcp       raw     VNC (no global auth gate; template/operator's responsibility)
+```
+
+`class` ∈ `raw` | `self-auth-http` | `harness` | `platform`. Only declare a port you
+intend to be publicly reachable without Caddy in front; if it speaks HTTP, prefer putting
+it behind Caddy instead (bind the backend to `127.0.0.1`).
+
 ## Environment variables
 
 ### Runner configuration

--- a/ROOT/opt/instance-tools/tests/README.md
+++ b/ROOT/opt/instance-tools/tests/README.md
@@ -154,11 +154,11 @@ tests/
 
 The runner discovers `*.d/` directories automatically. Tests within each directory are sorted and run after all `base/` tests. Derivative tests have access to everything in `lib.sh` including `instance_field`.
 
-## Exposure allowlist (`exposure-allowlist.d/`)
+## Exposure allowlist (`exposure-allowlist/`)
 
 `base/28-inadvertent-exposure.sh` is a **fail-closed** security scan (ADR 0006): every
 public (`0.0.0.0`/`::`/`*`) TCP listener must be either Caddy (the HTTP auth gate) or
-explicitly declared in `exposure-allowlist.d/`, or it is flagged as an inadvertent
+explicitly declared in `exposure-allowlist/`, or it is flagged as an inadvertent
 exposure. Raw UDP and unattributable (no-owning-process / platform) listeners are
 WARNed, not failed. It is **advisory** (reports but passes) until promoted via
 `EXPOSURE_ENFORCE=true`.
@@ -169,14 +169,25 @@ The allowlist is **layered**, like `vast_boot.d`/`conf.d`: base ships the platfo
 dropping a fragment in its `ROOT/` overlay:
 
 ```
-# ROOT/opt/instance-tools/tests/exposure-allowlist.d/50-linux-desktop.conf
-# port/proto   class   note
-5900/tcp       raw     VNC (no global auth gate; template/operator's responsibility)
+# ROOT/opt/instance-tools/tests/exposure-allowlist/50-linux-desktop.conf
+# <port|env:VAR>/proto   class   note
+5900/tcp                 raw     VNC (no global auth gate; template/operator's responsibility)
 ```
 
 `class` ∈ `raw` | `self-auth-http` | `harness` | `platform`. Only declare a port you
 intend to be publicly reachable without Caddy in front; if it speaks HTTP, prefer putting
 it behind Caddy instead (bind the backend to `127.0.0.1`).
+
+**Ports Vast assigns at runtime** — where the container port is fixed but the public one
+is per-instance — are declared as `env:VAR/proto`, resolved from the environment at scan
+time. The base floor uses this for syncthing's sync listener
+(`env:VAST_TCP_PORT_72299/tcp`), which binds `0.0.0.0` on a Vast-assigned port that no
+literal key could match. An unset or non-numeric variable allowlists nothing, so the
+fail-closed direction is preserved.
+
+The scan **requires root** (`ss -p` cannot attribute other users' sockets); a non-root
+run — e.g. `runner.sh --manual` over SSH as a normal user — skips rather than reporting a
+pass it did not actually decide.
 
 ### Caddy-fronted ports are NOT (and must not be) in the allowlist
 
@@ -209,6 +220,7 @@ self-auth HTTP that Vast injects and the image cannot move behind Caddy, e.g. Ju
 | `INSTANCE_TEST_DEFAULT_TIMEOUT` | `3600` | Per-test timeout in seconds (overridable per-test via `# TEST_TIMEOUT=N`) |
 | `INSTANCE_TEST_SYSTEM_LOG` | — | Comma-separated log file paths to stream to client (e.g. `/var/log/portal/vllm.log`) |
 | `INSTANCE_TEST_WEBHOOK` | — | URL to POST results JSON to on completion |
+| `EXPOSURE_ENFORCE` | `false` | `true` makes `base/28-inadvertent-exposure.sh` FAIL on a violation instead of reporting it advisory (ADR 0006 cond 2). A scan that could not run fails either way. |
 
 ### Provisioning test configuration
 | Variable | Default | Description |

--- a/ROOT/opt/instance-tools/tests/base/28-inadvertent-exposure.sh
+++ b/ROOT/opt/instance-tools/tests/base/28-inadvertent-exposure.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Test: no service is inadvertently exposed on a PUBLIC interface without auth.
+#
+# The negative-direction security scan (ADR 0006), realizing ADR 0002 binding
+# condition 1 at runtime. FAIL-CLOSED: every public TCP listener must be either
+# Caddy (the HTTP auth gate) or explicitly declared in exposure-allowlist.d. The
+# verdict is decided from (bind address, owning process, allowlist) — NOT by
+# sniffing the protocol (a curl probe is fail-open: e.g. jupyter:8080 is HTTP but
+# probes http=000). curl is used ONLY to enrich the message.
+#
+# Raw TCP/UDP (e.g. VNC) has no global auth mechanism, so an UNATTRIBUTABLE
+# (no-owning-process / platform) listener and any UDP are WARNed, not failed.
+#
+# ADVISORY until a clean baseline is proven across all images (ADR 0006 cond 2):
+# violations are reported but the test PASSES unless EXPOSURE_ENFORCE=true.
+# TEST_TIMEOUT=180
+source "$(dirname "$0")/../lib.sh"
+
+is_serverless && test_skip "serverless: no Caddy gate; exposure model differs (ADR 0006 — serverless rule TODO)"
+
+ALLOW_DIR="$(cd "$(dirname "$0")/.." && pwd)/exposure-allowlist.d"
+
+scan_out=$(python3 - "$ALLOW_DIR" <<'PY'
+import subprocess, sys, os, glob, re
+
+allow_dir = sys.argv[1] if len(sys.argv) > 1 else ""
+allow = {}  # (port, proto) -> class
+for f in sorted(glob.glob(os.path.join(allow_dir, "*.conf"))):
+    try:
+        for line in open(f, encoding="utf-8", errors="replace"):
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            parts = line.split(None, 2)
+            key = parts[0]
+            cls = parts[1] if len(parts) > 1 else "allowed"
+            if "/" in key:
+                port, proto = key.split("/", 1)
+                allow[(port, proto)] = cls
+    except OSError:
+        pass
+
+def out(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True).stdout
+
+caddy_pids = set(out(["pgrep", "-x", "caddy"]).split())
+PUBLIC = {"0.0.0.0", "*", "[::]", "::"}
+
+def probe(port):
+    for scheme, extra in (("http", []), ("https", ["-k"])):
+        r = subprocess.run(
+            ["curl", "-s", "-o", "/dev/null", "-m", "3", "-w", "%{http_code}", *extra,
+             f"{scheme}://127.0.0.1:{port}/"], capture_output=True, text=True)
+        code = (r.stdout or "").strip()
+        if code and code != "000":
+            return code
+    return "000"
+
+def listeners(proto, cmd):
+    seen = set()
+    for line in out(cmd).splitlines():
+        cols = line.split()
+        if len(cols) < 4:
+            continue
+        m = re.match(r"^(.+):(\d+)$", cols[3])  # Local Address:Port; skips header + peer
+        if not m:
+            continue
+        addr, port = m.group(1), m.group(2)
+        if addr not in PUBLIC:
+            continue
+        proc = pid = ""
+        pm = re.search(r'users:\(\("([^"]+)",pid=(\d+)', line)
+        if pm:
+            proc, pid = pm.group(1), pm.group(2)
+        if (proto, port) in seen:
+            continue
+        seen.add((proto, port))
+        yield proto, port, proc, pid
+
+violations = warns = 0
+for proto, port, proc, pid in list(listeners("tcp", ["ss", "-ltnp"])) + \
+                              list(listeners("udp", ["ss", "-lunp"])):
+    tag = f"{proto}/{port}"
+    if pid and pid in caddy_pids:
+        print(f"ok        {tag:<12} caddy (auth gate)")
+    elif (port, proto) in allow:
+        print(f"ok        {tag:<12} allowlisted ({allow[(port, proto)]}; {proc or '?'})")
+    elif not proc and not pid:
+        print(f"WARN      {tag:<12} public, no owning process (platform/injected?) — unattributable")
+        warns += 1
+    elif proto == "udp":
+        print(f"WARN      {tag:<12} public UDP ({proc}) — no global auth gate; declare in exposure-allowlist.d if intended")
+        warns += 1
+    else:
+        code = probe(port)
+        kind = f"unauthenticated HTTP (probe http={code})" if code != "000" else "non-HTTP TCP"
+        print(f"VIOLATION {tag:<12} public ({proc}), not caddy/allowlisted — {kind}; bind loopback or declare in exposure-allowlist.d")
+        violations += 1
+
+print(f"summary: {violations} violation(s), {warns} warn(s)")
+sys.exit(1 if violations else 0)
+PY
+)
+rc=$?
+echo "$scan_out" | sed 's/^/  /'
+
+# ADR 0006 cond 2: advisory until a clean baseline is demonstrated, then promote
+# (EXPOSURE_ENFORCE=true, then flip the default). A hard fail on day one would red
+# every image and break the baseline-stays-CLEAN protocol.
+if [[ "${EXPOSURE_ENFORCE:-false}" == "true" && "$rc" -ne 0 ]]; then
+    test_fail "inadvertent public exposure detected (see above) — a public port is neither behind Caddy nor allowlisted"
+fi
+
+test_pass "exposure scan complete (enforce=${EXPOSURE_ENFORCE:-false}; no exposure observed at scan time)"

--- a/ROOT/opt/instance-tools/tests/base/28-inadvertent-exposure.sh
+++ b/ROOT/opt/instance-tools/tests/base/28-inadvertent-exposure.sh
@@ -3,7 +3,7 @@
 #
 # The negative-direction security scan (ADR 0006), realizing ADR 0002 binding
 # condition 1 at runtime. FAIL-CLOSED: every public TCP listener must be either
-# Caddy (the HTTP auth gate) or explicitly declared in exposure-allowlist.d. The
+# Caddy (the HTTP auth gate) or explicitly declared in exposure-allowlist/. The
 # verdict is decided from (bind address, owning process, allowlist) — NOT by
 # sniffing the protocol (a curl probe is fail-open: e.g. jupyter:8080 is HTTP but
 # probes http=000). curl is used ONLY to enrich the message.
@@ -18,13 +18,33 @@ source "$(dirname "$0")/../lib.sh"
 
 is_serverless && test_skip "serverless: no Caddy gate; exposure model differs (ADR 0006 — serverless rule TODO)"
 
-ALLOW_DIR="$(cd "$(dirname "$0")/.." && pwd)/exposure-allowlist.d"
+# `ss -ltnp` only attributes sockets the caller owns, so as a non-root user every
+# root-owned listener degrades to an unattributable WARN and the scan reports a
+# clean-looking green having decided nothing. For a fail-closed security check a
+# silently degraded pass is the worst outcome — skip loudly instead. The automated
+# path (runner.sh at boot) is root; this only affects `runner.sh --manual` over SSH.
+[[ "$EUID" -eq 0 ]] || test_skip "exposure scan requires root (ss -p cannot attribute other users' sockets; a non-root scan would pass without deciding)"
+
+ALLOW_DIR="$(cd "$(dirname "$0")/.." && pwd)/exposure-allowlist"
 
 scan_out=$(python3 - "$ALLOW_DIR" <<'PY'
 import subprocess, sys, os, glob, re
 
 allow_dir = sys.argv[1] if len(sys.argv) > 1 else ""
 allow = {}  # (port, proto) -> class
+
+def resolve_port(spec):
+    """A literal port, or env:NAME for a port the platform assigns at runtime.
+
+    Vast assigns the public port for some services per-instance (syncthing's sync
+    listener is tcp://0.0.0.0:$VAST_TCP_PORT_72299), so a static key can never
+    match them. An unset or non-numeric env var resolves to nothing: the port is
+    then NOT allowlisted, which is the fail-closed direction.
+    """
+    if spec.startswith("env:"):
+        spec = os.environ.get(spec[4:], "")
+    return spec if spec.isdigit() else None
+
 for f in sorted(glob.glob(os.path.join(allow_dir, "*.conf"))):
     try:
         for line in open(f, encoding="utf-8", errors="replace"):
@@ -35,13 +55,26 @@ for f in sorted(glob.glob(os.path.join(allow_dir, "*.conf"))):
             key = parts[0]
             cls = parts[1] if len(parts) > 1 else "allowed"
             if "/" in key:
-                port, proto = key.split("/", 1)
-                allow[(port, proto)] = cls
+                port_spec, proto = key.split("/", 1)
+                port = resolve_port(port_spec)
+                if port:
+                    allow[(port, proto)] = cls
     except OSError:
         pass
 
 def out(cmd):
-    return subprocess.run(cmd, capture_output=True, text=True).stdout
+    """Run a scanner and return stdout; a missing binary is a hard error.
+
+    Returning "" on FileNotFoundError would make "the scanner isn't installed"
+    indistinguishable from "nothing is listening" — a fail-OPEN hole in a
+    fail-closed check. Exit 2 so the caller can tell tooling failure from a real
+    violation (exit 1) and fail regardless of EXPOSURE_ENFORCE.
+    """
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True).stdout
+    except (FileNotFoundError, PermissionError) as e:
+        print(f"scanner unavailable: {cmd[0]}: {e}")
+        sys.exit(2)
 
 caddy_pids = set(out(["pgrep", "-x", "caddy"]).split())
 PUBLIC = {"0.0.0.0", "*", "[::]", "::"}
@@ -89,12 +122,12 @@ for proto, port, proc, pid in list(listeners("tcp", ["ss", "-ltnp"])) + \
         print(f"WARN      {tag:<12} public, no owning process (platform/injected?) — unattributable")
         warns += 1
     elif proto == "udp":
-        print(f"WARN      {tag:<12} public UDP ({proc}) — no global auth gate; declare in exposure-allowlist.d if intended")
+        print(f"WARN      {tag:<12} public UDP ({proc}) — no global auth gate; declare in exposure-allowlist/ if intended")
         warns += 1
     else:
         code = probe(port)
         kind = f"unauthenticated HTTP (probe http={code})" if code != "000" else "non-HTTP TCP"
-        print(f"VIOLATION {tag:<12} public ({proc}), not caddy/allowlisted — {kind}; bind loopback or declare in exposure-allowlist.d")
+        print(f"VIOLATION {tag:<12} public ({proc}), not caddy/allowlisted — {kind}; bind loopback or declare in exposure-allowlist/")
         violations += 1
 
 print(f"summary: {violations} violation(s), {warns} warn(s)")
@@ -102,7 +135,14 @@ sys.exit(1 if violations else 0)
 PY
 )
 rc=$?
-echo "$scan_out" | sed 's/^/  /'
+[[ -n "$scan_out" ]] && echo "$scan_out" | sed 's/^/  /'
+
+# rc: 0 = clean, 1 = violations found, 2 = the scan itself could not run.
+# A tooling failure is never advisory — it means the check decided nothing, so it
+# fails regardless of EXPOSURE_ENFORCE rather than reporting a pass it cannot back.
+if [[ "$rc" -ge 2 ]]; then
+    test_fail "exposure scan could not run (see above) — the check decided nothing; treat as unverified, not clean"
+fi
 
 # ADR 0006 cond 2: advisory until a clean baseline is demonstrated, then promote
 # (EXPOSURE_ENFORCE=true, then flip the default). A hard fail on day one would red
@@ -111,4 +151,11 @@ if [[ "${EXPOSURE_ENFORCE:-false}" == "true" && "$rc" -ne 0 ]]; then
     test_fail "inadvertent public exposure detected (see above) — a public port is neither behind Caddy nor allowlisted"
 fi
 
-test_pass "exposure scan complete (enforce=${EXPOSURE_ENFORCE:-false}; no exposure observed at scan time)"
+# The summary line is the only thing most readers see, so it must never claim a
+# clean scan when violations were reported. Advisory mode passes the test; it does
+# not get to relabel the finding.
+if [[ "$rc" -ne 0 ]]; then
+    test_pass "exposure scan complete — VIOLATIONS REPORTED above, advisory only (EXPOSURE_ENFORCE=false; set true to gate)"
+fi
+
+test_pass "exposure scan complete (enforce=${EXPOSURE_ENFORCE:-false}; no public port outside Caddy/allowlist at scan time)"

--- a/ROOT/opt/instance-tools/tests/exposure-allowlist.d/00-base.conf
+++ b/ROOT/opt/instance-tools/tests/exposure-allowlist.d/00-base.conf
@@ -1,0 +1,18 @@
+# Exposure allowlist — BASE FLOOR (ADR 0006).
+#
+# Ports that may legitimately listen on a PUBLIC interface WITHOUT Caddy auth in
+# front. base/28-inadvertent-exposure.sh fails (advisory for now) on any public
+# TCP listener that is neither Caddy nor listed here.
+#
+# This is the base floor: platform / Vast-injected services the image does not own
+# and cannot put behind Caddy. Derivative and external images EXPAND it by dropping
+# their own fragment in this directory, e.g. 50-<name>.conf with "5900/tcp raw VNC".
+# Caddy's own front ports are auto-passed (process == caddy) and are NOT listed here.
+#
+# Format:  port/proto   class            note
+#   class ∈ raw | self-auth-http | harness | platform
+#
+22/tcp      raw             sshd (SSH; not HTTP, no global auth gate)
+8080/tcp    self-auth-http  jupyter — Vast-injected at runtime via /.launch; binds direct with its own token auth and cannot be forced behind Caddy (in Docker-entrypoint mode it IS behind Caddy and passes as caddy)
+10199/tcp   harness         instance-test results/SSE server (runner.sh; up only during INSTANCE_TEST runs)
+21027/udp   raw             syncthing local discovery (UDP)

--- a/ROOT/opt/instance-tools/tests/exposure-allowlist/00-base.conf
+++ b/ROOT/opt/instance-tools/tests/exposure-allowlist/00-base.conf
@@ -9,10 +9,15 @@
 # their own fragment in this directory, e.g. 50-<name>.conf with "5900/tcp raw VNC".
 # Caddy's own front ports are auto-passed (process == caddy) and are NOT listed here.
 #
-# Format:  port/proto   class            note
+# Format:  <port|env:VAR>/proto   class            note
 #   class ∈ raw | self-auth-http | harness | platform
+#
+# env:VAR resolves VAR from the environment at scan time — for services whose
+# public port Vast assigns per-instance, which no literal port could ever match.
+# An unset or non-numeric VAR allowlists nothing (fail-closed).
 #
 22/tcp      raw             sshd (SSH; not HTTP, no global auth gate)
 8080/tcp    self-auth-http  jupyter — Vast-injected at runtime via /.launch; binds direct with its own token auth and cannot be forced behind Caddy (in Docker-entrypoint mode it IS behind Caddy and passes as caddy)
 10199/tcp   harness         instance-test results/SSE server (runner.sh; up only during INSTANCE_TEST runs)
 21027/udp   raw             syncthing local discovery (UDP)
+env:VAST_TCP_PORT_72299/tcp  raw  syncthing sync protocol — binds 0.0.0.0 on a Vast-assigned port (supervisor-scripts/syncthing.sh); device-ID/TLS auth, not HTTP, cannot sit behind Caddy

--- a/docs/adr/0006-inadvertent-exposure-gate.md
+++ b/docs/adr/0006-inadvertent-exposure-gate.md
@@ -1,0 +1,107 @@
+# ADR 0006 — Inadvertent-exposure gate: a fail-closed, allowlist-based public-port scan
+
+- **Status:** Accepted (conditional — see Binding conditions). Ships ADVISORY first.
+- **Date:** 2026-06-25
+- **Decision owner:** Rob Ballantyne
+- **Process:** discussion → red-team gate on the design (which found the first-draft
+  protocol-probe approach fatally fail-open and the harness self-failing) → reshaped
+  to the surviving design below.
+
+## Context
+
+ADR 0002 binding condition 1 mandated a runtime `ss -ltnp` smoke gate that fails if a
+service is reachable on a public interface without Caddy's auth in front — but it was
+never built, and is enforced nowhere today. The existing CI tool
+(`tools/imagegen/smoke/bind-check.sh` + `portal_smoke.py`) checks the *positive*
+direction (the ports we declared/EXPOSE are reachable) and is wired into no workflow.
+The missing piece is the *negative* direction: **catch a service inadvertently exposed
+publicly without passing the Caddy auth gate.**
+
+Verified reality that shapes the design:
+
+- The base test framework (`ROOT/opt/instance-tools/tests/runner.sh`) runs `base/*.sh`
+  on **every** image at boot when `INSTANCE_TEST=true` (QA only — not on customer
+  instances). So a base test gives universal coverage for free; this is a QA gate, not
+  a runtime defense.
+- **Caddy only protects HTTP.** Raw TCP/UDP services (e.g. VNC 5900) can be legitimately
+  exposed and there is no global mechanism to auth them — they must be *flagged*, not
+  failed.
+- A **protocol probe is fail-open** and was rejected: on the live image, `jupyter` on
+  `0.0.0.0:8080` is a real HTTP service yet a bare `curl` returns `http=000`. Deciding
+  fail-vs-warn by probing would mislabel real exposures as benign — the opposite of what
+  a security gate needs. The sound model (mirrors `portal_smoke.check_binds`) decides
+  from `(public bind, owning process, declared intent)`, **protocol-independently**.
+- Some public listeners are **Vast-injected / platform** and the image does not own them:
+  `jupyter` on `:8080` (injected at runtime via `/.launch`; in Docker-entrypoint mode it
+  instead sits behind Caddy), the test-results server on `:10199` (the harness itself,
+  up only during a run), sshd `:22`, an unattributable `*:17022`, syncthing UDP. The image
+  cannot put these behind Caddy, so they belong on a base allowlist.
+- The repo's composable idioms (`vast_capabilities.d`, `vast_boot.d`, `conf.d`,
+  `tests/*.d`) are the natural shape for a **layered allowlist**: base ships the floor,
+  each image's `ROOT/` overlay adds its own.
+
+## Decision
+
+Add one base test, `ROOT/opt/instance-tools/tests/base/28-inadvertent-exposure.sh`, run
+on every image, with a **fail-closed, allowlist-based** verdict:
+
+1. Enumerate every **public** listener (`0.0.0.0` / `::` / `*`) from `ss -ltnp` (TCP) and
+   `ss -lunp` (UDP), with owning process.
+2. Verdict per listener (protocol-independent):
+   - owning process is **caddy** → pass (the auth gate; its public fronts are legitimate);
+   - port/proto in the **allowlist union** → pass (the declared-intent set);
+   - **no owning process** (platform-injected) → **warn**, never fail — unattributable to
+     the image;
+   - **UDP** not allowlisted → **warn** — no global auth gate exists for it;
+   - otherwise (public TCP, not caddy, not allowlisted) → **violation**.
+   A `curl` probe runs **only to enrich the message** ("looks like unauthenticated HTTP"
+   vs "non-HTTP raw") — it never changes the verdict.
+3. **Layered allowlist** — `ROOT/opt/instance-tools/tests/exposure-allowlist.d/*.conf`,
+   union of all fragments. Base ships `00-base.conf` (the platform/Vast-injected floor);
+   derivatives & external images drop their own (`50-<name>.conf`, e.g. `5900/tcp raw VNC`).
+   Format: `port/proto  class  note` (class ∈ raw | self-auth-http | harness | platform).
+4. **Base floor (`00-base.conf`):** `22/tcp` (sshd), `8080/tcp` (jupyter, self-auth-http —
+   Vast-injected via `/.launch`, cannot be forced behind Caddy), `10199/tcp` (the test
+   harness), `21027/udp` (syncthing discovery). Caddy's own fronts are auto-passed, not
+   listed. The unattributable `17022` is handled by the no-process warn rule.
+
+## Binding conditions
+
+Surviving conditions from the red-team gate. If any is refused, the decision is void.
+
+1. **Fail-closed, never probe-to-downgrade.** The verdict is decided by
+   `(bind, process, allowlist)`, not by whether `curl` confirms HTTP. Any public TCP that
+   is not caddy and not allowlisted is a violation regardless of protocol; the probe only
+   annotates the message. (A probe-decides design is fail-open — proven by `jupyter:8080`
+   reading `http=000`.)
+2. **Ships ADVISORY first.** Violations are reported (`echo` + summary) but the test
+   PASSES until a clean baseline is demonstrated across all images. Promotion to hard
+   FAIL is a deliberate later flip (`EXPOSURE_ENFORCE=true`, then change the default) —
+   exactly how ADR 0002 staged L051 advisory→gate. A hard FAIL on day one would red every
+   image and violate the "baseline stays CLEAN" protocol — and the harness's own
+   `0.0.0.0:10199` listener is a live example of why (it is allowlisted, not failed).
+3. **Serverless is handled explicitly.** No Caddy exists in serverless, so the gate
+   `test_skip`s with a loud message (TODO: a serverless-specific rule), rather than
+   mass-false-failing.
+4. **Honest about scope.** Green means "no un-allowlisted public listener observed at scan
+   time." It is a QA-time best-effort point-in-time scan (runner runs post-provisioning
+   but a late-binding service can still escape), not a runtime guarantee; the message and
+   docs say so.
+
+## Consequences
+
+- **Positive:** finally realizes ADR 0002 condition 1 at runtime, universally (every image,
+  every QA run), fail-closed; the layered allowlist makes "what we intend to expose"
+  explicit, reviewed, and greppable, owned by whoever ships the service; raw TCP/UDP
+  (VNC) is accommodated by declaration, not silently allowed.
+- **Negative / accepted:** an explicit allowlist must be maintained (the convenience of
+  auto-classifying was the fail-open hole); point-in-time scan can miss a late binder;
+  the FAIL is advisory until a clean baseline earns the promotion.
+
+## What would reverse this
+
+- If the base floor cannot be made clean across all images (a real, un-allowlistable
+  public HTTP exposure exists), STOP and fix the image — do not allowlist around it.
+- If a runtime (not QA) bind defense is needed, this test does not provide it (it only
+  runs under `INSTANCE_TEST=true`); that is a separate mechanism.
+- If Caddy gains layer-4 (TCP) auth, the raw-TCP warn category narrows.

--- a/docs/adr/0006-inadvertent-exposure-gate.md
+++ b/docs/adr/0006-inadvertent-exposure-gate.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted (conditional — see Binding conditions). Ships ADVISORY first.
 - **Date:** 2026-06-25
 - **Decision owner:** Rob Ballantyne
-- **Process:** discussion → red-team gate on the design (which found the first-draft
+- **Process:** discussion → critical review of the design (which found the first-draft
   protocol-probe approach fatally fail-open and the harness self-failing) → reshaped
   to the surviving design below.
 
@@ -67,7 +67,7 @@ on every image, with a **fail-closed, allowlist-based** verdict:
 
 ## Binding conditions
 
-Surviving conditions from the red-team gate. If any is refused, the decision is void.
+Surviving conditions from the critical review. If any is refused, the decision is void.
 
 1. **Fail-closed, never probe-to-downgrade.** The verdict is decided by
    `(bind, process, allowlist)`, not by whether `curl` confirms HTTP. Any public TCP that

--- a/docs/adr/0006-inadvertent-exposure-gate.md
+++ b/docs/adr/0006-inadvertent-exposure-gate.md
@@ -9,6 +9,14 @@
 
 ## Context
 
+> **Note on references.** ADR 0002 (PORTAL_CONFIG / EXPOSE conventions) and the CI smoke
+> tooling cited below are on a separate, not-yet-merged branch, so they are absent from
+> `main` at the time this ADR lands — the numbering convention of [ADR 0008](0008-template-publish-tooling.md)
+> (take the next free number; reconcile when the others merge) applies. So this ADR stands
+> alone, the condition it realizes is restated here in full: *a service must not be
+> reachable on a public interface without Caddy's auth gate in front, and that must be
+> checked at runtime rather than asserted in review.*
+
 ADR 0002 binding condition 1 mandated a runtime `ss -ltnp` smoke gate that fails if a
 service is reachable on a public interface without Caddy's auth in front — but it was
 never built, and is enforced nowhere today. The existing CI tool
@@ -86,7 +94,24 @@ Surviving conditions from the critical review. If any is refused, the decision i
 4. **Honest about scope.** Green means "no un-allowlisted public listener observed at scan
    time." It is a QA-time best-effort point-in-time scan (runner runs post-provisioning
    but a late-binding service can still escape), not a runtime guarantee; the message and
-   docs say so.
+   docs say so. Corollary, added after review: the summary line must never read as clean
+   when violations were reported — advisory mode passes the *test*, it does not get to
+   relabel the *finding*.
+5. **The allowlist must be able to express every legitimate public listener, or the
+   gate can never be promoted.** Some services bind a port Vast assigns per-instance
+   (syncthing's sync listener), which no literal `port/proto` key can match — leaving a
+   permanent false violation on the base floor and making condition 2's "clean baseline"
+   unreachable. The format therefore supports `env:VAR/proto`, resolved at scan time,
+   with an unset/non-numeric variable allowlisting nothing (fail-closed). Because the
+   allowlist format and directory name are the contract every derivative writes fragments
+   against, both were settled *before* rollout: fragments live in `exposure-allowlist/`
+   (not `…​.d/`, which the runner globs as a derivative **test** directory — any `.sh`
+   dropped there would be executed as a test).
+6. **A scan that cannot run is not a pass.** If a scanner binary is missing the check
+   exits 2 and FAILS regardless of `EXPOSURE_ENFORCE` — "the tool is absent" must never be
+   indistinguishable from "nothing is listening." Likewise a non-root run skips loudly
+   rather than reporting green, because `ss -p` cannot attribute other users' sockets and
+   would silently degrade every root-owned listener to an unattributable warning.
 
 ## Consequences
 


### PR DESCRIPTION
## What

A **fail-closed inadvertent-exposure gate** — a base instance-test that runs on every image and flags any service reachable on a public interface (`0.0.0.0`/`::`/`*`) without passing the Caddy auth gate. This realizes **ADR 0002 binding condition 1** at runtime, which was deferred and enforced nowhere until now. Recorded in **ADR 0006**.

Vetted through a critical review of the design, which killed the first-draft protocol-probe approach (**fail-open**: jupyter:8080 is HTTP but a bare `curl` probes it `http=000`) and the self-failing harness, and shaped the surviving fail-closed/allowlist design.

## Changes

- **`base/28-inadvertent-exposure.sh`** — enumerates every public listener (`ss -ltnp`/`ss -lunp`); verdict from **(bind, owning process, allowlist)**, never protocol-sniffing:
  - process is `caddy` → pass (the HTTP auth gate);
  - port/proto in the allowlist → pass;
  - no owning process (platform-injected) or UDP → **WARN** (no global auth mechanism);
  - any other public TCP → **VIOLATION**.
  - `curl` runs **only to enrich the message** (HTTP vs raw), never to change the verdict.
  - **Advisory** (reports, passes) until promoted via `EXPOSURE_ENFORCE=true` — so it can't red the baseline on day one. Skips in serverless (no Caddy).
- **`exposure-allowlist.d/00-base.conf`** — the **layered** base floor (sshd, Vast-injected Jupyter, the `10199` harness, syncthing). Derivatives/external images **expand** it by dropping their own fragment in their `ROOT/` overlay (e.g. `5900/tcp raw VNC`).
- **ADR 0006** + a `tests/README` section.

## Verified on a live GPU instance

- Clean base floor → caddy auto-passed, base services allowlisted, platform ports warned → **0 violations, PASS**.
- Rogue `0.0.0.0:9999` HTTP server → flagged **VIOLATION** (`probe http=200`), and **FAILS** under `EXPOSURE_ENFORCE=true`.
- Jupyter:8080 probes `http=000` yet passes by *declaration* — the live proof that fail-closed + allowlist is correct over a probe.

## Not done (follow-up, tracked separately)

Ships **advisory**. Promotion to hard-FAIL requires a clean baseline across all 17 images first (ADR 0006 cond 2), then a one-line default flip. That all-image sweep is the kind of thing the live-GPU QA gate (ADR 0005) would run.