### PR TITLE
CON-1591: live-GPU QA gate + template publish/test tooling

### DIFF
--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -152,8 +152,37 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  merge-manifests:
+  # Live-GPU QA gate (ADR 0005, CON-1585) — calls the reusable qa-gate.yml once per
+  # promoted CUDA variant (amd64). All per-image specifics (tag, label, the
+  # SHA-pinned provisioning URL) are here; the shared create -> test -> destroy ->
+  # delete -> verdict core + the account concurrency group live in qa-gate.yml.
+  # amd64-only (ADR 0005 cond 4); advisory until VAST_API_KEY exists.
+  qa:
     needs: [preflight, build]
+    if: needs.preflight.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      # cuda/py are constants per variant (matching the build matrix), so the
+      # staging tag is built inline below — no per-cell shell derivation.
+      matrix:
+        include:
+          - { cuda: "12.9", py: "py312" }
+          - { cuda: "13.2", py: "py312" }
+    uses: ./.github/workflows/qa-gate.yml
+    with:
+      repo: ${{ inputs.DOCKERHUB_REPO || 'comfy' }}
+      tag: ${{ inputs.CUSTOM_IMAGE_TAG || needs.preflight.outputs.comfyui-ref }}-cuda-${{ matrix.cuda }}-${{ matrix.py }}-amd64
+      template_dir: derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa
+      label: base-image-qa-comfyui
+      log_paths: "/var/log/portal/comfyui.log /var/log/portal/api-wrapper.log"
+      # SHA-pinned so the QA box provisions the workflow on the ref under test.
+      extra_env: "PROVISIONING_COMFYUI_WORKFLOWS=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json"
+    secrets:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+
+  merge-manifests:
+    needs: [preflight, build, qa]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -180,6 +180,7 @@ jobs:
     secrets:
       VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
       DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   merge-manifests:
     needs: [preflight, build, qa]

--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -275,6 +275,7 @@ jobs:
     secrets:
       VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
       DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   merge-manifests:
     needs: [preflight, build, qa]

--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -253,8 +253,31 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  merge-manifests:
+  # Live-GPU QA gate (ADR 0005, CON-1585) — calls the reusable qa-gate.yml once per
+  # promoted variant (amd64), gating the prod manifest merge. Per-image specifics
+  # (the {tag,cuda} matrix, the staging tag, the QA template, the label) are here;
+  # the shared core + account concurrency group live in qa-gate.yml. amd64-only;
+  # advisory until VAST_API_KEY exists.
+  qa:
     needs: [preflight, build]
+    if: needs.preflight.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.preflight.outputs.merge-matrix) }}
+    uses: ./.github/workflows/qa-gate.yml
+    with:
+      repo: ${{ inputs.DOCKERHUB_REPO || 'vllm' }}
+      tag: ${{ inputs.CUSTOM_IMAGE_TAG || needs.preflight.outputs.vllm-version }}-cuda-${{ matrix.cuda }}-amd64
+      template_dir: external/vllm/templates/vllm-qa
+      label: base-image-qa-vllm
+      log_paths: "/var/log/portal/vllm.log /var/log/portal/ray.log"
+    secrets:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+
+  merge-manifests:
+    needs: [preflight, build, qa]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -11,7 +11,7 @@
 #     strategy: { matrix: { include: [ {cuda: "12.9", py: "py312"}, ... ] } }
 #     uses: ./.github/workflows/qa-gate.yml
 #     with: { repo: comfy, tag: "...-cuda-${{matrix.cuda}}-...-amd64", template_dir: ..., label: base-image-qa-<img>, ... }
-#     secrets: { VAST_API_KEY: ..., DOCKERHUB_NAMESPACE_STAGING: ... }
+#     secrets: { VAST_API_KEY: ..., DOCKERHUB_NAMESPACE_STAGING: ..., SLACK_WEBHOOK_URL: ... }
 #   merge-manifests: { needs: [preflight, build, qa] }   # gated on qa
 name: QA gate (reusable)
 
@@ -44,10 +44,6 @@ on:
         required: false
         type: string
         default: ""
-      max_price:
-        required: false
-        type: string
-        default: "0.50"
       timeout:
         required: false
         type: string
@@ -62,10 +58,17 @@ on:
         required: false
       DOCKERHUB_NAMESPACE_STAGING:
         required: false
+      SLACK_WEBHOOK_URL:
+        required: false
 
 jobs:
   qa:
     runs-on: ubuntu-latest
+    # soft_pass is set only when an unattended scheduled run promoted UNGATED
+    # (inconclusive infra outcome). notify-soft-pass below pings Slack so that
+    # silent no-op surfaces instead of decaying quietly.
+    outputs:
+      soft_pass: ${{ steps.verdict.outputs.soft_pass }}
     # Serialize live-GPU QA across ALL callers onto the single capped QA account so
     # concurrent builds can't 429-storm it (a 429 -> no_offers -> schedule soft-pass
     # -> silent promotion). Centralised here so every caller inherits it.
@@ -131,7 +134,7 @@ jobs:
           set +e
           python "${TM}/test_template.py" "${{ steps.create.outputs.hash }}" \
             --destroy --raw --force --label "${{ inputs.label }}" \
-            --max-price "${{ inputs.max_price }}" --timeout "${{ inputs.timeout }}" \
+            --timeout "${{ inputs.timeout }}" \
             "${ARGS[@]}" \
             > /tmp/qa-raw.json
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
@@ -145,6 +148,7 @@ jobs:
             || echo "::warning::template ${{ steps.create.outputs.id }} delete failed (HTTP error) — harmless private-template clutter; the instance was already destroyed"
 
       - name: Verdict
+        id: verdict
         if: steps.guard.outputs.run == 'true'
         run: |
           CODE="${{ steps.test.outputs.exit_code }}"
@@ -168,8 +172,34 @@ jobs:
                 else
                   echo "::error::passed WITHOUT a result event — verdict not trustworthy (ADR 0005 cond 2)"; exit 1
                 fi ;;
-            2|3) echo "::warning::INCONCLUSIVE (state=${STATE}) — thin market / infra; holding unless scheduled"; exit ${INCONCLUSIVE_EXIT} ;;
+            2|3) echo "::warning::INCONCLUSIVE (state=${STATE}) — thin market / infra; holding unless scheduled"
+                 if [ "${INCONCLUSIVE_EXIT}" = "0" ]; then
+                   # Unattended schedule soft-passes (promotes ungated). Flag it so
+                   # notify-soft-pass pings Slack — a chronically-skipped gate must
+                   # not decay silently. Set BEFORE the exit so the output is written.
+                   echo "soft_pass=true" >> "$GITHUB_OUTPUT"
+                   echo "::warning::scheduled run promoted UNGATED (no live QA ran) — Slack alerted"
+                 fi
+                 exit ${INCONCLUSIVE_EXIT} ;;
             1|5) echo "::error::BLOCK (state=${STATE}) — a real test failure or instance crash"; exit 1 ;;
             4)  echo "::error::CONFIG ERROR (state=${STATE}) — CI/template bug, not the image"; exit 1 ;;
             *)  echo "::error::unexpected exit code ${CODE}"; exit 1 ;;
           esac
+
+  # When an unattended scheduled run soft-passed (promoted UNGATED on an infra-
+  # inconclusive outcome), ping Slack. Real test failures BLOCK the qa job, so
+  # this never runs for those — it exists solely so a silently-skipped gate on the
+  # release train surfaces instead of decaying to a no-op (review follow-up).
+  notify-soft-pass:
+    needs: qa
+    if: needs.qa.outputs.soft_pass == 'true'
+    uses: ./.github/workflows/notify-slack.yml
+    with:
+      build-result: "failure"   # render as an alert — promotion happened without live QA
+      image-name: ${{ inputs.repo }}
+      image-ref: ${{ inputs.tag }}
+      image-tags: ${{ format('["{0}"]', inputs.tag) }}
+      trigger: "schedule — QA INCONCLUSIVE, image promoted UNGATED"
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -1,0 +1,175 @@
+# Reusable live-GPU QA gate (ADR 0005, CON-1585). Image-agnostic: a build workflow
+# calls this once per staging artifact, passing the finished image coordinates +
+# the QA template. All per-image variation (tag derivation, matrix shape, the
+# provisioning/model env) stays in the CALLER; this job is just the shared core —
+# create a throwaway template -> launch + run the in-instance harness, DESTROYING
+# the instance -> delete the template -> map a machine-readable verdict.
+#
+# Caller pattern:
+#   qa:
+#     needs: [preflight, build]
+#     strategy: { matrix: { include: [ {cuda: "12.9", py: "py312"}, ... ] } }
+#     uses: ./.github/workflows/qa-gate.yml
+#     with: { repo: comfy, tag: "...-cuda-${{matrix.cuda}}-...-amd64", template_dir: ..., label: base-image-qa-<img>, ... }
+#     secrets: { VAST_API_KEY: ..., DOCKERHUB_NAMESPACE_STAGING: ... }
+#   merge-manifests: { needs: [preflight, build, qa] }   # gated on qa
+name: QA gate (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "Dockerhub repo; the tested image is <staging-namespace>/<repo>"
+        required: true
+        type: string
+      tag:
+        description: "The amd64 staging tag to test (already derived by the caller)"
+        required: true
+        type: string
+      template_dir:
+        description: "Path to the QA template dir (<name>/template.yml)"
+        required: true
+        type: string
+      label:
+        description: "Vast instance label to stamp (reaper scope; prefix base-image-qa)"
+        required: true
+        type: string
+      log_paths:
+        description: "Space-separated in-instance log files to stream into the run"
+        required: false
+        type: string
+        default: ""
+      extra_env:
+        description: "Newline-separated KEY=VAL passed as test_template --env (e.g. a SHA-pinned provisioning URL)"
+        required: false
+        type: string
+        default: ""
+      max_price:
+        required: false
+        type: string
+        default: "0.50"
+      timeout:
+        required: false
+        type: string
+        default: "7800"
+      require_floor:
+        description: "Fail if the template declares no parseable compute_cap floor"
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      VAST_API_KEY:
+        required: false
+      DOCKERHUB_NAMESPACE_STAGING:
+        required: false
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    # Serialize live-GPU QA across ALL callers onto the single capped QA account so
+    # concurrent builds can't 429-storm it (a 429 -> no_offers -> schedule soft-pass
+    # -> silent promotion). Centralised here so every caller inherits it.
+    concurrency:
+      group: qa-vast-account
+      cancel-in-progress: false
+    env:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      TM: tools/template_manager
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Gate readiness (advisory until the QA account secret exists)
+        id: guard
+        run: |
+          if [ -z "${VAST_API_KEY}" ]; then
+            echo "::warning::VAST_API_KEY not set — skipping live QA (advisory; promotion not blocked)."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.guard.outputs.run == 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Install template_manager deps
+        if: steps.guard.outputs.run == 'true'
+        run: pip install -r "${TM}/requirements.txt"
+
+      - name: Create throwaway QA template
+        if: steps.guard.outputs.run == 'true'
+        id: create
+        env:
+          STAGING_NS: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+        run: |
+          IMAGE="${STAGING_NS}/${{ inputs.repo }}"
+          echo "Testing ${IMAGE}:${{ inputs.tag }}"
+          python "${TM}/create.py" "${{ github.workspace }}/${{ inputs.template_dir }}" \
+            --image "${IMAGE}" --tag "${{ inputs.tag }}" \
+            --emit-result /tmp/qa-create.json
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          r = json.load(open("/tmp/qa-create.json"))
+          assert r and r[0].get("hash_id") and r[0].get("id"), f"create returned no hash/id: {r}"
+          print(f"hash={r[0]['hash_id']}")
+          print(f"id={r[0]['id']}")
+          PY
+
+      - name: Run live test (DESTROY the instance after)
+        if: steps.guard.outputs.run == 'true'
+        id: test
+        continue-on-error: true
+        env:
+          LOG_PATHS: ${{ inputs.log_paths }}
+          EXTRA_ENV: ${{ inputs.extra_env }}
+        run: |
+          ARGS=()
+          for p in ${LOG_PATHS}; do ARGS+=(--log "$p"); done
+          while IFS= read -r kv; do [ -n "$kv" ] && ARGS+=(--env "$kv"); done <<< "${EXTRA_ENV}"
+          if [ "${{ inputs.require_floor }}" = "true" ]; then ARGS+=(--require-floor); fi
+          set +e
+          python "${TM}/test_template.py" "${{ steps.create.outputs.hash }}" \
+            --destroy --raw --force --label "${{ inputs.label }}" \
+            --max-price "${{ inputs.max_price }}" --timeout "${{ inputs.timeout }}" \
+            "${ARGS[@]}" \
+            > /tmp/qa-raw.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+          echo "---- machine-readable verdict ----"; cat /tmp/qa-raw.json || echo "(no --raw output)"
+
+      - name: Delete the throwaway template (always)
+        if: always() && steps.create.outputs.id != ''
+        run: |
+          python "${TM}/create.py" --delete "${{ steps.create.outputs.id }}" \
+            || echo "::warning::template ${{ steps.create.outputs.id }} delete failed (HTTP error) — harmless private-template clutter; the instance was already destroyed"
+
+      - name: Verdict
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          CODE="${{ steps.test.outputs.exit_code }}"
+          # The client prints the verdict as a single-line JSON object (json.dumps,
+          # no indent) as its FINAL stdout line. Narration/system-logs go to stderr,
+          # but be robust to any bleed: take the last complete {...} line, not the
+          # whole file (json.load on a multi-line/polluted file fails -> '?', which
+          # silently turned a real PASS into a BLOCK on the cu12.9 cell).
+          RAW=$(grep -E '^\{.*\}$' /tmp/qa-raw.json | tail -n1)
+          STATE=$(printf '%s' "$RAW" | python -c "import sys,json;print(json.load(sys.stdin).get('state','?'))" 2>/dev/null || echo "?")
+          GOT=$(printf '%s' "$RAW" | python -c "import sys,json;print(json.load(sys.stdin).get('got_result_event',False))" 2>/dev/null || echo "?")
+          echo "exit_code=${CODE} state=${STATE} got_result_event=${GOT}"
+          # ADR 0005 cond 2: a 'passed' without a result event is not trustworthy.
+          # Inconclusive must not silently auto-promote on the gating path — a
+          # manual/dispatch run HOLDS (exit 1); only the unattended schedule soft-passes.
+          INCONCLUSIVE_EXIT=1
+          [ "${{ github.event_name }}" = "schedule" ] && INCONCLUSIVE_EXIT=0
+          case "${CODE}" in
+            0)  if [ "${GOT}" = "True" ]; then
+                  echo "::notice::FULL pass (state=${STATE})"; exit 0
+                else
+                  echo "::error::passed WITHOUT a result event — verdict not trustworthy (ADR 0005 cond 2)"; exit 1
+                fi ;;
+            2|3) echo "::warning::INCONCLUSIVE (state=${STATE}) — thin market / infra; holding unless scheduled"; exit ${INCONCLUSIVE_EXIT} ;;
+            1|5) echo "::error::BLOCK (state=${STATE}) — a real test failure or instance crash"; exit 1 ;;
+            4)  echo "::error::CONFIG ERROR (state=${STATE}) — CI/template bug, not the image"; exit 1 ;;
+            *)  echo "::error::unexpected exit code ${CODE}"; exit 1 ;;
+          esac

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: string
         default: ""
+      max_price:
+        description: "Per-run $/hr cost cap (dph_total). Backstops the VRAM band, which bounds box size but not price."
+        required: false
+        type: string
+        default: "2.00"
       timeout:
         required: false
         type: string
@@ -134,7 +139,7 @@ jobs:
           set +e
           python "${TM}/test_template.py" "${{ steps.create.outputs.hash }}" \
             --destroy --raw --force --label "${{ inputs.label }}" \
-            --timeout "${{ inputs.timeout }}" \
+            --max-price "${{ inputs.max_price }}" --timeout "${{ inputs.timeout }}" \
             "${ARGS[@]}" \
             > /tmp/qa-raw.json
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/qa-reaper.yml
+++ b/.github/workflows/qa-reaper.yml
@@ -1,0 +1,63 @@
+# QA reaper (ADR 0005 condition 1) — scheduled backstop that destroys orphaned
+# QA instances a runner-kill may have leaked past test_template.py's --destroy.
+# The QA account is single-tenant, so any instance older than the max test
+# duration is an orphan. Schedule + dispatch only (no pull_request) so the QA
+# secret is never exposed to a fork. Active on schedule only once on the default
+# branch; until then, run it manually via workflow_dispatch.
+name: QA reaper — destroy orphaned QA instances
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'   # every 30 minutes
+  workflow_dispatch:
+    inputs:
+      max_age_min:
+        description: "Reap instances with uptime over this many minutes"
+        required: false
+        default: "180"
+      dry_run:
+        description: "Report only — do not destroy"
+        type: boolean
+        default: false
+
+jobs:
+  reap:
+    runs-on: ubuntu-latest
+    env:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Gate readiness
+        id: guard
+        run: |
+          if [ -z "${VAST_API_KEY}" ]; then
+            echo "::notice::VAST_API_KEY not set — nothing to reap (QA account not configured)."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.guard.outputs.run == 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Reap orphaned QA instances
+        if: steps.guard.outputs.run == 'true'
+        env:
+          # Primary scope: the QA label that test_template.py stamps on every
+          # instance it launches (prefix 'base-image-qa'). A good non-test instance
+          # carries no QA label, so it can never be reaped. The staging-namespace
+          # image prefix is ANDed as an extra layer when available. The script's
+          # --max-reap ceiling aborts if an implausible number match (wrong account).
+          QA_LABEL: base-image-qa
+          STAGING_NS: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+        run: |
+          DESTROY="--destroy"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then DESTROY=""; fi
+          PREFIX=""
+          if [ -n "${STAGING_NS}" ]; then PREFIX="--image-prefix ${STAGING_NS}/"; fi
+          python tools/template_manager/reap_orphans.py \
+            --label "${QA_LABEL}" \
+            --max-age-min "${{ inputs.max_age_min || '180' }}" $PREFIX $DESTROY

--- a/.github/workflows/qa-reaper.yml
+++ b/.github/workflows/qa-reaper.yml
@@ -12,9 +12,9 @@ on:
   workflow_dispatch:
     inputs:
       max_age_min:
-        description: "Reap instances with uptime over this many minutes"
+        description: "Reap instances with uptime over this many minutes (blank = script default)"
         required: false
-        default: "180"
+        default: ""
       dry_run:
         description: "Report only — do not destroy"
         type: boolean
@@ -58,6 +58,10 @@ jobs:
           if [ "${{ inputs.dry_run }}" = "true" ]; then DESTROY=""; fi
           PREFIX=""
           if [ -n "${STAGING_NS}" ]; then PREFIX="--image-prefix ${STAGING_NS}/"; fi
+          # Omit --max-age-min on the scheduled path so reap_orphans.py's derived
+          # default governs (single source of truth, kept in sync with the test
+          # budget). A manual dispatch may override it.
+          AGE=""
+          if [ -n "${{ inputs.max_age_min }}" ]; then AGE="--max-age-min ${{ inputs.max_age_min }}"; fi
           python tools/template_manager/reap_orphans.py \
-            --label "${QA_LABEL}" \
-            --max-age-min "${{ inputs.max_age_min || '180' }}" $PREFIX $DESTROY
+            --label "${QA_LABEL}" $AGE $PREFIX $DESTROY

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__
 .env
+
+# template_manager run logs (may reference account ids; never commit)
+tools/template_manager/output/

--- a/derivatives/pytorch/derivatives/comfyui/ROOT/opt/instance-tools/tests/comfyui.d/10-comfyui-serving.sh
+++ b/derivatives/pytorch/derivatives/comfyui/ROOT/opt/instance-tools/tests/comfyui.d/10-comfyui-serving.sh
@@ -168,7 +168,17 @@ wait_for_service_health api-wrapper "${API_URL}/health" "API wrapper"
 echo ""
 echo "  -- workflow payloads --"
 
+# If the template DECLARED workflows to provision (PROVISIONING_COMFYUI_WORKFLOWS
+# set) but none materialised, that's a failure — a 404 on the workflow URL, a
+# provisioning error, or a conversion bug — NOT a skip. A skip would be reported
+# as an overall pass (skip-as-pass), defeating the QA gate (ADR 0005 cond 3). With
+# no workflows declared, skipping is correct (a plain ComfyUI image, nothing to run).
+_declared_workflows="${PROVISIONING_COMFYUI_WORKFLOWS:-}"
+
 if [[ ! -d "$PAYLOADS_DIR" ]]; then
+    if [[ -n "$_declared_workflows" ]]; then
+        test_fail "PROVISIONING_COMFYUI_WORKFLOWS is set but ${PAYLOADS_DIR} does not exist — provisioning/conversion produced no payloads"
+    fi
     test_skip "payloads directory ${PAYLOADS_DIR} does not exist (no API workflows configured)"
 fi
 
@@ -177,6 +187,9 @@ payloads=("${PAYLOADS_DIR}"/*.json)
 shopt -u nullglob
 
 if [[ ${#payloads[@]} -eq 0 ]]; then
+    if [[ -n "$_declared_workflows" ]]; then
+        test_fail "PROVISIONING_COMFYUI_WORKFLOWS is set but no API-format workflows in ${PAYLOADS_DIR} — provisioning/conversion produced nothing"
+    fi
     test_skip "no API-format workflows in ${PAYLOADS_DIR} (nothing to exercise)"
 fi
 

--- a/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/README.md
+++ b/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/README.md
@@ -1,0 +1,43 @@
+# ComfyUI QA template — SD1.5 smoke
+
+The template the [live-GPU QA gate](../../../../../../docs/adr/0005-live-gpu-qa-gate.md)
+launches to verify a freshly-built `vastai/comfyui` image on real hardware before
+promotion. It is **not** a user-facing template — it is disposable and private.
+
+## What it exercises
+
+`comfyui.d/10-comfyui-serving.sh` waits for ComfyUI + the API wrapper, then POSTs
+every provisioned workflow to `/generate/sync` and requires a real output. To make
+that a genuine test (and not a skip-as-pass), this template provisions one real
+workflow + model:
+
+- **Workflow:** [`sd15-txt2img.json`](sd15-txt2img.json) — a standard SD1.5 512×512
+  text-to-image graph. `PROVISIONING_COMFYUI_WORKFLOWS` points the
+  `provisioner_comfyui` extension at it; the extension auto-discovers the checkpoint
+  from the workflow's `properties.models[]`, downloads it, and
+  `convert-workflows.sh` turns it into an API payload.
+- **Model:** `v1-5-pruned-emaonly-fp16.safetensors` (2.1 GB) from the Comfy-Org
+  archive, embedded in the workflow's checkpoint node.
+
+## Launch mode
+
+The template mirrors the **production** ComfyUI template
+(`vast_landing/.../recommended_templates/160-comfyui`) — `runtype: jupyter`, the full
+`PORTAL_CONFIG`, the production `COMFYUI_ARGS`, `COMFYUI_API_BASE` direct-to-ComfyUI,
+the jupyter/ssh-direct flags — so QA exercises the real user launch path, not an
+entrypoint-mode approximation. QA-only deltas: `private`, the SD1.5 smoke workflow
+(prod ships SDXL-Turbo), and the selection floors below.
+
+## Floors (ADR 0005)
+
+`extra_filters` declares the gate's selection floors: `compute_cap >= 750` (sm_75,
+matching production), `cuda_max_good >= 13.2` (host driver must satisfy the newer
+matrix variant), and `gpu_total_ram >= 8192` (8 GB). The gate picks the smallest
+viable amd64 box at/above these, bounded at 2× VRAM — so it smokes an ~8–16 GB box,
+generalising upward.
+
+## CI overrides
+
+`create.py --tag <staging>` repoints `tag` at the image under test. The workflow URL
+default resolves once this lands on `main`; for a pre-merge run the gate passes
+`test_template.py --env PROVISIONING_COMFYUI_WORKFLOWS=<raw URL on the ref under test>`.

--- a/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/README.md
+++ b/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/README.md
@@ -33,7 +33,7 @@ entrypoint-mode approximation. QA-only deltas: `private`, the SD1.5 smoke workfl
 `extra_filters` declares the gate's selection floors: `compute_cap >= 750` (sm_75,
 matching production), `cuda_max_good >= 13.2` (host driver must satisfy the newer
 matrix variant), and `gpu_total_ram >= 8192` (8 GB). The gate picks the smallest
-viable amd64 box at/above these, bounded at 2× VRAM — so it smokes an ~8–16 GB box,
+viable amd64 box at/above these, bounded at 3× VRAM — so it smokes an ~8–24 GB box,
 generalising upward.
 
 ## CI overrides

--- a/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json
+++ b/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json
@@ -1,0 +1,532 @@
+{
+  "id": "03418cd2-b490-418f-9d3c-f7d7d72d992c",
+  "revision": 0,
+  "last_node_id": 9,
+  "last_link_id": 9,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        413,
+        389
+      ],
+      "size": [
+        425.27801513671875,
+        180.6060791015625
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "clip",
+          "name": "clip",
+          "type": "CLIP",
+          "link": 5
+        },
+        {
+          "localized_name": "text",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "CONDITIONING",
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            6
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "text, watermark"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        415,
+        186
+      ],
+      "size": [
+        422.84503173828125,
+        164.31304931640625
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "clip",
+          "name": "clip",
+          "type": "CLIP",
+          "link": 3
+        },
+        {
+          "localized_name": "text",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "CONDITIONING",
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            4
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [
+        473,
+        609
+      ],
+      "size": [
+        315,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "width",
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "height",
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "batch_size",
+          "name": "batch_size",
+          "type": "INT",
+          "widget": {
+            "name": "batch_size"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            2
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        512,
+        512,
+        1
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        863,
+        186
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 1
+        },
+        {
+          "localized_name": "positive",
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 4
+        },
+        {
+          "localized_name": "negative",
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 6
+        },
+        {
+          "localized_name": "latent_image",
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 2
+        },
+        {
+          "localized_name": "seed",
+          "name": "seed",
+          "type": "INT",
+          "widget": {
+            "name": "seed"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "steps",
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "cfg",
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "sampler_name",
+          "name": "sampler_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "sampler_name"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "scheduler",
+          "name": "scheduler",
+          "type": "COMBO",
+          "widget": {
+            "name": "scheduler"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "denoise",
+          "name": "denoise",
+          "type": "FLOAT",
+          "widget": {
+            "name": "denoise"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            7
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        1029256639393460,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1209,
+        188
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "samples",
+          "name": "samples",
+          "type": "LATENT",
+          "link": 7
+        },
+        {
+          "localized_name": "vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 8
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            9
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        1451,
+        189
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "link": 9
+        },
+        {
+          "localized_name": "filename_prefix",
+          "name": "filename_prefix",
+          "type": "STRING",
+          "widget": {
+            "name": "filename_prefix"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        26,
+        474
+      ],
+      "size": [
+        315,
+        98
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "ckpt_name",
+          "name": "ckpt_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "ckpt_name"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "MODEL",
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            1
+          ]
+        },
+        {
+          "localized_name": "CLIP",
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": [
+            3,
+            5
+          ]
+        },
+        {
+          "localized_name": "VAE",
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": [
+            8
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "v1-5-pruned-emaonly-fp16.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/ce8e3e3657a9b767b33fc0171ff91fb04aed1b2f/v1-5-pruned-emaonly-fp16.safetensors",
+            "directory": "checkpoints"
+          }
+        ]
+      },
+      "widgets_values": [
+        "v1-5-pruned-emaonly-fp16.safetensors"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      4,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      2,
+      5,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      3,
+      4,
+      1,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      4,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      5,
+      4,
+      1,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      6,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      7,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      8,
+      4,
+      2,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      9,
+      8,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.18.9"
+  },
+  "version": 0.4
+}

--- a/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/template.yml
+++ b/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/template.yml
@@ -1,0 +1,49 @@
+# ComfyUI QA template (ADR 0005 live-GPU QA gate, CON-1585).
+#
+# Mirrors the PRODUCTION ComfyUI template (vast_landing .../recommended_templates/
+# 160-comfyui) so QA exercises the real launch path — `runtype: jupyter` (Jupyter
+# injected by Vast at runtime, not the entrypoint/args mode), the full PORTAL_CONFIG,
+# the production COMFYUI_ARGS, and the api-wrapper backend. QA-only deltas: private/
+# disposable, an SD1.5 smoke workflow (vs prod's SDXL-Turbo), and the ADR 0005
+# selection floors (amd64 is forced by the tool, not the template).
+#
+# CI overrides `tag` (and `image`) with the freshly-built staging tag via
+# `create.py --tag`, and PROVISIONING_COMFYUI_WORKFLOWS via `test_template.py --env`
+# pinned to the dispatched SHA (the `main` default below is for manual runs).
+name: "ComfyUI QA — SD1.5 smoke"
+image: vastai/comfyui
+tag: latest                       # CI overrides with the staging tag
+private: true                     # disposable QA template, never public
+readme_visible: false
+onstart: entrypoint.sh
+runtype: jupyter                  # production launch mode (was 'args' = entrypoint mode)
+jup_direct: true
+ssh_direct: true
+use_ssh: true
+use_jupyter_lab: false
+ports:
+  - "1111:1111"                   # Instance Portal
+  - "8080:8080"                   # Jupyter
+  - "8188:8188"                   # ComfyUI
+  - "8288:8288"                   # API Wrapper
+  - "8384:8384"                   # Syncthing
+env:
+  COMFYUI_ARGS: "--disable-auto-launch --disable-xformers --port 18188 --enable-cors-header"
+  # api-wrapper /health probes the backend's /system_stats + WebSocket; point it at
+  # ComfyUI DIRECTLY (18188), not the Caddy edge (8188) which OPEN_BUTTON_TOKEN auth-gates.
+  COMFYUI_API_BASE: "http://localhost:18188"
+  PORTAL_CONFIG: "localhost:1111:11111:/:Instance Portal|localhost:8188:18188:/:ComfyUI|localhost:8288:18288:/docs:API Wrapper|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal|localhost:8384:18384:/:Syncthing"
+  OPEN_BUTTON_PORT: "1111"
+  OPEN_BUTTON_TOKEN: "1"
+  JUPYTER_DIR: "/"
+  DATA_DIRECTORY: "/workspace/"
+  PROVISIONING_COMFYUI_WORKFLOWS: "https://raw.githubusercontent.com/vast-ai/base-image/main/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json"
+# QA gate floors (ADR 0005): smallest viable box at/above these, VRAM bounded 2x.
+extra_filters:
+  compute_cap:
+    gte: 750                      # sm_75 — matches the production template
+  cuda_max_good:
+    gte: 13.2                     # host driver must satisfy the newer matrix variant (cuda-13.2)
+  gpu_total_ram:
+    gte: 8192                     # 8 GB floor (SD1.5 + headroom); selection bounds to [8,16] GB
+recommended_disk_space: 40.0      # ComfyUI image + 2.1 GB SD1.5 checkpoint + workspace

--- a/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/template.yml
+++ b/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/template.yml
@@ -38,12 +38,12 @@ env:
   JUPYTER_DIR: "/"
   DATA_DIRECTORY: "/workspace/"
   PROVISIONING_COMFYUI_WORKFLOWS: "https://raw.githubusercontent.com/vast-ai/base-image/main/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json"
-# QA gate floors (ADR 0005): smallest viable box at/above these, VRAM bounded 2x.
+# QA gate floors (ADR 0005): smallest viable box at/above these, VRAM bounded 3x.
 extra_filters:
   compute_cap:
     gte: 750                      # sm_75 — matches the production template
   cuda_max_good:
     gte: 13.2                     # host driver must satisfy the newer matrix variant (cuda-13.2)
   gpu_total_ram:
-    gte: 8192                     # 8 GB floor (SD1.5 + headroom); selection bounds to [8,16] GB
+    gte: 8192                     # 8 GB floor (SD1.5 + headroom); selection bounds to [8,24] GB
 recommended_disk_space: 40.0      # ComfyUI image + 2.1 GB SD1.5 checkpoint + workspace

--- a/docs/adr/0005-live-gpu-qa-gate.md
+++ b/docs/adr/0005-live-gpu-qa-gate.md
@@ -1,0 +1,306 @@
+# ADR 0005 — Live-GPU QA gate (template publish + instance test in CI)
+
+- **Status:** Accepted (conditional — see Binding conditions; build sequenced from condition 9, first template ComfyUI)
+- **Date:** 2026-06-26
+- **Decision owner:** Rob Ballantyne
+- **Process:** idea brief → critical review → scope collapse → synthesis → **final review of the written plan** (caught the selection-mechanism/code mismatch and the exit-code enforceability gaps, now folded into the Decision and conditions). The original "gate the whole fleet" framing was judged to manufacture false confidence and is a rejected alternative below.
+
+## Context
+
+CI today gates on **image build** only: a `build-<x>.yml` runs
+`preflight → build (matrix base_image × arch → arch-suffixed tags in the STAGING
+namespace) → merge-manifests (crane-assemble the multi-arch index at the
+PRODUCTION tag)`. Nothing boots the image on a GPU before it is promoted to
+users. We want a second tier — a **FULL pass** that means "the published artifact
+actually ran on real hardware" — without manufacturing false confidence or
+runaway GPU spend.
+
+The machinery mostly exists (CON-1585): an in-instance harness
+(`ROOT/opt/instance-tools/tests/`, SSE on port 10199, base health + the ADR-0006
+exposure gate + per-image `<name>.d` functional tests), a stdlib client
+`tools/template_manager/test_template.py` that launches a Vast instance from a
+template hash, streams results, and tears the instance down, and
+`tools/template_manager/create.py` that creates a template from
+`<name>/{template.yml, README.md}`. Tooling scope/terms are in [ADR 0008](0008-template-publish-tooling.md);
+the in-instance exposure check is [ADR 0006](0006-inadvertent-exposure-gate.md).
+
+A critical review of the obvious design ("every image gets a live GPU test that gates
+promotion") found it net-negative as framed:
+
+- **Coverage cliff.** Only **5** images have a functional `*.d` test
+  (`pytorch`, `comfyui`, `llama-cpp`, `external/vllm`, `external/sglang`); the
+  other ~25 get boot-and-curl health checks. A whole-fleet gate spends GPU money
+  to assert "QA'd" when it means "booted."
+- **Skip-as-pass.** `external/vllm/.../vllm.d/10-vllm-serving.sh` *skips itself*
+  when `VLLM_MODEL` is unset, and the runner still reports pass. The richest test
+  in the repo is a no-op unless the QA template pins a real model.
+- **Overloaded exit codes.** `test_template.py` emits `0/1/2/3`. `2` conflates
+  genuine spot-market flake with template-not-found, API errors, and
+  instance-crashed-mid-test (`error` final state). "All of 2 → inconclusive →
+  promote" silently promotes real breakage.
+- **No reaper.** `--destroy` runs inside the very process a runner
+  cancellation/timeout kills; nothing out-of-band knows the instance ID, so paid
+  instances leak.
+- **Arch blind spot.** Vast GPU hosts are overwhelmingly x86; the gate validates
+  only the amd64 staging tag while `merge-manifests` promotes a multi-arch index
+  including the untested arm64 manifest.
+- **Flake → rubber-stamp.** 2h default timeouts, 25 launch attempts, and a thin
+  spot market make a whole-fleet gate slow and noisy enough to be ignored or
+  overridden — worse than no gate.
+
+## Options considered
+
+- **A. Whole-fleet live-GPU gate.** Every image's promotion blocked on a live
+  instance test. **Rejected:** for ~25 of ~30 images the harness is boot-and-curl,
+  so the gate launders "booted" into "QA'd"; renting a GPU to run `curl localhost`
+  is unfavorable vs a CPU/static check; the spend and latency invite rubber-stamping.
+- **B. Static/container-only checks (no live GPU).** Lint + `docker run` smoke on
+  a CPU runner. **Rejected as the *whole* answer:** cannot catch runtime
+  regressions that need a GPU (a CUDA pin that breaks inference, a model that
+  loads but generates garbage, an OOM under real load). Kept as the *floor* for
+  the non-allowlist images (see Decision).
+- **C. Narrow allowlist live gate + non-gating smoke (chosen).** Live GPU test
+  *gates* promotion only for an allowlist of images whose `<name>.d` test exercises
+  the product (and loads a real model for inference images), amd64-only; all other
+  images emit a separate, weaker, **non-gating** smoke signal that does not claim
+  "QA passed."
+
+## Decision
+
+Add a `qa` job on the seam between `build` and `merge-manifests`
+(`merge-manifests` gains `needs: [..., qa]`). It runs on a cheap `ubuntu-latest`
+runner — the GPU is the rented Vast instance, not the runner. The job:
+`create.py` makes a **private, SHA-named, TTL-labelled** throwaway template
+pointing at the freshly-built **amd64 STAGING** tag; `test_template.py` launches an
+instance, runs the harness, streams results, destroys the instance; the job maps
+the exit code to a verdict; then deletes the throwaway template.
+
+**Scope is an allowlist, not the fleet.** The gate *blocks promotion* only for
+images on a `qa-gating` allowlist — those whose `<name>.d` functional test
+exercises the product. Inference images on the allowlist **must** have their QA
+template pin a small real model, and the test must **fail (not skip)** if that
+precondition is absent. Every other image emits a distinct, **non-gating** smoke
+status (base health + exposure) that must not be presented as "QA passed."
+
+**Verdict mapping (as shipped — distinct exit codes; auto-promote requires a
+positive signal).** `test_template.py` emits a distinct code per outcome and a
+`--raw` JSON carrying `state` + `got_result_event`; the workflow Verdict step keys
+on both:
+
+| exit | state | verdict |
+|---|---|---|
+| `0` **and** `got_result_event == true` | `passed` | **FULL pass** → allow promote |
+| `0` **and** `got_result_event == false` | `passed` | **BLOCK** — a pass without a result event is not trustworthy |
+| `1` | `failed` | **BLOCK** — a real in-instance test failed |
+| `5` | `instance_error` | **BLOCK** — instance crashed mid-test (treat as the image) |
+| `4` | `config_error` | **HARD ERROR** — template-not-found / bad `--env` / non-`vastai` image / auth / API error (CI bug — fix, do not promote) |
+| `2` | `no_offers` | **inconclusive** — thin market (no box in the arch/VRAM band) |
+| `3` | `bad_instance` | **inconclusive** — exhausted launch attempts |
+| `130` | `interrupted` | treated as BLOCK (a cancellation, not a pass) |
+
+"Inconclusive" (`2`/`3`) **never auto-promotes on the gating path** (manual
+dispatch / post-merge): the Verdict step **holds** (exit 1) so a human looks. Only
+the **unattended `schedule` path soft-passes** an inconclusive, so a thin 00:00
+market doesn't block the nightly promotion of an unchanged image.
+
+**As shipped (cron gates too).** The narrower "non-gating smoke for non-allowlist
+images" in option C below is *not yet built* — the only gate wired is the comfyui
+allowlist gate, and it runs on **both** the `schedule` build and `workflow_dispatch`,
+gating `merge-manifests` in each. So a scheduled build *does* gate promotion; the
+only schedule-vs-dispatch difference is the inconclusive handling above (cron
+soft-passes a thin market; dispatch holds). When non-allowlist images gain their
+own non-gating smoke, that split lands; until then "cron = non-gating only" does
+not apply.
+
+**Offer selection — smallest viable box above mandatory floors (built).** Every
+template declares a `compute_cap` floor (enforced by the template linter — a
+template that omits it fails validation, so there is no floor-less path and no
+default to be silently wrong). The tester restricts to amd64 (`cpu_arch ==
+"amd64"`, a confirmed Vast offer field), then selects the **smallest VRAM above the
+declared floor, then the lowest `compute_cap`** above its floor — the cheapest box
+that still has the capacity and features the image needs. The VRAM search is
+**hard-bounded above** at `VRAM_CEILING_MULTIPLIER × floor` (default 2×): a
+"`>=12GB`" claim is never tested on a 96GB box (a template may set its own
+`gpu_total_ram` upper bound to override).
+
+Generalisation is **directional — state it honestly:**
+- *Upward in VRAM it holds (the primary axis).* More VRAM is strictly safer for OOM,
+  so a pass at the (headroom-adjusted) VRAM floor implies bigger boxes pass — which
+  is why VRAM dominates selection and the search is bounded close to the floor.
+- *Across compute capability it holds because GPUs are backward-compatible* (sm_90
+  runs sm_70 code): testing at the lowest capability **at or above the declared
+  floor** generalises up to every higher one. The floor must encode the image's
+  **feature target** (e.g. `compute_cap >= 890` for FP8/sm_89): a floor declared
+  *too low* would test below the features the image actually uses and leave that
+  kernel path promoted-but-untested. Mandatory declaration removes the floor-less
+  hole; floor *correctness* is enforced separately (condition 10 — validated by a
+  real passing run). (`compute_cap` is an integer ×100: 700 = sm_70, 890 = sm_89/
+  FP8, 900 = H100, 1200 = B200.)
+
+VRAM floors carry **headroom** (footprint × margin), not the model's resting size —
+a closest-fit box OOMs on KV-cache/graph-capture. If no offer meets the floor the run
+is a HARD ERROR (under-provisioned test), never a skip. Because every template carries
+explicit floors, even the non-gating smoke selects a determinate, bounded GPU class
+rather than a random-generation box, so it does not flap red for hardware reasons.
+(The narrow VRAM band trades some availability for representativeness — a thin market
+in the band surfaces as "no offers"/inconclusive, not a silent jump to a huge box.)
+
+## Binding conditions
+
+Non-negotiable; the gate must not be enabled until all hold. Each maps to a
+surviving review finding.
+
+1. **Out-of-band reaper exists and is proven.** A mechanism independent of the
+   test process reaps paid instances after a simulated runner kill — a scheduled
+   sweep that destroys QA-account instances older than N minutes **and/or** a
+   server-side instance TTL/auto-destroy label set at launch. Without this the
+   design leaks billable instances and is void.
+2. **Verdict read from machine-readable output, not `$?` alone.** Today the tool
+   collapses *instance-error*, *config/CI error*, *no-offers* and *interrupt* all
+   into a single exit `2`, and `got_result_event` is in neither the exit code nor
+   `--raw` — so the 4-way table is **not implementable against the current
+   surface**. Before the gate is enabled the tool must emit distinct,
+   machine-readable outcomes (distinct exit codes and/or a `--raw` JSON carrying
+   `state` + `got_result_event` on *every* exit path, including the early
+   `sys.exit(2)` config-error paths). CI reads that JSON: an `error` final state
+   and config/CI errors are **hard-stops** (not "inconclusive"); auto-promote
+   requires `passed` **with** `got_result_event == true`. (Tool change tracked in
+   condition 9.)
+3. **Allowlist gating + fail-not-skip.** The gate blocks promotion only for the
+   `qa-gating` allowlist; inference images on it pin a real model and the test
+   **fails** when the model precondition is unmet. Non-allowlist images get a
+   non-gating smoke check that does not claim "QA passed."
+4. **amd64-only, enforced.** The offer search filters `cpu_arch == "amd64"`; the
+   tool never silently lands on an arm host. arm GPU instances are beginning to
+   appear on Vast but their availability and reliability are not yet characterised,
+   so arm64 is QA-untested at promotion and the status check must not claim arm
+   coverage. An opt-in arm path (`--arch`/allowlist) is revisited once arm
+   availability/reliability is understood — not before.
+5. **Fork-PR safety verified, not just intended.** Live QA never runs on
+   `pull_request`/`pull_request_target` from forks. Triggers are post-merge `main`,
+   nightly schedule, or maintainer-approved dispatch — verified on the trigger,
+   not asserted in prose. The QA `VAST_API_KEY` is a dedicated QA-account key with
+   a **capped balance** (blast radius = balance) since Vast key scoping may be
+   coarse.
+6. **Concurrency cap on the QA account.** QA launches are serialized/staggered so
+   a shared cron across ~22 workflows cannot self-DoS the account into 429s (which
+   would otherwise become exit-2 inconclusive → mass silent promotion). The gating
+   path is opt-in per promotion, not fanned out unattended.
+7. **Cost ceiling.** Every launch carries `--max-price` and `--timeout`; the
+   gating smoke config is cheap (no large model download where avoidable); a
+   per-run and per-day spend ceiling on the QA account is set and monitored.
+8. **Plaintext-channel acknowledged.** The harness auth token is the instance
+   `jupyter_token` streamed over `http://` on a public IP — accepted only because
+   the box is a short-lived throwaway; the QA key is never round-tripped through an
+   instance `--env` (the `*_pass/_token/_key/_secret` redactor would not catch a
+   `VAST_API_KEY`-named value).
+9. **Prerequisite work shipped first.** Landed: the `cpu_arch == "amd64"` filter and
+   the VRAM-primary + bounded `compute_cap`-floor selection (condition 10), with unit
+   tests. Still to build before the gate is enabled: `create.py`/`models.py`
+   `--tag`/`--image` override (point a template at a staging tag); a re-added
+   **scoped** template delete; the template-linter check that rejects a template
+   missing a `compute_cap` floor; **distinct machine-readable outcomes** (exit codes
+   and/or `--raw` `state` + `got_result_event` on every exit path, condition 2); the
+   reaper (condition 1); and the per-arch **staging tag exported as a `build` job
+   output** and consumed by `qa` — never recomputing the date-derived tag downstream
+   (`STAGING_TAG_BASE` is built from `date -u` and can roll across midnight into a
+   404). The gate is not enabled until these land with tests.
+
+10. **Mandatory floors; smallest-viable bounded selection; floors validated.**
+    Every template declares a `compute_cap` floor — the template linter rejects one
+    that omits it, so there is no floor-less path and no default to be silently
+    wrong. Selection is **VRAM-primary**: the smallest VRAM above the floor, then the
+    lowest `compute_cap` above its floor; the VRAM search is **bounded above** at
+    `VRAM_CEILING_MULTIPLIER × floor` so a small claim is not tested on a huge box.
+    The `compute_cap` floor must encode the image's **feature target** (e.g.
+    `compute_cap >= 890` for FP8), not just VRAM; a floor declared too low under-tests
+    newer-arch kernels. VRAM floors carry headroom (footprint × margin). Each
+    allowlist floor is **validated by a real passing run at that floor before gating
+    is enabled** (a too-tight floor OOM-BLOCKs; a too-high floor or too-narrow VRAM
+    band HARD-ERRORs/no-offers on the thin amd64 market — both brick the gate). An
+    unmeetable floor is a hard error, not a skip.
+
+11. **Each condition is merge-blocking, not prose.** Before `qa` gates an image,
+    every condition above has a concrete enforcing artifact — the reaper a
+    SIGKILL-and-assert-destroyed test (condition 1); fork-PR safety a CI assertion
+    that the `qa` trigger excludes fork `pull_request` (condition 5); each allowlist
+    floor a recorded passing run (condition 10). A condition without its artifact
+    keeps the gate disabled for that image; conditions must not degrade silently
+    into aspirations.
+
+If any condition is refused, this decision is void.
+
+## Consequences
+
+- A genuine **FULL pass** tier for the handful of images where it means something
+  (inference products run a real model on a real GPU on the actual published
+  artifact), gating their promotion — while the rest of the fleet keeps an honest,
+  cheap, non-gating smoke signal instead of a green check that overclaims.
+- Real but bounded GPU spend, concentrated on the allowlist; a reaper and spend
+  ceiling cap the downside.
+- arm64 remains QA-untested at promotion (accepted, stated) until a separate path
+  exists; consistent with the current amd64-pinned reality of many derivatives.
+- New CI surface and a QA account to operate; orphan/spend monitoring becomes an
+  ongoing cost.
+- **Honest marginal value.** Over the cheaper option B (CPU `docker run` + static
+  import/CUDA-availability checks + the existing boot-and-curl), the live gate's
+  *only* additional catch is the genuinely-runtime-GPU class — "model loads but
+  OOMs or emits 0 tokens under real load" (the vLLM test does assert
+  `completion_tokens > 0`) — for the ~5 allowlist images. That is real signal, but
+  it is a lot of standing surface (QA account, reaper, monitoring, ~6 tool
+  features, per-model floor tuning) for a handful of images. If the team will not
+  also commit to keeping floors tuned and the reaper tested, this rots into a
+  flaky red check that gets `[skip qa]`'d — strictly worse than option B. The
+  go/no-go on building it should weigh that explicitly.
+
+## Rollout to other images — scale-readiness
+
+The comfyui gate is the first consumer; extending it to other images (the ones with
+a real `<name>.d` functional test — vllm, sglang, llama-cpp, pytorch) must satisfy
+these, or the gate's safety properties invert at scale:
+
+- **Reaper ceiling scales with the allowlist.** `--max-reap` is a runaway backstop,
+  **not** the primary guard — the `--label` scope is (only QA-stamped instances are
+  ever candidates). The default (30) is sized above full-rollout concurrency
+  (images × matrix cells × in-flight); raise it as images are gated. A ceiling sized
+  for one image fail-closes into a leak once concurrency exceeds it.
+- **One QA account → serialize launches.** All qa jobs share the
+  `concurrency: qa-vast-account` group so concurrent builds can't 429-storm the
+  single capped key — a 429 maps to `no_offers`/inconclusive, which the schedule
+  path soft-passes, i.e. silent promotion. Onboarded images **must** join the group
+  **and** stagger their build crons (the group alone drops excess matrix cells under
+  contention → those images held, not tested).
+- **Smoke model ≠ production model.** Mirror the production template's *launch path*
+  (runtype, ports, PORTAL_CONFIG, args) but **not** its model/floors: production
+  models are large (e.g. llama-cpp's default is a ~35B GGUF) and would brick the
+  small-box selector (OOM or no-offers). Each image pins a deliberately tiny model
+  with its **own** `compute_cap`/VRAM/`cuda_max_good` floor + disk, validated by a
+  real passing run (condition 10). Note: vllm/sglang/llama deliver the model via a
+  `*_MODEL` env + serve-time HF download, not comfyui's `PROVISIONING_COMFYUI_WORKFLOWS`
+  mechanism — the onboarding step is per-image, not a uniform "mirror the template."
+- **Multi-GPU sub-tests are skipped by the single-box selector.** `pytorch.d`'s NCCL
+  test only runs on `num_gpus > 1`; the smallest-viable-box selection gives one GPU,
+  so it self-skips. Either pin `num_gpus >= 2` for that image (cost) or scope its gate
+  as single-GPU-only and state it (same honesty as the amd64-only caveat) — do not let
+  a multi-GPU regression promote as a FULL pass.
+- **Generalise from two, not one.** Extract a reusable `qa-gate.yml` workflow only
+  after a second, structurally-different consumer exists (build matrices differ:
+  comfyui's static `base_image` list vs vllm/sglang's dynamic `{tag,cuda}` JSON vs
+  llama's weekly single-base) — generalising from comfyui alone yields a leaky
+  abstraction.
+
+## What would reverse this
+
+- The harness gaining real functional tests across the fleet (so the allowlist
+  stops being tiny) — then a broader gate becomes defensible and this narrow scope
+  is revisited.
+- Evidence the gate catches little that a cheaper CPU `docker run` + static checks
+  miss — then collapse to option B and drop the live GPU spend.
+- Vast offering first-class ephemeral/TTL instances or scoped keys that make the
+  reaper and capped-balance conditions trivial — simplifies, doesn't reverse.
+
+## Note on ADR numbering
+
+ADRs 0002–0008 are spread across CON-1585 feature branches not yet merged
+together (see [ADR 0008](0008-template-publish-tooling.md)); reconcile the
+sequence when they land.

--- a/docs/adr/0005-live-gpu-qa-gate.md
+++ b/docs/adr/0005-live-gpu-qa-gate.md
@@ -101,7 +101,10 @@ on both:
 "Inconclusive" (`2`/`3`) **never auto-promotes on the gating path** (manual
 dispatch / post-merge): the Verdict step **holds** (exit 1) so a human looks. Only
 the **unattended `schedule` path soft-passes** an inconclusive, so a thin 00:00
-market doesn't block the nightly promotion of an unchanged image.
+market doesn't block the nightly promotion of an unchanged image. A soft-pass is
+**not silent**: the gate sets a `soft_pass` output and a `notify-soft-pass` job
+pings Slack (`notify-slack.yml`), so a gate that chronically can't run (a too-tight
+floor, a thin market) surfaces instead of decaying to a no-op on the release train.
 
 **As shipped (cron gates too).** The narrower "non-gating smoke for non-allowlist
 images" in option C below is *not yet built* — the only gate wired is the comfyui
@@ -186,9 +189,15 @@ surviving review finding.
    a shared cron across ~22 workflows cannot self-DoS the account into 429s (which
    would otherwise become exit-2 inconclusive → mass silent promotion). The gating
    path is opt-in per promotion, not fanned out unattended.
-7. **Cost ceiling.** Every launch carries `--max-price` and `--timeout`; the
-   gating smoke config is cheap (no large model download where avoidable); a
-   per-run and per-day spend ceiling on the QA account is set and monitored.
+7. **Cost ceiling.** Every launch carries `--timeout`, and offer selection is
+   bounded to a near-floor VRAM band (`apply_vram_ceiling`, 2× the declared floor)
+   so a `>=8GB` claim is never tested on a 96GB box — that band, not a price filter,
+   is the cost control. (A `dph_total`/`--max-price` filter was removed from the
+   gate: on top of the VRAM ceiling it mostly added `no_offers` inconclusives —
+   i.e. soft-passes — without meaningfully lowering spend. `--max-price` remains
+   available on `test_template.py` for ad-hoc caps.) The gating smoke config is
+   cheap (no large model download where avoidable); a per-run and per-day spend
+   ceiling on the QA account is set and monitored.
 8. **Plaintext-channel acknowledged.** The harness auth token is the instance
    `jupyter_token` streamed over `http://` on a public IP — accepted only because
    the box is a short-lived throwaway; the QA key is never round-tripped through an

--- a/docs/adr/0005-live-gpu-qa-gate.md
+++ b/docs/adr/0005-live-gpu-qa-gate.md
@@ -122,9 +122,11 @@ default to be silently wrong). The tester restricts to amd64 (`cpu_arch ==
 "amd64"`, a confirmed Vast offer field), then selects the **smallest VRAM above the
 declared floor, then the lowest `compute_cap`** above its floor — the cheapest box
 that still has the capacity and features the image needs. The VRAM search is
-**hard-bounded above** at `VRAM_CEILING_MULTIPLIER × floor` (default 2×): a
-"`>=12GB`" claim is never tested on a 96GB box (a template may set its own
-`gpu_total_ram` upper bound to override).
+**hard-bounded above** at `VRAM_CEILING_MULTIPLIER × floor` (default 3×): an
+"`>=8GB`" claim is never tested on a 96GB box (a template may set its own
+`gpu_total_ram` upper bound to override). 3× admits the abundant 24GB consumer
+tier to keep the market from going thin while still excluding the 40/80GB
+datacenter cards — the band, not a price filter, is the cost control.
 
 Generalisation is **directional — state it honestly:**
 - *Upward in VRAM it holds (the primary axis).* More VRAM is strictly safer for OOM,
@@ -190,7 +192,7 @@ surviving review finding.
    would otherwise become exit-2 inconclusive → mass silent promotion). The gating
    path is opt-in per promotion, not fanned out unattended.
 7. **Cost ceiling.** Every launch carries `--timeout`, and offer selection is
-   bounded to a near-floor VRAM band (`apply_vram_ceiling`, 2× the declared floor)
+   bounded to a near-floor VRAM band (`apply_vram_ceiling`, 3× the declared floor)
    so a `>=8GB` claim is never tested on a 96GB box — that band, not a price filter,
    is the cost control. (A `dph_total`/`--max-price` filter was removed from the
    gate: on top of the VRAM ceiling it mostly added `no_offers` inconclusives —

--- a/docs/adr/0005-live-gpu-qa-gate.md
+++ b/docs/adr/0005-live-gpu-qa-gate.md
@@ -191,15 +191,17 @@ surviving review finding.
    a shared cron across ~22 workflows cannot self-DoS the account into 429s (which
    would otherwise become exit-2 inconclusive → mass silent promotion). The gating
    path is opt-in per promotion, not fanned out unattended.
-7. **Cost ceiling.** Every launch carries `--timeout`, and offer selection is
-   bounded to a near-floor VRAM band (`apply_vram_ceiling`, 3× the declared floor)
-   so a `>=8GB` claim is never tested on a 96GB box — that band, not a price filter,
-   is the cost control. (A `dph_total`/`--max-price` filter was removed from the
-   gate: on top of the VRAM ceiling it mostly added `no_offers` inconclusives —
-   i.e. soft-passes — without meaningfully lowering spend. `--max-price` remains
-   available on `test_template.py` for ad-hoc caps.) The gating smoke config is
-   cheap (no large model download where avoidable); a per-run and per-day spend
-   ceiling on the QA account is set and monitored.
+7. **Cost ceiling.** Every launch carries `--timeout` and two complementary spend
+   bounds: offer selection is bounded to a near-floor VRAM band
+   (`apply_vram_ceiling`, 3× the declared floor) so a `>=8GB` claim is never tested
+   on a 96GB box — the band bounds box *size* — and a per-run `--max-price`
+   (`dph_total`) cap bounds the `$/hr` rate (VRAM size ≠ price). The cap is
+   deliberately **generous** (default `$2.00`, was `$0.50`): a too-tight cap mostly
+   produced `no_offers` inconclusives (→ schedule soft-passes) without lowering
+   real spend, so it is set high enough to admit the near-floor band while still
+   backstopping a runaway-priced offer. The gating smoke config is cheap (no large
+   model download where avoidable); a per-run and per-day spend ceiling on the QA
+   account is set and monitored as the blunt backstop.
 8. **Plaintext-channel acknowledged.** The harness auth token is the instance
    `jupyter_token` streamed over `http://` on a public IP — accepted only because
    the box is a short-lived throwaway; the QA key is never round-tripped through an

--- a/docs/adr/0008-template-publish-tooling.md
+++ b/docs/adr/0008-template-publish-tooling.md
@@ -64,9 +64,9 @@ CON-1585, under these terms:
 4. **Tool-local dependency policy.** Third-party deps for a tool live in
    `tools/<x>/requirements.txt` and are **not** part of any image. `pydantic` +
    `pyyaml` (typed validation of `template.yml`) earn their place; `httpx`/async
-   is heavier than this serial, self-paced workload needs (`test_template.py`
-   does gnarlier networking in stdlib) — kept for now, not to be cargo-culted by
-   the next tool.
+   was rejected in favor of stdlib `urllib` — heavier than this serial,
+   self-paced workload needs (`test_template.py` does gnarlier networking in
+   stdlib too), and not to be cargo-culted by the next tool.
 
 ## Binding conditions
 
@@ -95,7 +95,7 @@ If any condition is refused, this decision is void.
 - A duplicated, now-diverged Vast-API core exists in two repos. Mitigated by the
   ownership split and a fenced scope; the residual risk is parallel maintenance
   if the console API changes.
-- New tool-local deps (`httpx`, `pydantic`, `pyyaml`, `python-dotenv`) enter the
+- New tool-local deps (`pydantic`, `pyyaml`, `python-dotenv`) enter the
   repo's dev surface, but not any image.
 
 ## What would reverse this

--- a/docs/adr/0008-template-publish-tooling.md
+++ b/docs/adr/0008-template-publish-tooling.md
@@ -1,0 +1,113 @@
+# ADR 0008 — Template publish + live-test tooling in base-image
+
+- **Status:** Accepted (conditional — see Binding conditions)
+- **Date:** 2026-06-26
+- **Decision owner:** Rob Ballantyne
+- **Process:** copied from `vast_landing` (director-authorised) → trimmed to two tools → multi-dimension review (correctness / security / fit) → findings fixed
+
+## Context
+
+CON-1585 builds the new-image pipeline. The last mile of that pipeline is
+*publishing* a built image as a Vast.ai template and *testing* it on real
+hardware. Both already existed in the private `vast_landing` repo's
+`scripts/template_manager`, which is a larger suite (model-library generator,
+recommended/autoscaler pipelines, template CRUD). With director approval the
+relevant pieces were copied into this repo (the source remains in
+`vast_landing`) and trimmed to just the two tools the pipeline needs:
+
+- **`create.py` (+ `template_manager.py`, `models.py`)** — create a Vast.ai
+  template from a directory of `<name>/{template.yml, README.md}`. Talks to the
+  Vast.ai **console** API (`POST /template/`).
+- **`test_template.py`** — launch a live GPU instance from a template hash and
+  stream the in-instance test results. It is the client half of the test runner
+  this repo already owns at `ROOT/opt/instance-tools/tests/` (SSE on port
+  **10199**).
+
+This couples an image-build repo to the Vast.ai console API (account/template
+management), which is a different concern from building images. The decision is
+whether that coupling belongs here, and on what terms.
+
+## Options considered
+
+- **Leave it in `vast_landing`.** Rejected: `test_template.py` drives a contract
+  (`ROOT/opt/instance-tools/tests/`, port 10199/SSE) that is *defined in this
+  repo*. A client living in another repo silently drifts when the contract here
+  changes. The publish step also consumes `template.yml`+`README.md` describing
+  images built here — it is the natural tail of this pipeline.
+- **A new dedicated ops repo.** Rejected for now: premature for two small tools;
+  adds a third place to keep the shared Vast-API core in sync. Revisit if the
+  console-API surface here grows beyond publish+test.
+- **Host the two tools in `tools/template_manager/` (chosen).** Keeps the test
+  client next to the contract it depends on, and the publish tool next to the
+  artifacts it publishes — fenced off from the image-build path.
+
+## Decision
+
+Host the two tools in `tools/template_manager/`, as the QA/publish layer of
+CON-1585, under these terms:
+
+1. **Scope boundary.** `tools/template_manager/` is publish/QA tooling. It is
+   **not** part of the image build or any CI correctness path, and must never be
+   imported by a build script, Dockerfile, or workflow. It is run by a human (or
+   a future `imagegen qa` step, ADR 0005) against a dedicated QA account.
+2. **Source-of-truth split, not a silent fork.** Ownership is split *by tool*:
+   base-image is canonical for the create-from-directory + live-test tools;
+   `vast_landing` keeps the model-library/recommended/autoscaler half. The shared
+   core (`VastTemplate`, the async API client) is duplicated and has now
+   **diverged** (this copy is trimmed, hardened, and `extra="forbid"`); do not
+   back-port between the copies. If the console API changes, both copies update
+   independently (accepted cost) until/unless a shared package is extracted.
+3. **The 10199 / SSE contract is named.** `test_template.py` ↔
+   `ROOT/opt/instance-tools/tests/` communicate over port 10199 with an SSE event
+   shape owned in this repo. A change to that port or event shape on either side
+   is a breaking change to the other; keep them in step.
+4. **Tool-local dependency policy.** Third-party deps for a tool live in
+   `tools/<x>/requirements.txt` and are **not** part of any image. `pydantic` +
+   `pyyaml` (typed validation of `template.yml`) earn their place; `httpx`/async
+   is heavier than this serial, self-paced workload needs (`test_template.py`
+   does gnarlier networking in stdlib) — kept for now, not to be cargo-culted by
+   the next tool.
+
+## Binding conditions
+
+The review's findings are fixed as a condition of acceptance:
+
+- **Secret hygiene (security).** The Vast API key is sent via
+  `Authorization: Bearer`, never as a URL query param; `*_pass`/`*_token`/`*_key`
+  are redacted in dry-run/log output; `tools/template_manager/output/` is
+  gitignored; `.env` is never committed (only `.env.example`). The QA account key
+  must be a **dedicated QA-only key** (shared with ADR 0005/0006).
+- **Strict input model.** `VastTemplate` is `extra="forbid"` — an unknown
+  `template.yml` key is rejected, not forwarded to the API verbatim.
+- **Correctness.** The 429/retry path surfaces terminal status errors instead of
+  looping; retries are limited to transport faults.
+- **Tested logic.** The pure logic (env/ports folding, `to_api_dict`,
+  `inject_readme`, `extra_filters` parsing) carries unit tests, run the same way
+  as imagegen's: `cd tools/template_manager && PYTHONPATH=. python -m pytest -q`.
+
+If any condition is refused, this decision is void.
+
+## Consequences
+
+- The publish + live-test last mile lives next to the pipeline and the test
+  contract it depends on; the new-image flow can reach a real template + a real
+  GPU smoke without leaving the repo.
+- A duplicated, now-diverged Vast-API core exists in two repos. Mitigated by the
+  ownership split and a fenced scope; the residual risk is parallel maintenance
+  if the console API changes.
+- New tool-local deps (`httpx`, `pydantic`, `pyyaml`, `python-dotenv`) enter the
+  repo's dev surface, but not any image.
+
+## What would reverse this
+
+- `create.py` re-growing toward model-library/autoscaler/account-management — the
+  "it's just the publish tail of our pipeline" justification collapses; move it
+  back to `vast_landing` or a dedicated ops repo.
+- A shared Vast-API client being extracted as an installable package — then both
+  repos depend on it and the duplication (condition 2) goes away.
+
+## Note on ADR numbering
+
+ADRs 0002–0007 are committed on sibling CON-1585 feature branches (oobabooga,
+exposure-gate, agent-guides) not yet merged here. This took the next free number
+(0008); reconcile the sequence when the branches land together.

--- a/external/vllm/templates/vllm-qa/template.yml
+++ b/external/vllm/templates/vllm-qa/template.yml
@@ -1,0 +1,58 @@
+# vLLM QA template (ADR 0005 live-GPU QA gate, CON-1585).
+#
+# Mirrors the production vLLM template's LAUNCH path (vast_landing .../070-vllm):
+# runtype: jupyter, OPEN_BUTTON/JUPYTER env, the vLLM serving path. QA-only deltas
+# (per ADR 0005 rollout note — smoke model != production model):
+#  - VLLM_MODEL is a deliberately TINY chat model (prod ships Qwen3.5-9B @ 24GB floor,
+#    which would brick the small-box selector); vllm.d hits /v1/chat/completions and
+#    asserts completion_tokens > 0, so it must be chat-capable.
+#  - Single-GPU smoke: AUTO_PARALLEL off, so vLLM serves on one GPU with no tensor
+#    parallelism. Ray STILL runs: ray.sh self-skips (exit_portal "ray dash") unless a
+#    "Ray Dashboard" entry is in PORTAL_CONFIG, and vllm.sh hard-waits for Ray's
+#    gcs_server before it will serve — so the Ray Dashboard entry is mandatory for the
+#    image's real launch path, not decorative. Model UI (7860) is the one production
+#    service we omit: it's optional and skipping it avoids a port check on a service the
+#    serving smoke doesn't exercise. A portal entry whose port isn't listening fails the
+#    harness's port check, so we list only entries that actually bind.
+#  - Selection floors tuned for the tiny model, not production's 24GB.
+# CI overrides image/tag with the freshly-built staging tag via create.py --tag.
+name: "vLLM QA — tiny-model smoke"
+image: vastai/vllm
+tag: latest                       # CI overrides with the staging tag
+private: true
+readme_visible: false
+onstart: entrypoint.sh
+runtype: jupyter                  # production launch mode
+jup_direct: true
+ssh_direct: true
+use_ssh: true
+use_jupyter_lab: false
+ports:
+  - "1111:1111"                   # Instance Portal
+  - "8080:8080"                   # Jupyter
+  - "8000:8000"                   # vLLM API
+  - "8265:8265"                   # Ray Dashboard (ray.sh gates on this portal entry)
+env:
+  OPEN_BUTTON_PORT: "1111"
+  OPEN_BUTTON_TOKEN: "1"
+  JUPYTER_DIR: "/"
+  DATA_DIRECTORY: "/workspace/"
+  PORTAL_CONFIG: "localhost:1111:11111:/:Instance Portal|localhost:8000:18000:/docs:vLLM API|localhost:8265:28265:/:Ray Dashboard|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+  AUTO_PARALLEL: "false"          # single-GPU smoke — no tensor parallelism (Ray head still required by vllm.sh)
+  RAY_ADDRESS: "127.0.0.1"        # local Ray head (mirrors production 070-vllm)
+  VLLM_MODEL: "Qwen/Qwen2.5-0.5B-Instruct"   # tiny chat model (~1 GB), fast load
+  # --enforce-eager is a QA-only delta: it disables torch.compile + CUDA-graph capture
+  # (VLLM_COMPILE captures 50+ graph sizes). That phase is silent, multi-minute and
+  # RAM/compile-heavy; on the smallest box it collided with the boot test sweep and the
+  # instance dropped before serving. A smoke proves the serving path works, not compiled
+  # throughput, so eager is the right trade — production keeps full compilation.
+  VLLM_ARGS: "--enforce-eager --max-model-len 4096 --download-dir /workspace/models --host 127.0.0.1 --port 18000"
+# QA gate floors (ADR 0005): smallest viable box, VRAM bounded 2x.
+extra_filters:
+  compute_cap:
+    gte: 800                      # sm_80 — matches the production vLLM floor (vLLM kernels)
+  cuda_max_good:
+    gte: 13.0                     # host driver must satisfy the newest matrix variant (cuda-13.0)
+  gpu_total_ram:
+    gte: 8192                     # 8 GB — ample for a 0.5B model + KV cache
+recommended_disk_space: 32.0      # vLLM image + small model + workspace

--- a/external/vllm/templates/vllm-qa/template.yml
+++ b/external/vllm/templates/vllm-qa/template.yml
@@ -47,7 +47,7 @@ env:
   # instance dropped before serving. A smoke proves the serving path works, not compiled
   # throughput, so eager is the right trade — production keeps full compilation.
   VLLM_ARGS: "--enforce-eager --max-model-len 4096 --download-dir /workspace/models --host 127.0.0.1 --port 18000"
-# QA gate floors (ADR 0005): smallest viable box, VRAM bounded 2x.
+# QA gate floors (ADR 0005): smallest viable box, VRAM bounded 3x.
 extra_filters:
   compute_cap:
     gte: 800                      # sm_80 — matches the production vLLM floor (vLLM kernels)

--- a/tools/template_manager/.env.example
+++ b/tools/template_manager/.env.example
@@ -1,0 +1,3 @@
+# Vast.ai API key — used by both create.py and test_template.py.
+# Copy to .env (gitignored) or export in your shell. Never commit a real key.
+VAST_API_KEY=your_vast_api_key_here

--- a/tools/template_manager/README.md
+++ b/tools/template_manager/README.md
@@ -1,0 +1,54 @@
+# template_manager
+
+Vast.ai template publish + live-test tooling — the QA/publish tail of the new-image
+pipeline (CON-1585). Copied from `vast_landing/scripts/template_manager` and trimmed to
+two tools; the model-library generator and recommended/autoscaler pipelines were left
+behind. Scope, the duplicate-source split, and the port-10199 test contract are pinned in
+[ADR 0008](../../docs/adr/0008-template-publish-tooling.md). **Not** part of the image
+build or any CI path — never import it from a build script or workflow.
+
+Both read `VAST_API_KEY` (see `.env.example`; `.env` is loaded by `create.py`). Use a
+dedicated QA-only key. The key is sent as an `Authorization: Bearer` header, never in a URL.
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt        # httpx, pydantic, PyYAML, python-dotenv
+```
+
+Unknown keys in a `template.yml` are rejected (`extra="forbid"`) so a typo surfaces
+instead of being POSTed to the API.
+
+### Tests
+
+```bash
+cd tools/template_manager && PYTHONPATH=. python3 -m pytest -q
+```
+
+## `create.py` — create templates from a directory
+
+Creates Vast.ai templates from a **directory of template subdirectories**, each containing
+a `template.yml` (the template spec) and an optional `README.md` (injected as the template
+readme). Always POSTs new templates.
+
+```bash
+python3 create.py path/to/templates/        # a dir of <name>/{template.yml,README.md} subdirs
+python3 create.py my-template.yml --readme my-readme.md   # a single template
+python3 create.py path/to/templates/ --dry-run            # validate + render, don't POST
+python3 create.py path/to/templates/ --image vastai/comfyui --tag staging-abc123  # CI: override image/tag
+python3 create.py --delete 484392                         # teardown a throwaway template by id
+```
+`--image`/`--tag` override the loaded template before POST (CI points a QA template at a
+freshly-built staging tag); `--delete <id>` removes a template (QA teardown). Depends on
+`template_manager.py` + `models.py` (same directory).
+
+## `test_template.py` — live-GPU template test
+
+Launches a Vast.ai instance from a template hash and streams the in-instance test results
+(it pairs with the base image's `ROOT/opt/instance-tools/tests/` runner on port 10199).
+Stdlib-only.
+
+```bash
+python3 test_template.py <template_hash>            # launch, stream results, tear down
+python3 test_template.py <template_hash> --dry-run
+```
+See `python3 test_template.py --help` for offer/price/timeout/keep flags.

--- a/tools/template_manager/README.md
+++ b/tools/template_manager/README.md
@@ -12,7 +12,7 @@ dedicated QA-only key. The key is sent as an `Authorization: Bearer` header, nev
 
 ```bash
 python3 -m venv .venv && . .venv/bin/activate
-pip install -r requirements.txt        # httpx, pydantic, PyYAML, python-dotenv
+pip install -r requirements.txt        # pydantic, PyYAML, python-dotenv
 ```
 
 Unknown keys in a `template.yml` are rejected (`extra="forbid"`) so a typo surfaces

--- a/tools/template_manager/create.py
+++ b/tools/template_manager/create.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+Create Vast.ai templates from local YAML.
+
+Entry point accepts either a single YAML file or a directory of template
+subdirectories. Each subdirectory should contain template.yml and optionally
+README.md. Always creates new templates via POST.
+
+Usage:
+    python create.py path/to/templates/ --api-key KEY     # dir of <name>/{template.yml,README.md}
+    python create.py path/to/templates/ --dry-run
+    python create.py my-template.yml --readme my-readme.md --api-key KEY
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Resolve directories before any local imports
+_GENERATOR_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(_GENERATOR_ROOT))
+
+from dotenv import load_dotenv
+load_dotenv(_GENERATOR_ROOT / ".env")
+
+from models import VastTemplate
+from template_manager import TemplateManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the create-from-directory flow
+# ---------------------------------------------------------------------------
+
+def discover_template_dirs(templates_dir: Path) -> List[Path]:
+    """
+    Discover template subdirectories containing template.yml.
+
+    Returns sorted list of directories.
+    """
+    dirs = []
+    for child in sorted(templates_dir.iterdir()):
+        if child.is_dir() and (child / "template.yml").exists():
+            dirs.append(child)
+    return dirs
+
+
+def inject_readme(
+    template: VastTemplate,
+    readme_path: Path,
+    template_name: str,
+    referral_url: Optional[str] = None,
+    dry_run: bool = False,
+) -> VastTemplate:
+    """Read README.md and inject into the template readme field.
+
+    Supports placeholders:
+        <<LAUNCH_LINK>>         - Vast.ai launch URL with referral
+        <<SELF_REFERRAL_URL>>   - Backward-compat alias for LAUNCH_LINK
+        <<TEMPLATE_NAME>>       - The template name
+
+    Appends an 'updated YYYY-MM-DD HH:MM' timestamp to the readme.
+    """
+    if not readme_path.exists():
+        return template
+
+    content = readme_path.read_text()
+
+    # Substitute placeholders
+    if dry_run:
+        placeholder = "[LAUNCH_LINK_PLACEHOLDER]"
+        content = content.replace("<<LAUNCH_LINK>>", placeholder)
+        content = content.replace("<<SELF_REFERRAL_URL>>", placeholder)
+    else:
+        url = referral_url or ""
+        content = content.replace("<<LAUNCH_LINK>>", url)
+        content = content.replace("<<SELF_REFERRAL_URL>>", url)
+
+    content = content.replace("<<TEMPLATE_NAME>>", template_name)
+
+    # Strip any existing "updated ..." line and append fresh timestamp
+    content = re.sub(r'(?:^|\n)updated \d{4}-\d{2}-\d{2} \d{2}:\d{2}\s*$', '', content)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+    content = content.rstrip() + f"\nupdated {now}"
+
+    template.readme = content
+    return template
+
+
+# ---------------------------------------------------------------------------
+# Create-from-YAML entry point helpers
+# ---------------------------------------------------------------------------
+
+def load_template_from_yaml(yaml_path: Path) -> List[VastTemplate]:
+    """Load and validate one or more templates from a YAML file."""
+    try:
+        return TemplateManager.load_templates_from_yaml(yaml_path)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def process_template_dir(
+    template_dir: Path,
+    manager: TemplateManager,
+    dry_run: bool = False,
+    readme_override: Optional[Path] = None,
+    yaml_filename: str = "template.yml",
+    image_override: Optional[str] = None,
+    tag_override: Optional[str] = None,
+) -> List[dict]:
+    """
+    Process a single template directory (template.yml + optional README.md).
+
+    Always creates new templates via POST (see create_or_preview for rationale).
+
+    Args:
+        yaml_filename: Name of the YAML file inside template_dir (default
+            ``template.yml``). Pass a different name for single-file mode.
+        image_override / tag_override: replace the template's ``image``/``tag``
+            before POST — used by CI to point a QA template at a freshly-built
+            staging tag.
+
+    Returns list of result dicts for logging.
+    """
+    yaml_path = template_dir / yaml_filename
+    readme_path = readme_override or (template_dir / "README.md")
+
+    templates = load_template_from_yaml(yaml_path)
+    for t in templates:
+        if image_override is not None:
+            t.image = image_override
+        if tag_override is not None:
+            t.tag = tag_override
+    results = []
+
+    # Build referral URL once per directory
+    referral_url = None
+    if not dry_run and readme_path.exists():
+        uid = manager.get_user_id()
+        referral_url = TemplateManager.build_referral_url(uid, templates[0].name)
+
+    for template in templates:
+        template = inject_readme(
+            template, readme_path, template.name,
+            referral_url=referral_url, dry_run=dry_run
+        )
+
+        result = manager.create_or_preview(template, dry_run=dry_run)
+
+        if result:
+            results.append({
+                "dir": template_dir.name,
+                "name": result.get("name", template.name),
+                "hash_id": result.get("hash_id", "N/A"),
+                "id": result.get("id", "N/A"),
+                "action": result.get("_action", "created"),
+            })
+        else:
+            results.append({
+                "dir": template_dir.name,
+                "name": template.name,
+                "action": "dry_run",
+            })
+
+    return results
+
+
+def process_single_file(
+    yaml_path: Path,
+    manager: TemplateManager,
+    dry_run: bool = False,
+    readme_override: Optional[Path] = None,
+    image_override: Optional[str] = None,
+    tag_override: Optional[str] = None,
+) -> List[dict]:
+    """Process a standalone YAML file (backward-compatible mode).
+
+    Delegates to process_template_dir using the file's parent directory.
+    When no readme_override is provided, passes a non-existent sentinel
+    path so that the sibling README.md is not auto-discovered.
+    """
+    # Use a sentinel readme path that won't exist so process_template_dir
+    # skips auto-discovery of sibling README.md files.
+    effective_readme = readme_override or (yaml_path.parent / "__no_readme__")
+
+    results = process_template_dir(
+        yaml_path.parent, manager, dry_run,
+        readme_override=effective_readme, yaml_filename=yaml_path.name,
+        image_override=image_override, tag_override=tag_override,
+    )
+
+    # Strip the "dir" key that process_template_dir adds
+    for r in results:
+        r.pop("dir", None)
+
+    return results
+
+
+def write_results_log(results: List[Dict], log_dir: Path, prefix: str):
+    """Write results to a timestamped JSON log file."""
+    if not results:
+        return
+    log_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_path = log_dir / f"{timestamp}_{prefix}.json"
+    log_data = {
+        "timestamp": datetime.now().isoformat(),
+        "templates": results,
+    }
+    with open(log_path, "w") as f:
+        json.dump(log_data, f, indent=2)
+    print(f"\nLog written to: {log_path}")
+
+
+def print_results_summary(results: List[Dict]):
+    """Print hash IDs and a create/dry-run summary."""
+    if not results:
+        return
+
+    print("\n[Hash IDs]")
+    for r in results:
+        _print_hash_line(r)
+
+    created = sum(1 for r in results if r["action"] == "created")
+    previewed = sum(1 for r in results if r["action"] == "dry_run")
+    parts = []
+    if created:
+        parts.append(f"{created} created")
+    if previewed:
+        parts.append(f"{previewed} previewed (dry run)")
+    if parts:
+        print(f"\n[Summary] {', '.join(parts)}")
+
+
+def _print_hash_line(r: Dict):
+    status = f"({r['action']})" if r["action"] != "dry_run" else "(dry run)"
+    hid = r.get("hash_id", "")
+    print(f"  {r['name']}: {hid} {status}")
+
+
+def run(path: Path, api_key: str, dry_run: bool, readme: Optional[Path] = None,
+        image_override: Optional[str] = None, tag_override: Optional[str] = None):
+    """Main entry point."""
+    over = {"image_override": image_override, "tag_override": tag_override}
+    with TemplateManager(api_key=api_key) as manager:
+        all_results = []
+
+        if path.is_file():
+            # Single file mode (backward compatible)
+            print(f"Processing single file: {path}")
+            results = process_single_file(path, manager, dry_run, readme_override=readme, **over)
+            all_results.extend(results)
+
+        elif path.is_dir():
+            # Check if this directory itself has template.yml (single template dir)
+            if (path / "template.yml").exists():
+                print(f"Processing template directory: {path.name}")
+                results = process_template_dir(path, manager, dry_run, readme_override=readme, **over)
+                all_results.extend(results)
+            else:
+                # Directory iteration mode -- look for subdirectories with template.yml
+                template_dirs = discover_template_dirs(path)
+                if not template_dirs:
+                    print(f"Error: No template directories found in {path}", file=sys.stderr)
+                    print("Hint: Each subdirectory should contain template.yml", file=sys.stderr)
+                    sys.exit(1)
+
+                print(f"Discovered {len(template_dirs)} template director{'y' if len(template_dirs) == 1 else 'ies'}")
+                for td in template_dirs:
+                    print(f"  - {td.name}")
+
+                for template_dir in template_dirs:
+                    print(f"\nProcessing: {template_dir.name}")
+                    results = process_template_dir(template_dir, manager, dry_run, readme_override=readme, **over)
+                    all_results.extend(results)
+
+        if not dry_run:
+            write_results_log(all_results, _GENERATOR_ROOT / "output" / "logs", "create")
+        print_results_summary(all_results)
+        return all_results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create Vast.ai templates from local YAML",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Process all template directories
+  python create.py recommended_templates/templates/ --api-key KEY
+
+  # Dry run
+  python create.py recommended_templates/templates/ --dry-run
+
+  # Single YAML file with a readme
+  python create.py my-template.yml --readme my-readme.md --api-key KEY
+
+  # Single YAML file (backward compatible)
+  python create.py my-template.yml --api-key KEY
+        """,
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        nargs="?",
+        help="Path to a YAML file, a single template directory, or a directory of template subdirectories",
+    )
+    parser.add_argument(
+        "--api-key",
+        help="Vast.ai API key (or set VAST_API_KEY in .env)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print payloads without creating templates",
+    )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        help="Path to a .md or .txt file to inject as the template readme",
+    )
+    parser.add_argument(
+        "--image",
+        help="Override the template's image (e.g. point a QA template at a staging build)",
+    )
+    parser.add_argument(
+        "--tag",
+        help="Override the template's tag (e.g. the freshly-built staging tag)",
+    )
+    parser.add_argument(
+        "--delete",
+        type=int,
+        metavar="TEMPLATE_ID",
+        help="Delete a template by numeric id and exit (teardown of a throwaway QA template)",
+    )
+    parser.add_argument(
+        "--emit-result",
+        type=Path,
+        metavar="PATH",
+        help="Write the created templates (name/hash_id/id) as JSON to PATH (for CI to capture)",
+    )
+    args = parser.parse_args()
+
+    api_key = args.api_key or os.getenv("VAST_API_KEY")
+
+    # Teardown mode: delete a template by id and exit.
+    if args.delete is not None:
+        if not api_key:
+            print("Error: API key required for --delete.", file=sys.stderr)
+            sys.exit(1)
+        with TemplateManager(api_key=api_key) as manager:
+            manager.delete_template(args.delete)
+        return
+
+    if args.path is None:
+        print("Error: a path is required (or use --delete TEMPLATE_ID).", file=sys.stderr)
+        sys.exit(1)
+
+    if not api_key and not args.dry_run:
+        print("Error: API key required. Provide via --api-key or VAST_API_KEY env var.", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.path.exists():
+        print(f"Error: Path not found: {args.path}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.readme:
+        if not args.readme.exists():
+            print(f"Error: Readme file not found: {args.readme}", file=sys.stderr)
+            sys.exit(1)
+        if args.readme.suffix.lower() not in (".md", ".txt"):
+            print(f"Error: --readme must be a .md or .txt file, got: {args.readme.suffix}", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        results = run(args.path, api_key or "", args.dry_run, readme=args.readme,
+                      image_override=args.image, tag_override=args.tag)
+    except urllib.error.HTTPError as e:
+        # The API-layer handler already printed the status + body; exit cleanly
+        # (no traceback) so CI logs show the actionable message, not a stack.
+        print(f"Template API request failed: HTTP {e.code}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Template API connection failed: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.emit_result:
+        args.emit_result.write_text(json.dumps(results or [], indent=2))
+        print(f"Wrote result to {args.emit_result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/template_manager/create.py
+++ b/tools/template_manager/create.py
@@ -85,7 +85,10 @@ def inject_readme(
     # Strip any existing "updated ..." line and append fresh timestamp
     content = re.sub(r'(?:^|\n)updated \d{4}-\d{2}-\d{2} \d{2}:\d{2}\s*$', '', content)
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
-    content = content.rstrip() + f"\nupdated {now}"
+    body = content.rstrip()
+    # Avoid a leading blank line when the body is empty (e.g. a README that was
+    # only a prior "updated ..." stamp).
+    content = f"{body}\nupdated {now}" if body else f"updated {now}"
 
     template.readme = content
     return template

--- a/tools/template_manager/models.py
+++ b/tools/template_manager/models.py
@@ -1,0 +1,74 @@
+"""
+Data model for a Vast.ai template.
+
+Models only the fields the create flow sends to ``POST /template/``. Unknown
+keys in a ``template.yml`` are rejected (``extra="forbid"``) so a typo'd or
+attacker-supplied field surfaces as an error instead of being forwarded to the
+API verbatim.
+"""
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class VastTemplate(BaseModel):
+    """A Vast.ai template to create. Maps to the POST /template/ request body."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Required
+    name: str
+
+    # Optional create fields
+    image: Optional[str] = None
+    tag: Optional[str] = None
+    href: Optional[str] = None
+    repo: Optional[str] = None
+    env: Optional[str] = None  # Docker arg string: "-e KEY=VALUE -p 8080:8080"
+    ports: Optional[List[str]] = None  # load-only: folded into env, never POSTed
+    onstart: Optional[str] = None
+    jup_direct: bool = False
+    ssh_direct: bool = False
+    use_jupyter_lab: bool = False
+    runtype: str = "args"
+    use_ssh: bool = False
+    jupyter_dir: Optional[str] = None
+    docker_login_repo: Optional[str] = ""
+    docker_login_user: Optional[str] = ""
+    docker_login_pass: Optional[str] = ""
+    extra_filters: Optional[Union[str, Dict[str, Any]]] = None  # dict from config, JSON string passthrough
+    recommended_disk_space: Optional[float] = None
+    readme: Optional[str] = None
+    readme_visible: bool = True
+    desc: Optional[str] = None
+    private: bool = True
+    vm: Optional[bool] = None         # only sent when explicitly set (VM templates)
+    autoscaler: Optional[bool] = None  # only sent when explicitly set
+
+    @field_validator('extra_filters', mode='before')
+    @classmethod
+    def parse_extra_filters(cls, v):
+        """extra_filters may be a JSON string or a dict; normalise to a dict."""
+        if v is None or isinstance(v, dict):
+            return v
+        if isinstance(v, str):
+            try:
+                return json.loads(v)
+            except json.JSONDecodeError:
+                return v  # leave malformed JSON as-is for the API to reject
+        return v
+
+    def to_api_dict(self) -> Dict[str, Any]:
+        """Build the POST /template/ payload.
+
+        ``ports`` is load-only (already folded into ``env``). ``vm`` and
+        ``autoscaler`` are only sent when explicitly set, so a plain template
+        does not pin them.
+        """
+        exclude_fields = {'ports'}
+        if self.vm is None:
+            exclude_fields.add('vm')
+        if self.autoscaler is None:
+            exclude_fields.add('autoscaler')
+        return self.model_dump(exclude_none=False, exclude=exclude_fields)

--- a/tools/template_manager/reap_orphans.py
+++ b/tools/template_manager/reap_orphans.py
@@ -79,6 +79,30 @@ def old_out_of_scope(instances, max_age_min, label, image_prefix):
             if _age_min(i) > max_age_min and not in_scope(i, label, image_prefix)]
 
 
+def destroy_instance(iid, key):
+    """Destroy one instance. Returns a (status, detail) pair:
+
+      "reaped" — deleted by us;
+      "gone"   — already destroyed (HTTP 404). A concurrent test_template
+                 --destroy, a prior reaper pass, or a spot reclaim beat us to it;
+                 that is the goal state, not a leak, so it must NOT count as a
+                 failure (mirrors test_template.py's _request_safe teardown). A
+                 404 that alarmed would train operators to ignore the one alert
+                 that signals a real leak;
+      "failed" — a genuine error (5xx, 429, transport) worth surfacing; detail
+                 carries the message.
+    """
+    try:
+        _request("DELETE", f"/instances/{iid}/", key)
+        return "reaped", None
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return "gone", None
+        return "failed", str(e)
+    except urllib.error.URLError as e:
+        return "failed", str(e)
+
+
 def _request(method, path, key, body=None):
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(f"{BASE_URL}{path}", data=data, method=method)
@@ -186,17 +210,20 @@ def main():
     failures = 0
     for inst in candidates:
         iid = inst.get("id")
-        if args.destroy:
-            try:
-                _request("DELETE", f"/instances/{iid}/", key)
-                print(f"  REAPED     id={iid}")
-                reaped += 1
-            except (urllib.error.HTTPError, urllib.error.URLError) as e:
-                print(f"  FAILED     id={iid}: {e}")
-                failures += 1
-        else:
+        if not args.destroy:
             print(f"  WOULD REAP id={iid}")
             reaped += 1
+            continue
+        status, detail = destroy_instance(iid, key)
+        if status == "reaped":
+            print(f"  REAPED     id={iid}")
+            reaped += 1
+        elif status == "gone":
+            print(f"  GONE       id={iid} (already destroyed)")
+            reaped += 1
+        else:
+            print(f"  FAILED     id={iid}: {detail}")
+            failures += 1
 
     print(f"{'reaped' if args.destroy else 'would reap'}: {reaped}/{len(instances)}")
     # A swallowed reap failure means a leaked paid instance persists; surface it so

--- a/tools/template_manager/reap_orphans.py
+++ b/tools/template_manager/reap_orphans.py
@@ -24,6 +24,60 @@ import urllib.request
 
 BASE_URL = "https://console.vast.ai/api/v0"
 
+# Worst-case lifetime of a HEALTHY QA instance, mirrored from test_template.py's
+# auto-lifted client --timeout (prov + derivative + headroom; see
+# test_template.py:1100). The instance bills for this whole window on a good run,
+# so the reaper MUST stay above it or it deletes a live instance mid-test — a
+# false BLOCK plus the wasted spend of the whole run. The coupling is enforced by
+# tests/test_qa_reaper.py::test_default_threshold_stays_above_test_template_budget,
+# which fails if test_template.py raises its budget past our margin.
+_HEALTHY_TEST_PHASE_SEC = 3600 + 3600 + 600   # 7800s = 130 min
+# A live instance also bills during poll-to-running + connectivity probing before
+# the test phase and briefly during teardown, none of it counted above. Reaping
+# latency is cheap (an orphan over-running on a sub-$0.50/hr QA GPU costs cents),
+# but clipping a live run is expensive — so the default sits at 2x the test-phase
+# ceiling. Override per-run with --max-age-min when a gated image needs more.
+DEFAULT_MAX_AGE_MIN = (_HEALTHY_TEST_PHASE_SEC * 2) / 60   # 260 min
+
+
+def in_scope(inst, label, image_prefix):
+    """True if an instance falls within the QA reap scope.
+
+    Label and image-prefix are each optional; when set they are ANDed (an
+    instance must match every supplied filter). A non-QA instance carries no QA
+    label, so a label scope excludes it. Returns True only for the intended
+    targets — keep this the single definition of "in scope" so the dry-run report
+    and the destroy path can never diverge.
+    """
+    ilabel = inst.get("label") or ""
+    image = inst.get("image_uuid") or inst.get("image") or ""
+    return ((label is None or ilabel.startswith(label))
+            and (image_prefix is None or image.startswith(image_prefix)))
+
+
+def is_reapable(inst, max_age_min, label, image_prefix):
+    """An instance is reapable iff it is older than the threshold AND in scope."""
+    return _age_min(inst) > max_age_min and in_scope(inst, label, image_prefix)
+
+
+def select_candidates(instances, max_age_min, label, image_prefix):
+    """The instances the reaper would destroy under this scope and threshold."""
+    return [i for i in instances
+            if is_reapable(i, max_age_min, label, image_prefix)]
+
+
+def old_out_of_scope(instances, max_age_min, label, image_prefix):
+    """Over-age instances EXCLUDED only by scope.
+
+    On the single-tenant QA account these are the smoking gun for silent
+    under-reaping: an orphan whose ``--label`` failed to round-trip, or an image
+    string the ``--image-prefix`` AND no longer matches, ages forever while the
+    reaper reports a clean ``reaped: 0``. Surfacing them turns that invisible
+    no-op into a warning so a broken scope can't masquerade as a quiet account.
+    """
+    return [i for i in instances
+            if _age_min(i) > max_age_min and not in_scope(i, label, image_prefix)]
+
 
 def _request(method, path, key, body=None):
     data = json.dumps(body).encode() if body is not None else None
@@ -47,9 +101,10 @@ def _age_min(inst):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--max-age-min", type=float, default=180.0,
-                    help="reap instances whose uptime exceeds this many minutes "
-                         "(default 180 — comfortably above the max QA test duration)")
+    ap.add_argument("--max-age-min", type=float, default=DEFAULT_MAX_AGE_MIN,
+                    help=f"reap instances whose uptime exceeds this many minutes "
+                         f"(default {DEFAULT_MAX_AGE_MIN:.0f} — 2x the max healthy QA "
+                         f"test lifetime, derived from test_template.py's budget)")
     ap.add_argument("--label", default=None,
                     help="ONLY reap instances whose Vast label starts with this — the "
                          "primary QA scope (test_template.py --label stamps it at launch). "
@@ -100,14 +155,24 @@ def main():
         ilabel = inst.get("label") or ""
         desc = (f"id={inst.get('id')} {inst.get('gpu_name', '?')} {image} "
                 f"label={ilabel or '-'} uptime={age:.0f}min status={inst.get('actual_status', '?')}")
-        in_scope = ((args.label is None or ilabel.startswith(args.label))
-                    and (args.image_prefix is None or image.startswith(args.image_prefix)))
-        if age > args.max_age_min and in_scope:
+        scoped = in_scope(inst, args.label, args.image_prefix)
+        if age > args.max_age_min and scoped:
             candidates.append(inst)
             print(f"  CANDIDATE  {desc}")
         else:
             print(f"  keep       {desc}"
-                  + ("" if in_scope else "  (out of QA scope)"))
+                  + ("" if scoped else "  (out of QA scope)"))
+
+    # Canary for silent under-reaping: an over-age instance the scope EXCLUDED is,
+    # on the single-tenant QA account, most likely an orphan whose label/prefix
+    # stopped matching — exactly the failure a bare 'reaped: 0' would hide. Warn
+    # (not error) so it surfaces without false-failing a legitimately quiet sweep.
+    stale_unscoped = old_out_of_scope(instances, args.max_age_min, args.label, args.image_prefix)
+    if stale_unscoped:
+        ids = ", ".join(str(i.get("id")) for i in stale_unscoped)
+        print(f"::warning::{len(stale_unscoped)} over-age instance(s) are OUT of QA scope "
+              f"(id={ids}) — if these are leaked QA orphans the label/prefix is not matching; "
+              f"verify before trusting 'reaped: 0'.", file=sys.stderr)
 
     # Fail-closed: a count far above what QA ever produces means the key is
     # pointed at the wrong (e.g. production) account — abort rather than wipe it.

--- a/tools/template_manager/reap_orphans.py
+++ b/tools/template_manager/reap_orphans.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Reap orphaned QA instances (ADR 0005 condition 1 — the out-of-band reaper).
+
+The live-GPU QA gate destroys its instance via ``test_template.py --destroy`` on
+the normal path, but a GitHub runner that is hard-killed mid-test (cancellation,
+timeout, eviction) can skip that and leak a paid instance. This is the backstop:
+a scheduled sweep that destroys orphaned QA instances older than a threshold.
+
+Scope is by the Vast **label** ``test_template.py --label`` stamps on every
+instance it launches (``--label`` here, prefix-matched): a good non-test instance
+carries no QA label and is therefore never reaped — so this does not rely on the
+account being single-tenant. An image-prefix and a ``--max-reap`` ceiling provide
+defence in depth, and ``--destroy`` refuses to run with no scope at all.
+
+Reads ``VAST_API_KEY`` from the environment (the dedicated QA-account key).
+Dry-run by default; pass ``--destroy`` to actually reap. Stdlib only.
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+BASE_URL = "https://console.vast.ai/api/v0"
+
+
+def _request(method, path, key, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{BASE_URL}{path}", data=data, method=method)
+    req.add_header("Authorization", f"Bearer {key}")
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        text = resp.read().decode()
+    return json.loads(text) if text else {}
+
+
+def _age_min(inst):
+    """Uptime in minutes, defensively coerced. None/missing/malformed -> 0 (keep)."""
+    try:
+        return float(inst.get("uptime_mins") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--max-age-min", type=float, default=180.0,
+                    help="reap instances whose uptime exceeds this many minutes "
+                         "(default 180 — comfortably above the max QA test duration)")
+    ap.add_argument("--label", default=None,
+                    help="ONLY reap instances whose Vast label starts with this — the "
+                         "primary QA scope (test_template.py --label stamps it at launch). "
+                         "A non-test instance has no QA label, so it is never reaped.")
+    ap.add_argument("--image-prefix", default=None,
+                    help="additional scope: only reap instances whose image starts with "
+                         "this prefix (e.g. the staging namespace). ANDed with --label.")
+    ap.add_argument("--allow-no-scope", action="store_true",
+                    help="permit --destroy with NO --label and NO --image-prefix (age-only, "
+                         "ALL images) — only safe on a verified single-tenant QA account.")
+    ap.add_argument("--max-reap", type=int, default=30,
+                    help="refuse to destroy if more than this many instances match — a "
+                         "runaway backstop, NOT the primary guard (the --label scope is). "
+                         "Sized above full-rollout QA concurrency (images x matrix cells x "
+                         "in-flight); raise it as more images are gated. Abort + alert.")
+    ap.add_argument("--destroy", action="store_true",
+                    help="actually destroy matching instances (default: dry-run report)")
+    args = ap.parse_args()
+
+    key = os.environ.get("VAST_API_KEY")
+    if not key:
+        print("VAST_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+
+    # Fail-closed: never destroy unscoped by accident. Require a positive QA scope
+    # (label or image prefix) so a mis-set key can't sweep good instances. An empty
+    # secret that drops both filters is caught here rather than reaping ALL images.
+    if args.destroy and args.label is None and args.image_prefix is None and not args.allow_no_scope:
+        print("::error::--destroy requires --label (preferred) or --image-prefix. Pass "
+              "--allow-no-scope only on a verified single-tenant QA account.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    instances = _request("GET", "/instances/?owner=me", key).get("instances", [])
+    parts = []
+    if args.label:
+        parts.append(f"label prefix '{args.label}'")
+    if args.image_prefix:
+        parts.append(f"image prefix '{args.image_prefix}'")
+    scope = " AND ".join(parts) if parts else "ALL images (age only)"
+    print(f"{len(instances)} instance(s) on the account; threshold "
+          f"{args.max_age_min:.0f} min; scope = {scope}")
+
+    candidates = []
+    for inst in instances:
+        age = _age_min(inst)
+        image = inst.get("image_uuid") or inst.get("image") or ""
+        ilabel = inst.get("label") or ""
+        desc = (f"id={inst.get('id')} {inst.get('gpu_name', '?')} {image} "
+                f"label={ilabel or '-'} uptime={age:.0f}min status={inst.get('actual_status', '?')}")
+        in_scope = ((args.label is None or ilabel.startswith(args.label))
+                    and (args.image_prefix is None or image.startswith(args.image_prefix)))
+        if age > args.max_age_min and in_scope:
+            candidates.append(inst)
+            print(f"  CANDIDATE  {desc}")
+        else:
+            print(f"  keep       {desc}"
+                  + ("" if in_scope else "  (out of QA scope)"))
+
+    # Fail-closed: a count far above what QA ever produces means the key is
+    # pointed at the wrong (e.g. production) account — abort rather than wipe it.
+    if args.destroy and len(candidates) > args.max_reap:
+        print(f"::error::refusing to reap {len(candidates)} instances "
+              f"(> --max-reap {args.max_reap}) — likely a mis-scoped key/account. Aborting.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    reaped = 0
+    failures = 0
+    for inst in candidates:
+        iid = inst.get("id")
+        if args.destroy:
+            try:
+                _request("DELETE", f"/instances/{iid}/", key)
+                print(f"  REAPED     id={iid}")
+                reaped += 1
+            except (urllib.error.HTTPError, urllib.error.URLError) as e:
+                print(f"  FAILED     id={iid}: {e}")
+                failures += 1
+        else:
+            print(f"  WOULD REAP id={iid}")
+            reaped += 1
+
+    print(f"{'reaped' if args.destroy else 'would reap'}: {reaped}/{len(instances)}")
+    # A swallowed reap failure means a leaked paid instance persists; surface it so
+    # a stuck reaper (e.g. repeated 429/5xx) alerts instead of silently exiting 0.
+    if failures:
+        print(f"::error::{failures} instance(s) failed to reap — still leaking; check the account.",
+              file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/template_manager/requirements.txt
+++ b/tools/template_manager/requirements.txt
@@ -1,0 +1,3 @@
+pydantic>=2.0.0
+PyYAML>=6.0.0
+python-dotenv>=1.0.0

--- a/tools/template_manager/template_manager.py
+++ b/tools/template_manager/template_manager.py
@@ -22,13 +22,23 @@ def _redact_secrets(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Return a copy of a payload with secret-bearing values masked.
 
     Used for dry-run/log output so a docker registry password (or any
-    ``*_pass``/``*_token``/``*_key`` field) is never printed in the clear.
+    ``*_pass``/``*_token``/``*_key``/``*_secret`` field) is never printed in the
+    clear — at any nesting depth, since payloads can carry nested dicts/lists.
     """
-    redacted = dict(payload)
-    for key, value in redacted.items():
-        if value and key.lower().endswith(("_pass", "_token", "_key", "_secret")):
-            redacted[key] = "***redacted***"
-    return redacted
+    _SECRET_SUFFIXES = ("_pass", "_token", "_key", "_secret")
+
+    def _walk(value):
+        if isinstance(value, dict):
+            return {k: ("***redacted***"
+                        if v and isinstance(k, str)
+                        and k.lower().endswith(_SECRET_SUFFIXES)
+                        else _walk(v))
+                    for k, v in value.items()}
+        if isinstance(value, list):
+            return [_walk(v) for v in value]
+        return value
+
+    return _walk(payload)
 
 
 class TemplateManager:
@@ -156,12 +166,12 @@ class TemplateManager:
         retry_count = 0
 
         while retry_count <= max_retries:
+            # Backoff applies only AFTER a retryable failure — the first attempt
+            # fires immediately (no unconditional per-request latency).
             if retry_count > 0:
                 delay = min(base_delay * (2 ** (retry_count - 1)), 60)
                 print(f"    [Retry {retry_count}/{max_retries}] Waiting {delay:.1f}s before retry...")
                 time.sleep(delay)
-            else:
-                time.sleep(base_delay)
 
             try:
                 result = self._open(method, url, payload)

--- a/tools/template_manager/template_manager.py
+++ b/tools/template_manager/template_manager.py
@@ -295,7 +295,7 @@ class TemplateManager:
             ports_list = entry.pop('ports', None)
             env_value = entry.pop('env', None)
 
-            if ports_list or (env_value and isinstance(env_value, (list, dict))):
+            if ports_list or isinstance(env_value, (list, dict)):
                 if isinstance(env_value, str) and ports_list:
                     # Mixed: ports as list + env as string — prepend port flags
                     port_flags = ' '.join(f'-p {p}' for p in ports_list)

--- a/tools/template_manager/template_manager.py
+++ b/tools/template_manager/template_manager.py
@@ -1,0 +1,312 @@
+"""
+Template Manager for Vast.ai API interactions — create templates from local YAML.
+
+Synchronous stdlib client (urllib): the create flow is a serial, self-paced loop
+with no concurrency, so it carries no async/httpx machinery. Matches the stdlib
+networking already used by test_template.py in this directory. See ADR 0008.
+"""
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Union
+
+import yaml
+
+from models import VastTemplate
+
+
+def _redact_secrets(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of a payload with secret-bearing values masked.
+
+    Used for dry-run/log output so a docker registry password (or any
+    ``*_pass``/``*_token``/``*_key`` field) is never printed in the clear.
+    """
+    redacted = dict(payload)
+    for key, value in redacted.items():
+        if value and key.lower().endswith(("_pass", "_token", "_key", "_secret")):
+            redacted[key] = "***redacted***"
+    return redacted
+
+
+class TemplateManager:
+    """Manages Vast.ai template creation over the console API."""
+
+    BASE_URL = "https://console.vast.ai/api/v0"
+    TIMEOUT = 30.0
+
+    def __init__(self, api_key: str):
+        # Auth via header, never as a URL query param — keeps the key out of
+        # access logs, proxies, error output and process listings.
+        self._auth_header = f"Bearer {api_key}"
+        self._user_id: Optional[int] = None
+
+    # No persistent connection to close; the context manager is kept so call
+    # sites read the same as a pooled client and can gain teardown later.
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def _open(self, method: str, url: str, payload: Optional[Dict[str, Any]] = None):
+        """Issue one JSON request and return the parsed response.
+
+        Raises urllib.error.HTTPError on non-2xx and URLError/TimeoutError on
+        transport faults — the caller decides what is retryable.
+        """
+        data = json.dumps(payload).encode() if payload is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", self._auth_header)
+        req.add_header("Accept", "application/json")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=self.TIMEOUT) as resp:
+            body = resp.read().decode()
+        return json.loads(body) if body else {}
+
+    @staticmethod
+    def build_env_string_from_lists(
+        ports: Optional[List[str]] = None,
+        env_vars: Optional[Union[List[str], Dict[str, str]]] = None
+    ) -> str:
+        """Build a Docker env string from the *raw YAML config* shape.
+
+        Use this when reading ports and env from a template.yml on disk:
+        ports are bare ``"8080:8080"`` strings (no ``-p`` prefix), env vars
+        are either ``["KEY=VAL", ...]`` or ``{"KEY": "VAL"}``.
+
+        Args:
+            ports: List of port mappings like ``["8080:8080", "1111:1111"]``
+            env_vars: List ``["KEY=VAL"]`` or dict ``{"KEY": "VAL"}``
+
+        Returns:
+            Complete env string
+        """
+        parts = []
+
+        # Add port mappings
+        if ports:
+            for port in ports:
+                parts.append(f'-p {port}')
+
+        # Add environment variables
+        if env_vars:
+            if isinstance(env_vars, dict):
+                # Dict format: {"KEY": "VALUE"}
+                for key, value in env_vars.items():
+                    escaped_value = str(value).replace('"', '\\"')
+                    parts.append(f'-e {key}="{escaped_value}"')
+            elif isinstance(env_vars, list):
+                # List format: ["KEY=VALUE", "KEY2=VALUE2"]
+                for env_item in env_vars:
+                    if '=' in env_item:
+                        key, value = env_item.split('=', 1)
+                        escaped_value = value.replace('"', '\\"')
+                        parts.append(f'-e {key}="{escaped_value}"')
+
+        return ' '.join(parts)
+
+    def get_user_id(self) -> int:
+        """Get the current user's ID, cached after first call"""
+        if self._user_id is not None:
+            return self._user_id
+
+        print(f"    [Fetching] Current user info")
+        time.sleep(1)
+
+        data = self._open("GET", f"{self.BASE_URL}/users/current/")
+        user_id: int = data['id']
+        self._user_id = user_id
+
+        print(f"    [Cached] User ID: {user_id}")
+        return user_id
+
+    @staticmethod
+    def build_referral_url(user_id: int, template_name: str) -> str:
+        """Build a self-referral URL for the template"""
+        encoded_name = urllib.parse.quote(template_name)
+        return f"https://cloud.vast.ai/?ref_id={user_id}&creator_id={user_id}&name={encoded_name}"
+
+    def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        payload: Dict[str, Any],
+        label: str,
+        max_retries: int = 10,
+    ) -> Dict[str, Any]:
+        """Send an HTTP request with exponential backoff on rate limits.
+
+        Args:
+            method: HTTP method ("POST" or "PUT").
+            url: Request URL.
+            payload: JSON body.
+            label: Human-readable label for log messages (e.g. template name).
+            max_retries: Maximum retry attempts.
+
+        Returns:
+            Parsed JSON response. If the response contains a ``template`` key,
+            that nested dict is returned directly.
+        """
+        base_delay = 2.0
+        retry_count = 0
+
+        while retry_count <= max_retries:
+            if retry_count > 0:
+                delay = min(base_delay * (2 ** (retry_count - 1)), 60)
+                print(f"    [Retry {retry_count}/{max_retries}] Waiting {delay:.1f}s before retry...")
+                time.sleep(delay)
+            else:
+                time.sleep(base_delay)
+
+            try:
+                result = self._open(method, url, payload)
+            except urllib.error.HTTPError as e:
+                if e.code == 429:
+                    retry_count += 1
+                    retry_after = e.headers.get('Retry-After', 'unknown')
+                    print(f"    [Rate limited] HTTP 429. Retry-After: {retry_after}s")
+                    if retry_count > max_retries:
+                        print(f"    [Max retries] Reached {max_retries} attempts. Giving up.")
+                        raise
+                    if retry_after != 'unknown':
+                        try:
+                            wait_time = float(retry_after)
+                            print(f"    [Waiting] {wait_time}s as specified by server...")
+                            time.sleep(wait_time)
+                        except ValueError:
+                            pass
+                    continue
+                # Any other status error is terminal — surface it, don't loop.
+                try:
+                    body = e.read().decode(errors="replace")
+                except Exception:
+                    body = "(unable to read response body)"
+                print(f"    [Error] HTTP {e.code}: {body}")
+                raise
+            except (urllib.error.URLError, TimeoutError) as e:
+                # Transient transport/timeout faults only: retry with backoff.
+                # Other exceptions (e.g. JSON decode, bugs) propagate immediately.
+                retry_count += 1
+                if retry_count > max_retries:
+                    raise
+                delay = min(base_delay * (2 ** (retry_count - 1)), 60)
+                print(f"    [Transport error] {type(e).__name__}")
+                print(f"    [Retry {retry_count}/{max_retries}] Waiting {delay:.1f}s...")
+                time.sleep(delay)
+                continue
+
+            if retry_count > 0:
+                print(f"    [Success] After {retry_count} retr{'y' if retry_count == 1 else 'ies'}")
+
+            if isinstance(result, dict) and 'template' in result:
+                return result['template']
+            return result
+
+        raise Exception(f"Failed {method} for {label} after {max_retries} retries")
+
+    def create_template(self, template: VastTemplate, max_retries: int = 10) -> Dict[str, Any]:
+        """
+        Create a new template via API with exponential backoff for rate limiting
+
+        Args:
+            template: Template to create
+            max_retries: Maximum number of retry attempts
+
+        Returns:
+            Template data from API response
+        """
+        print(f"    [Creating] Template: {template.name}")
+
+        return self._request_with_retry(
+            "POST", f"{self.BASE_URL}/template/", payload=template.to_api_dict(),
+            label=template.name, max_retries=max_retries,
+        )
+
+    def create_or_preview(
+        self,
+        template: VastTemplate,
+        dry_run: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Create a template via API, or preview the payload in dry-run mode.
+
+        Always creates new templates via POST. Updates are disabled due to:
+        - HOST-2493: PUT changes hash_id, breaking existing links
+        - CLN-927: hash_id excludes creator_id, making hash-based matching
+          unreliable across creators
+
+        Args:
+            template: Template to create
+            dry_run: If True, print payload without calling API
+
+        Returns:
+            Result dict with hash_id/id/name on creation, None on dry-run.
+        """
+        payload = template.to_api_dict()
+        if dry_run:
+            print(f"    [DRY RUN] [CREATE] {template.name}")
+            print(json.dumps(_redact_secrets(payload), indent=2))
+            return None
+
+        result = self.create_template(template)
+        rid = result.get("hash_id", "N/A")
+        tid = result.get("id", "N/A")
+        name = result.get("name", template.name)
+        print(f"    [Created] {name}  hash_id={rid}  id={tid}")
+        result["_action"] = "created"
+        return result
+
+    def delete_template(self, template_id: int) -> Dict[str, Any]:
+        """Delete a template by its numeric ID (DELETE /template/ {template_id}).
+
+        Scoped teardown for a throwaway QA template. ``template_id`` is the
+        numeric ``id``, not the ``hash_id``.
+        """
+        print(f"    [Deleting] Template id={template_id}")
+        # Route through the retry/backoff path so a single 429 on teardown doesn't
+        # leak the throwaway template (the reaper only sweeps instances, not templates).
+        result = self._request_with_retry(
+            "DELETE", f"{self.BASE_URL}/template/",
+            payload={"template_id": template_id}, label=f"delete template {template_id}")
+        print(f"    [Deleted] Template id={template_id}")
+        return result
+
+    @staticmethod
+    def load_templates_from_yaml(yaml_path: Path) -> List[VastTemplate]:
+        """Load and validate one or more VastTemplates from a YAML file."""
+        with open(yaml_path, "r") as f:
+            data = yaml.safe_load(f)
+
+        if data is None:
+            raise ValueError(f"Empty YAML file: {yaml_path}")
+
+        entries = data if isinstance(data, list) else [data]
+
+        templates = []
+        for i, entry in enumerate(entries, 1):
+            if not isinstance(entry, dict):
+                raise ValueError(f"Entry {i} in {yaml_path} is not a mapping")
+
+            # Fold list/dict ports+env into the Docker arg string
+            ports_list = entry.pop('ports', None)
+            env_value = entry.pop('env', None)
+
+            if ports_list or (env_value and isinstance(env_value, (list, dict))):
+                if isinstance(env_value, str) and ports_list:
+                    # Mixed: ports as list + env as string — prepend port flags
+                    port_flags = ' '.join(f'-p {p}' for p in ports_list)
+                    entry['env'] = f"{port_flags} {env_value}" if env_value else port_flags
+                else:
+                    entry['env'] = TemplateManager.build_env_string_from_lists(
+                        ports=ports_list, env_vars=env_value
+                    )
+            elif env_value is not None:
+                entry['env'] = env_value  # already a Docker arg string
+
+            templates.append(VastTemplate(**entry))
+
+        return templates

--- a/tools/template_manager/test_template.py
+++ b/tools/template_manager/test_template.py
@@ -84,8 +84,12 @@ def classify_outcome(final_state):
 MAX_LAUNCH_ATTEMPTS = 25       # how many offers to try before giving up
 DISK_TOLERANCE = 1.0           # instance must provision at least the full requested disk
 OFFER_CANDIDATE_POOL = 50      # cap on offers kept for the retry loop
-VRAM_CEILING_MULTIPLIER = 2.0  # bound the VRAM search at N x the declared floor
-                               # (ADR 0005: don't test a >=12GB claim on a 96GB box)
+VRAM_CEILING_MULTIPLIER = 3.0  # bound the VRAM search at N x the declared floor
+                               # (ADR 0005: don't test a >=8GB claim on a 96GB box).
+                               # 3x = an 8GB floor admits the abundant 24GB consumer
+                               # tier (RTX 3090/4090) to widen a thin market, while
+                               # still excluding the 40/80GB datacenter cards. This
+                               # band is the cost control now the price filter is gone.
 NETWORK_PROBE_TIMEOUT = 60     # seconds of nothing-but-connection-timeouts before an
                                # instance is judged to have broken host networking.
                                # Connection *refused* does NOT count against this window —

--- a/tools/template_manager/test_template.py
+++ b/tools/template_manager/test_template.py
@@ -1,0 +1,1402 @@
+#!/usr/bin/env python3
+"""Launch a Vast.ai instance from a template and stream test results."""
+
+import argparse
+import errno
+import json
+import os
+import signal
+import sys
+import threading
+import time
+import types
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_BASE = "https://console.vast.ai"
+
+# Port the in-instance test results server binds on.  Must match the value
+# baked into the vastai/* base images' runner script.
+TEST_SERVER_PORT = 10199
+
+# ── Timeouts (seconds) ───────────────────────────────────────────────────
+DEFAULT_TEST_TIMEOUT = 7200      # 2 hours — total time for test suite to complete
+POLL_TIMEOUT = 7200              # 2 hours — max wait for instance to reach "running"
+API_REQUEST_TIMEOUT = 30         # individual API call timeout
+SSE_READ_TIMEOUT = 30            # read timeout per attempt (server heartbeats every 5s)
+TIMEOUT_HEADROOM = 600           # 10 min headroom added to computed minimum timeout
+
+# Instance-side timeout env vars and their defaults.  Used to auto-compute
+# the minimum sensible client --timeout so we don't time out before the
+# instance does.  These are sequential phases: provisioning runs first,
+# then all tests (including derivative tests like vLLM health).
+INSTANCE_TIMEOUT_ENVS = {
+    "PROV_TIMEOUT": 3600,                    # 12-provisioning.sh total wait
+    "VLLM_HEALTH_TIMEOUT": 3600,             # vLLM model loading + graph compilation
+    "INSTANCE_TEST_DEFAULT_TIMEOUT": 3600,   # runner.sh per-test fallback
+}
+
+# ── Verdict: exit codes + machine-readable outcome (ADR 0005) ────────────
+# Exit codes are distinct so CI can act on $?, and --raw emits a JSON line with
+# a "state" field on EVERY terminal path so CI reads the verdict from the
+# payload, not just the code. The two never disagree.
+EXIT_PASSED = 0           # state "passed"   — all tests passed
+EXIT_FAILED = 1           # state "failed"   — a test failed (block promotion)
+EXIT_NO_OFFERS = 2        # state "no_offers"     — thin market (inconclusive)
+EXIT_BAD_INSTANCE = 3     # state "bad_instance"  — exhausted launch attempts (infra)
+EXIT_CONFIG_ERROR = 4     # state "config_error"  — template/arg/image/auth/API error (CI bug)
+EXIT_INSTANCE_ERROR = 5   # state "instance_error"— instance crashed mid-test (treat as the image)
+EXIT_INTERRUPTED = 130    # state "interrupted"   — SIGINT/SIGTERM
+BAD_INSTANCE_EXIT_CODE = EXIT_BAD_INSTANCE  # back-compat alias
+
+_RAW_MODE = False  # set from args.raw in main(); read by emit_outcome()
+
+
+def emit_outcome(state, code, **extra):
+    """Emit a machine-readable terminal outcome and exit.
+
+    When --raw is set, prints one JSON line to stdout (``{"state", "exit_code",
+    ...}``) so CI reads the verdict from the payload. Always exits with ``code``.
+    Used for the pre-test terminal paths; the post-test path emits the richer
+    result JSON inline and exits with the mapped code.
+    """
+    if _RAW_MODE:
+        print(json.dumps({"state": state, "exit_code": code, **extra}))
+    sys.exit(code)
+
+
+def classify_outcome(final_state):
+    """Map the runner's final_state to a (machine-readable state, exit code).
+
+    "passed"/"failed" are authoritative; anything else ("error", or an
+    unexpected value) means the instance did not finish cleanly and is treated
+    as the image's problem (instance_error), not a soft "inconclusive".
+    """
+    if final_state == "passed":
+        return "passed", EXIT_PASSED
+    if final_state == "failed":
+        return "failed", EXIT_FAILED
+    return "instance_error", EXIT_INSTANCE_ERROR
+
+
+# ── Retry + disk verification tuning ─────────────────────────────────────
+MAX_LAUNCH_ATTEMPTS = 25       # how many offers to try before giving up
+DISK_TOLERANCE = 1.0           # instance must provision at least the full requested disk
+OFFER_CANDIDATE_POOL = 50      # cap on offers kept for the retry loop
+VRAM_CEILING_MULTIPLIER = 2.0  # bound the VRAM search at N x the declared floor
+                               # (ADR 0005: don't test a >=12GB claim on a 96GB box)
+NETWORK_PROBE_TIMEOUT = 60     # seconds of nothing-but-connection-timeouts before an
+                               # instance is judged to have broken host networking.
+                               # Connection *refused* does NOT count against this window —
+                               # it proves the host is reachable (port forwarding works),
+                               # the test server simply has not bound the port yet.  Once
+                               # any refused/HTTP reply is seen, probe_test_server switches
+                               # to the longer provisioning-aware deadline: the boot
+                               # sequence runs provisioning to completion before it starts
+                               # the test runner, so the server can be many minutes away.
+
+
+# ── Terminal split panel for log output ──────────────────────────────────
+
+class LogPanel:
+    """Split terminal: test output scrolls in top region, logs in fixed bottom panel.
+
+    Uses ANSI scroll regions so the top area scrolls naturally while the bottom
+    panel is redrawn in place. Falls back to inline dimmed output when stderr
+    is not a TTY or the terminal is too small.
+    """
+
+    def __init__(self, enabled=True, panel_height=12):
+        self.active = False
+        self._log_lines = []              # panel lines (list for indexed overwrite)
+        self._max_log_lines = 200         # cap to prevent unbounded growth
+        self._panel_height = panel_height
+        self._rows = 0
+        self._cols = 80
+        self._last_output_was_cr = False  # track \r lines for in-place overwrite
+        # Per-file progress state: maps src → index in _log_lines of the
+        # "active" line that should be overwritten on rapid updates.
+        # Cleared when a different src writes, committing the progress line.
+        self._file_progress = {}          # {src: int}
+        if not enabled or not sys.stderr.isatty():
+            return
+        try:
+            size = os.get_terminal_size(sys.stderr.fileno())
+            self._rows = size.lines
+            self._cols = size.columns
+        except (ValueError, OSError):
+            return
+        if self._rows < 24:
+            return  # too small to split
+        self._panel_height = min(panel_height, self._rows // 3)
+        self._scroll_end = self._rows - self._panel_height - 1  # 1 for separator
+        self.active = True
+        # Set scroll region for test output (top portion)
+        self._esc(f"\033[1;{self._scroll_end}r")
+        self._esc(f"\033[{self._scroll_end};1H")
+        self._draw_separator()
+
+    def _esc(self, seq):
+        sys.stderr.write(seq)
+
+    def _draw_separator(self, label="logs"):
+        self._esc("\033[s")  # save cursor
+        sep = f" ── {label} "
+        sep = sep + "─" * max(0, self._cols - len(sep))
+        self._esc(f"\033[{self._scroll_end + 1};1H\033[2m{sep[:self._cols]}\033[0m")
+        self._esc("\033[u")  # restore cursor
+        sys.stderr.flush()
+
+    def write_output(self, line):
+        r"""Write a test output line (top scroll region).
+
+        Handles progress bars that use \r to overwrite in place.  A line
+        like "50%\r75%\r100%" has mid-line \r — we show only the last
+        segment and stay on the current terminal line.  Trailing \r (from
+        \r\n line endings) is stripped and treated as a normal line.
+        """
+        # Strip trailing \r (CRLF artifact), then check for mid-line \r
+        line = line.rstrip("\r")
+        is_cr = "\r" in line
+        if self.active:
+            if is_cr:
+                segment = line.rsplit("\r", 1)[-1]
+                self._esc(f"\r\033[K{segment}")
+            else:
+                if self._last_output_was_cr:
+                    self._esc("\n")
+                self._esc(f"{line}\n")
+            sys.stderr.flush()
+        else:
+            if is_cr:
+                segment = line.rsplit("\r", 1)[-1]
+                print(f"\r\033[K{segment}", end="", file=sys.stderr, flush=True)
+            else:
+                if self._last_output_was_cr:
+                    print(file=sys.stderr)
+                print(line, file=sys.stderr)
+        self._last_output_was_cr = is_cr
+
+    def write_log(self, line, src="", overwrite=False):
+        r"""Write a log line (bottom panel or inline dimmed).
+
+        Per-file progress tracking: when the server signals overwrite=True
+        (line contained \r — a progress bar), the previous line from the
+        same source is replaced in-place.  Multiple files can each have
+        their own independent active progress line.  Normal lines (no
+        overwrite flag) always append and clear the source's active slot.
+        """
+        line = line.rstrip("\r")
+        if "\r" in line:
+            line = line.rsplit("\r", 1)[-1]
+        prefix = f"\033[36m{src}\033[2m " if src else ""
+        formatted = f"{prefix}{line}"
+        if self.active:
+            if overwrite and src:
+                # Progress line — overwrite this source's active slot, or append
+                idx = self._file_progress.get(src)
+                if idx is not None and 0 <= idx < len(self._log_lines):
+                    self._log_lines[idx] = formatted
+                else:
+                    self._log_lines.append(formatted)
+                    self._file_progress[src] = len(self._log_lines) - 1
+            else:
+                # Normal line — append and clear any active progress slot
+                self._log_lines.append(formatted)
+                self._file_progress.pop(src, None)
+            # Trim old lines to prevent unbounded growth
+            if len(self._log_lines) > self._max_log_lines:
+                trim = len(self._log_lines) - self._max_log_lines
+                self._log_lines = self._log_lines[trim:]
+                stale = []
+                for s, idx in self._file_progress.items():
+                    idx -= trim
+                    if idx < 0:
+                        stale.append(s)
+                    else:
+                        self._file_progress[s] = idx
+                for s in stale:
+                    del self._file_progress[s]
+            self._refresh_panel()
+        else:
+            if overwrite:
+                print(f"\r\033[K\033[2m{formatted}\033[0m",
+                      end="", file=sys.stderr, flush=True)
+            else:
+                print(f"\033[2m{formatted}\033[0m", file=sys.stderr)
+
+    def _refresh_panel(self):
+        self._esc("\033[s")  # save cursor
+        # Draw the most recent lines that fit in the panel
+        visible = self._log_lines[-self._panel_height:]
+        for i in range(self._panel_height):
+            row = self._scroll_end + 2 + i
+            self._esc(f"\033[{row};1H\033[K")
+            if i < len(visible):
+                # Truncate to terminal width, preserve ANSI
+                self._esc(f"\033[2m{visible[i]}\033[0m")
+        self._esc("\033[u")  # restore cursor
+        sys.stderr.flush()
+
+    def cleanup(self):
+        """Reset terminal to normal state."""
+        if self.active:
+            self._esc("\033[r")  # reset scroll region
+            self._esc(f"\033[{self._rows};1H\n")  # move to bottom
+            sys.stderr.flush()
+            self.active = False
+
+
+class VastAPI:
+    """Thin wrapper around Vast REST API."""
+
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+    def _do_request(self, method, path, body=None, query=None):
+        """Execute the HTTP request. Raises HTTPError/URLError on failure."""
+        url = API_BASE + path
+        if query:
+            params = {k: v if isinstance(v, str) else json.dumps(v) for k, v in query.items()}
+            url += "?" + urllib.parse.urlencode(params, quote_via=urllib.parse.quote_plus)
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Accept", "application/json")
+        req.add_header("Authorization", f"Bearer {self.api_key}")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=API_REQUEST_TIMEOUT) as resp:
+            raw = resp.read().decode()
+            if not raw:
+                return {}
+            return json.loads(raw)
+
+    def _request(self, method, path, body=None, query=None):
+        """Make authenticated API request, return parsed JSON.  Exits on
+        transport/HTTP errors — used for one-shot calls where retry is not
+        meaningful.  Long-running pollers should use ``_request_safe``."""
+        try:
+            return self._do_request(method, path, body, query)
+        except urllib.error.HTTPError as e:
+            body_text = ""
+            try:
+                body_text = e.read().decode()
+            except Exception:
+                pass
+            print(f"API error {e.code} {method} {path}: {body_text}", file=sys.stderr)
+            emit_outcome("config_error", EXIT_CONFIG_ERROR, reason=f"API error {e.code} on {path}")
+        except urllib.error.URLError as e:
+            print(f"API connection error {method} {path}: {e.reason}", file=sys.stderr)
+            emit_outcome("config_error", EXIT_CONFIG_ERROR, reason=f"API connection error on {path}")
+
+    def _request_safe(self, method, path, body=None, query=None):
+        """Like ``_request`` but returns ``None`` on transport/HTTP errors
+        instead of exiting.  Used by pollers and the health watchdog so a
+        single transient API blip during a multi-hour run is not fatal."""
+        try:
+            return self._do_request(method, path, body, query)
+        except (urllib.error.HTTPError, urllib.error.URLError,
+                TimeoutError, OSError):
+            return None
+
+    def get_template(self, hash_id):
+        """Fetch template by hash_id via search endpoint."""
+        result = self._request("GET", "/api/v0/template/", query={
+            "select_cols": ["*"],
+            "select_filters": {"hash_id": {"eq": hash_id}},
+        })
+        templates = result.get("templates", [])
+        if not templates:
+            print(f"Template '{hash_id}' not found", file=sys.stderr)
+            emit_outcome("config_error", EXIT_CONFIG_ERROR, reason="template not found")
+        return templates[0]
+
+    def search_offers(self, filters):
+        return self._request("POST", "/api/v0/bundles/", filters)
+
+    def create_instance(self, offer_id, payload):
+        # Return a failure dict instead of exiting so the retry loop can
+        # survive a per-offer HTTP error (e.g. 409 "offer no longer available").
+        try:
+            return self._request("PUT", f"/api/v0/asks/{offer_id}/", payload)
+        except SystemExit:
+            return {"success": False, "msg": "API error (see stderr)"}
+
+    def get_instance(self, instance_id, safe=False):
+        """Fetch instance via list endpoint (has Docker-style port mappings).
+
+        Returns ``{}`` if the instance is not in the user's list (e.g.
+        destroyed externally).  When ``safe=True``, transport/HTTP errors
+        return ``None`` instead of exiting so callers in retry loops can
+        distinguish a destroyed instance from a transient API blip.
+        """
+        request = self._request_safe if safe else self._request
+        result = request("GET", "/api/v0/instances/", query={"owner": "me"})
+        if result is None:
+            return None
+        for inst in result.get("instances", []):
+            if inst.get("id") == instance_id:
+                return inst
+        return {}
+
+    def get_instance_status(self, instance_id, safe=False):
+        """Fetch a single instance via ``/api/v0/instances/{id}/`` — O(1).
+
+        Suitable for the health watchdog which only needs ``actual_status``.
+        The single-instance endpoint does not include Docker-style port
+        mappings, so the startup poll still uses ``get_instance``.
+
+        Returns ``{}`` if the instance is missing, ``None`` on transport
+        errors when ``safe=True``.  The endpoint shape is
+        ``{"instances": [{...}]}`` for a live instance and
+        ``{"instances": null}`` for an unknown id.
+        """
+        request = self._request_safe if safe else self._request
+        result = request("GET", f"/api/v0/instances/{instance_id}/")
+        if result is None:
+            return None
+        insts = result.get("instances")
+        if isinstance(insts, list) and insts:
+            return insts[0]
+        if isinstance(insts, dict):
+            return insts
+        return {}
+
+    @staticmethod
+    def get_status(test_url, token=None):
+        """Fetch final test status from instance's /test-status endpoint."""
+        req = urllib.request.Request(test_url + "/test-status")
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(req, timeout=API_REQUEST_TIMEOUT) as resp:
+            return json.loads(resp.read().decode())
+
+    def stop_instance(self, instance_id):
+        # _request_safe: an instance that's already gone (404) makes teardown a
+        # no-op rather than a hard exit — a mid-test spot reclaim must not turn
+        # cleanup into a spurious config_error.
+        return self._request_safe("PUT", f"/api/v0/instances/{instance_id}/",
+                                  {"state": "stopped"})
+
+    def destroy_instance(self, instance_id):
+        return self._request_safe("DELETE", f"/api/v0/instances/{instance_id}/")
+
+
+def format_filters(filters):
+    """Format filter dict for human-readable display."""
+    ops = {"eq": "=", "gte": ">=", "lte": "<=", "gt": ">", "lt": "<", "in": "in"}
+    parts = []
+    skip = {"verified", "external", "rentable", "rented"}
+    for key, val in filters.items():
+        if key in skip:
+            continue
+        if isinstance(val, dict):
+            for op, v in val.items():
+                parts.append(f"{key} {ops.get(op, op)} {v}")
+        else:
+            parts.append(f"{key} = {val}")
+    return ", ".join(parts) if parts else "(base filters only)"
+
+
+TERMINAL_STATES = {"stopped", "offline", "error", "exited"}
+
+# Status-message substrings that indicate the instance is unrecoverable but
+# may never transition to a TERMINAL_STATES value — polling would otherwise
+# wait until timeout.  Matched case-insensitively against ``status_msg``.
+BAD_STATUS_PATTERNS = (
+    "error response from daemon",      # Docker daemon errors (image pull, etc.)
+    "failed to pull image",
+    "no space left on device",
+    "manifest unknown",
+    "unauthorized",
+)
+
+
+def _bad_status_reason(status_msg):
+    if not status_msg:
+        return None
+    lower = status_msg.lower()
+    for pat in BAD_STATUS_PATTERNS:
+        if pat in lower:
+            return pat
+    return None
+
+
+def poll_until_running(api, instance_id, timeout=POLL_TIMEOUT):
+    """Poll instance until running with ports available.
+
+    Returns (test_url, auth_token) tuple. auth_token is the instance's
+    jupyter_token used as Bearer auth for the test server, or None if
+    the instance doesn't provide one.  Returns (None, None) on failure.
+    """
+    deadline = time.time() + timeout
+    last_status = ""
+    while time.time() < deadline:
+        inst = api.get_instance(instance_id, safe=True)
+
+        # Transient API error — sleep and retry rather than crash the whole
+        # tool on a single network blip during a multi-hour boot poll.
+        if inst is None:
+            time.sleep(5)
+            continue
+
+        if not inst:
+            print(f"\r\033[KInstance {instance_id} not found (destroyed externally?)",
+                  file=sys.stderr)
+            return None, None
+
+        status = inst.get("actual_status", "")
+        status_msg = inst.get("status_msg", "")
+
+        # Update status line in-place when it changes
+        current = status_msg.strip() if status_msg else status
+        if current and current != last_status:
+            last_status = current
+            # Clear line and overwrite
+            print(f"\r\033[K  Status: {current}", end="", flush=True, file=sys.stderr)
+
+        # Detect terminal failure states during startup
+        if status in TERMINAL_STATES:
+            print(f"\r\033[KInstance {instance_id} entered unexpected state: {status}",
+                  file=sys.stderr)
+            return None, None
+
+        # Detect unrecoverable status messages (e.g. "Error response from
+        # daemon") that never transition to a terminal state — no point
+        # waiting out the full POLL_TIMEOUT.
+        bad = _bad_status_reason(status_msg)
+        if bad:
+            print(f"\r\033[KInstance {instance_id} has bad status: {status_msg.strip()}",
+                  file=sys.stderr)
+            return None, None
+
+        if status == "running" and inst.get("public_ipaddr"):
+            ports = inst.get("ports", {})
+            test_port = None
+            for key, mappings in (ports or {}).items():
+                if key.startswith(str(TEST_SERVER_PORT)):
+                    if isinstance(mappings, list) and mappings:
+                        test_port = mappings[0].get("HostPort")
+                    break
+
+            if test_port:
+                host = inst["public_ipaddr"]
+                token = inst.get("jupyter_token")
+                # Clear status line and print final
+                print(f"\r\033[KInstance {instance_id} running ({host}:{test_port})",
+                      file=sys.stderr)
+                return f"http://{host}:{test_port}", token
+
+        time.sleep(5)
+
+    print(f"\r\033[KTimeout waiting for instance {instance_id} to start", file=sys.stderr)
+    return None, None
+
+
+def _parse_sse_event(data_lines, event_type):
+    """Parse SSE data lines into an event dict."""
+    raw_data = "\n".join(data_lines)
+    try:
+        parsed = json.loads(raw_data)
+    except json.JSONDecodeError:
+        parsed = raw_data
+    if isinstance(parsed, dict):
+        parsed["_event"] = event_type
+    else:
+        parsed = {"_event": event_type, "_data": parsed}
+    return parsed
+
+
+def stream_sse(url, timeout, token=None):
+    """Connect to SSE endpoint, yield parsed events.
+
+    Two phases:
+      1. Connection phase — retries every 5s for up to 5 min while the instance
+         boots and the test server starts.  Uses SSE_READ_TIMEOUT per attempt.
+      2. Streaming phase — once connected, uses SSE_READ_TIMEOUT as the socket
+         read timeout.  If no data arrives within that window, the connection is
+         considered lost and we exit immediately (no reconnect).  A dead instance
+         won't recover, so there's no point retrying.
+    """
+    deadline = time.time() + timeout
+    retries = 0
+    max_retries = 60  # 60 * 5s = 5 min for boot scripts + test server startup
+    connected = False
+
+    while time.time() < deadline and retries <= max_retries:
+        try:
+            req = urllib.request.Request(url)
+            req.add_header("Accept", "text/event-stream")
+            if token:
+                req.add_header("Authorization", f"Bearer {token}")
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            resp = urllib.request.urlopen(
+                req, timeout=min(SSE_READ_TIMEOUT, remaining))
+
+            # ── Connected ─────────────────────────────────────────────
+            if retries > 0:
+                print(" connected", flush=True, file=sys.stderr)
+            connected = True
+
+            # Set socket-level read timeout so readline() doesn't hang
+            # indefinitely if the instance dies mid-stream.
+            try:
+                sock = resp.fp.raw
+                if hasattr(sock, '_sock'):
+                    sock._sock.settimeout(SSE_READ_TIMEOUT)
+                elif hasattr(sock, 'settimeout'):
+                    sock.settimeout(SSE_READ_TIMEOUT)
+            except (AttributeError, OSError):
+                pass  # fall back to urlopen timeout
+
+            event_type = None
+            data_lines = []
+
+            while True:
+                raw_line = resp.readline()
+                if not raw_line:
+                    break
+                if time.time() > deadline:
+                    yield {"_timeout": True}
+                    return
+
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+
+                if line.startswith("event:"):
+                    event_type = line[6:].strip()
+                elif line.startswith("data:"):
+                    data_lines.append(line[5:].strip())
+                elif line == "" and data_lines:
+                    yield _parse_sse_event(data_lines, event_type)
+                    event_type = None
+                    data_lines = []
+
+            # Stream ended cleanly — flush any remaining data
+            if data_lines and event_type is not None:
+                yield _parse_sse_event(data_lines, event_type)
+            return
+
+        except (urllib.error.URLError, OSError, TimeoutError):
+            if connected:
+                # Lost connection after we were streaming — instance is gone
+                yield {"_error": f"connection lost (no data/heartbeat for {SSE_READ_TIMEOUT}s)"}
+                return
+            retries += 1
+            if retries > max_retries:
+                print("Could not connect to test server", file=sys.stderr)
+                yield {"_error": "connection failed after retries"}
+                return
+            if retries == 1:
+                print("Waiting for test server...", end="", flush=True, file=sys.stderr)
+            else:
+                print(".", end="", flush=True, file=sys.stderr)
+            time.sleep(5)
+
+    yield {"_timeout": True}
+
+
+def format_summary(state, counts, elapsed=None, failed_names=None):
+    """Format the final summary line."""
+    color = "\033[32m" if state == "passed" else "\033[31m"
+    reset = "\033[0m"
+    dur_str = f" ({elapsed}s)" if elapsed is not None else ""
+    summary = (f"{color}{state.upper()}{reset} — "
+               f"{counts['passed']} passed, {counts['failed']} failed, "
+               f"{counts['skipped']} skipped{dur_str}")
+    if failed_names:
+        summary += f"\n  Failed: {', '.join(failed_names)}"
+    return summary
+
+
+def _required_floor(extra_filters, key):
+    """Return the minimum value the template asks for (e.g. MB of gpu_total_ram).
+
+    Handles the filter shapes seen in practice: ``{"key": {"gte": N}}``,
+    ``{"key": {"gt": N}}``, ``{"key": {"eq": N}}`` and the bare scalar
+    ``{"key": N}``.  Returns None if absent or unparseable.
+    """
+    spec = extra_filters.get(key)
+    if spec is None:
+        return None
+    if isinstance(spec, dict):
+        for op in ("gte", "gt", "eq"):
+            if op in spec:
+                try:
+                    return float(spec[op])
+                except (TypeError, ValueError):
+                    return None
+        return None
+    try:
+        return float(spec)
+    except (TypeError, ValueError):
+        return None
+
+
+def _base_offer_score(o):
+    """Legacy inet/price score; used as the final tie-breaker in sort key."""
+    inet = o.get("inet_down", 0) + o.get("inet_up", 0)
+    price = max(o.get("dph_total", 1), 0.01)
+    dl_cost = o.get("inet_down_cost", 0)  # $/GB
+    # Value = internet speed per dollar, penalized by download cost.
+    # The 5000 multiplier means $0.01/GB download cost halves the score
+    # (1 + 0.01*5000 = 51 → ~50x penalty).  This heavily penalizes
+    # metered-bandwidth machines since image pulls are 10-50+ GB.
+    return (inet / price) / (1 + dl_cost * 5000)
+
+
+def apply_vram_ceiling(filters, multiplier):
+    """Bound the VRAM search above the declared floor (ADR 0005).
+
+    If the template declares a ``gpu_total_ram`` floor (``gte``) but no upper
+    bound, cap the search at ``multiplier × floor`` so a "``>=12GB``" claim is not
+    tested on a 96GB box. Templates that set their own ``lte`` are respected.
+    Returns a filters dict (the ``gpu_total_ram`` spec is copied, not mutated).
+    """
+    spec = filters.get("gpu_total_ram")
+    if isinstance(spec, dict) and "gte" in spec and "lte" not in spec:
+        try:
+            ceiling = float(spec["gte"]) * multiplier
+        except (TypeError, ValueError):
+            return filters
+        return {**filters, "gpu_total_ram": {**spec, "lte": ceiling}}
+    return filters
+
+
+def make_offer_sort_key(required_total_mb, required_per_gpu_mb, required_compute_cap=None):
+    """Build an ascending sort key for offers (ADR 0005: test the smallest viable box).
+
+    VRAM is primary: a pass at the (headroom-adjusted) VRAM floor generalises up to
+    bigger boxes, so prefer the least VRAM above the floor. ``compute_cap`` breaks
+    ties — among same-VRAM offers, prefer the lowest capability at or above the
+    floor (GPUs are backward-compatible, so a pass at the floor generalises up).
+
+    Components (earlier dominates):
+      1. gpu_total_ram overshoot — ``(actual - floor) / floor``; ``inf`` when below
+         the floor so undersized offers sink. Prefer the smallest VRAM above the
+         declared requirement (the search is also hard-bounded above — see
+         ``apply_vram_ceiling``).
+      2. gpu_ram overshoot — per-GPU VRAM fit, same shape.
+      3. compute_cap above the declared floor — ``compute_cap - floor``; ``inf``
+         below the floor. ``compute_cap`` is an integer ×100 (700 = sm_70,
+         890 = sm_89/FP8, 900 = H100); the floor (from ``extra_filters``) must
+         encode the image's feature target.
+      4. num_gpus ascending — smallest fanout that satisfies VRAM.
+      5. ``-_base_offer_score(o)`` — inet/price score, negated; tie-breaker, and
+         the dominant key when no floor is specified.
+    """
+    def key(o):
+        compute_cap = o.get("compute_cap") or 0
+        total_ram = o.get("gpu_total_ram") or 0
+        per_gpu_ram = o.get("gpu_ram") or 0
+        num_gpus = o.get("num_gpus") or 0
+
+        if required_total_mb:
+            total_overshoot = ((total_ram - required_total_mb) / required_total_mb
+                               if total_ram >= required_total_mb else float("inf"))
+        else:
+            total_overshoot = 0.0
+
+        if required_per_gpu_mb:
+            per_gpu_overshoot = ((per_gpu_ram - required_per_gpu_mb) / required_per_gpu_mb
+                                 if per_gpu_ram >= required_per_gpu_mb else float("inf"))
+        else:
+            per_gpu_overshoot = 0.0
+
+        if required_compute_cap:
+            cap_overshoot = ((compute_cap - required_compute_cap)
+                             if compute_cap >= required_compute_cap else float("inf"))
+        else:
+            cap_overshoot = 0.0
+
+        return (total_overshoot, per_gpu_overshoot, cap_overshoot, num_gpus, -_base_offer_score(o))
+    return key
+
+
+def _safe_destroy(api, instance_id, log):
+    try:
+        api.destroy_instance(instance_id)
+    except Exception as e:
+        log(f"    (destroy failed: {e})")
+
+
+def _is_connection_refused(exc):
+    """True when a socket error means 'host reachable, nothing listening yet'.
+
+    Connection refused / reset prove packets round-trip to the host — its
+    port forwarding works, there is just no server bound to the port.  A
+    timeout or unreachable-host error means the opposite: traffic is being
+    black-holed.  ``urllib.error.URLError`` wraps the real error in
+    ``.reason``; bare ``OSError`` subclasses are inspected directly.
+    """
+    reason = getattr(exc, "reason", exc)
+    if isinstance(reason, (ConnectionRefusedError, ConnectionResetError)):
+        return True
+    return getattr(reason, "errno", None) in (errno.ECONNREFUSED, errno.ECONNRESET)
+
+
+def probe_test_server(test_url, auth_token=None,
+                      connectivity_timeout=NETWORK_PROBE_TIMEOUT,
+                      server_timeout=NETWORK_PROBE_TIMEOUT, log=None):
+    """Return True once the instance's test results server answers HTTP.
+
+    Two failure modes are separated by the *kind* of socket error, so a
+    slow-but-healthy host is not mistaken for a broken one:
+
+      * Connection refused / reset — the host is reachable and its port
+        forwarding works; nothing is bound to the test port yet.  This is
+        expected: the boot sequence runs provisioning (model downloads,
+        pip installs) to completion *before* it launches the test runner
+        (75-provisioning-manifest.sh precedes 85-instance-test.sh), so the
+        results server can be many minutes away.  Keep waiting, up to
+        ``server_timeout``.
+
+      * Connection timeout / unreachable — packets are being black-holed.
+        Some hosts enter "running" with broken networking and never
+        recover.  Nothing but timeouts for ``connectivity_timeout``
+        seconds → abandon the instance.
+
+    Any HTTP response (even 4xx/5xx) proves the server is up → return True.
+    """
+    start = time.time()
+    host_reachable = False  # flipped once a refused/reset or HTTP reply arrives
+    last_report = 0.0
+    while True:
+        elapsed = time.time() - start
+        # Until the host proves reachable we only allow the short
+        # connectivity window; after that, the long provisioning deadline.
+        deadline = server_timeout if host_reachable else connectivity_timeout
+        if elapsed >= deadline:
+            return False
+        try:
+            req = urllib.request.Request(test_url + "/test-status")
+            if auth_token:
+                req.add_header("Authorization", f"Bearer {auth_token}")
+            with urllib.request.urlopen(req, timeout=5):
+                return True
+        except urllib.error.HTTPError:
+            # Any HTTP response proves the server is up, even non-200.
+            # Includes 401 from a missing/bad bearer token — auth failures
+            # surface later on the SSE stream rather than here.
+            return True
+        except (urllib.error.URLError, OSError, TimeoutError) as e:
+            if _is_connection_refused(e) and not host_reachable:
+                host_reachable = True
+                if log:
+                    log("  Host reachable (port forwarding OK) — waiting for "
+                        "the test server; provisioning runs first and may "
+                        "take a while...")
+            if log and host_reachable and elapsed - last_report >= 60:
+                last_report = elapsed
+                log(f"  [{elapsed:.0f}s] still waiting for test server "
+                    f"(deadline {server_timeout:.0f}s)")
+            time.sleep(2)
+
+
+def monitor_instance_health(api, instance_id, dead_event, set_dead,
+                            poll_interval=15):
+    """Background watchdog: signal ``set_dead(reason)`` when the instance
+    leaves the ``running`` state or is destroyed externally.
+
+    Survives transient API errors so a single network blip during a
+    multi-hour run does not silently terminate the thread:
+
+    * ``api.get_instance_status(safe=True)`` returns ``None`` on
+      transport/HTTP errors instead of exiting the process.
+    * ``BaseException`` catch is belt-and-braces against anything (including
+      ``SystemExit``) that might still leak from the call path — ``Exception``
+      alone misses ``SystemExit`` because it inherits from ``BaseException``.
+
+    Exits cleanly when ``dead_event`` is set externally (e.g. once the test
+    run has finished and the main thread no longer needs the watchdog).
+    """
+    while not dead_event.is_set():
+        dead_event.wait(poll_interval)
+        if dead_event.is_set():
+            return
+        try:
+            inst = api.get_instance_status(instance_id, safe=True)
+        except BaseException:
+            continue
+        if inst is None:
+            continue  # transient API error — retry next tick
+        if not inst:
+            set_dead("not found (destroyed externally?)")
+            return
+        status = inst.get("actual_status", "")
+        if status and status != "running":
+            set_dead(status)
+            return
+
+
+def launch_with_retry(api, candidate_offers, payload_factory, requested_disk,
+                      max_attempts, on_instance_created, log,
+                      server_probe_timeout=NETWORK_PROBE_TIMEOUT):
+    """Try candidate offers until one launches and provisions adequate disk.
+
+    Walks ``candidate_offers`` (assumed pre-sorted best-first), attempting
+    each until one yields a running instance with ``disk_space`` at least
+    ``DISK_TOLERANCE * requested_disk``.  Any instance that fails any check
+    is destroyed and its offer blacklisted so the same bad machine is not
+    retried within the same run.
+
+    ``on_instance_created(instance_id)`` is called the moment an instance_id
+    is known, so the outer scope (signal handler) can track the currently
+    booting instance for cleanup.
+
+    Returns ``(instance_id, test_url, auth_token)`` on success, or ``None``
+    if every candidate was exhausted.
+
+    When any offer fails (create error, never-runs, bad disk), both its
+    ``offer_id`` and its ``machine_id`` are blacklisted — a single flaky
+    machine can host several offers, and one bad offer is strong evidence
+    the others on the same machine will also fail.
+    """
+    offer_blacklist = set()
+    machine_blacklist = set()
+    attempts = 0
+    last_error = ""
+
+    def _blacklist(offer):
+        offer_blacklist.add(offer["id"])
+        mid = offer.get("machine_id")
+        if mid is not None:
+            machine_blacklist.add(mid)
+
+    for offer in candidate_offers:
+        if attempts >= max_attempts:
+            log(f"Reached max launch attempts ({max_attempts})")
+            break
+        offer_id = offer["id"]
+        if offer_id in offer_blacklist:
+            continue
+        machine_id = offer.get("machine_id")
+        if machine_id is not None and machine_id in machine_blacklist:
+            log(f"Skipping offer {offer_id} — machine {machine_id} already blacklisted")
+            continue
+        attempts += 1
+        log(f"[Attempt {attempts}/{max_attempts}] Launching offer {offer_id} "
+            f"({offer.get('gpu_name', '?')} x{offer.get('num_gpus', '?')})")
+
+        result = api.create_instance(offer_id, payload_factory(offer))
+        if not result.get("success"):
+            last_error = result.get("msg") or json.dumps(result)
+            log(f"  create_instance failed: {last_error}")
+            _blacklist(offer)
+            continue
+        instance_id = result["new_contract"]
+        on_instance_created(instance_id)
+        log(f"  Instance {instance_id} created, waiting for startup...")
+
+        test_url, auth_token = poll_until_running(api, instance_id)
+        if not test_url:
+            log(f"  Instance {instance_id} never reached running state — destroying")
+            _safe_destroy(api, instance_id, log)
+            _blacklist(offer)
+            on_instance_created(None)
+            continue
+
+        inst = api.get_instance(instance_id)
+        actual_disk = inst.get("disk_space")
+        if actual_disk is None:
+            log(f"  WARNING: instance {instance_id} did not report disk_space; "
+                f"proceeding without verification")
+        elif actual_disk < requested_disk * DISK_TOLERANCE:
+            log(f"  [Bad instance] {instance_id} under-provisioned disk: "
+                f"got {actual_disk:.1f} GB, requested {requested_disk:.1f} GB "
+                f"— destroying, retrying")
+            _safe_destroy(api, instance_id, log)
+            _blacklist(offer)
+            on_instance_created(None)
+            continue
+        else:
+            log(f"  Disk OK: {actual_disk:.1f} GB / {requested_disk:.1f} GB requested")
+
+        # Verify connectivity to the test server.  A host with broken
+        # networking never answers and is abandoned within seconds; a
+        # healthy host still provisioning is waited out up to
+        # server_probe_timeout (see probe_test_server).
+        if not probe_test_server(test_url, auth_token,
+                                 server_timeout=server_probe_timeout, log=log):
+            log(f"  [Bad instance] {instance_id} test server unreachable "
+                f"(broken networking, or never started) — destroying, retrying")
+            _safe_destroy(api, instance_id, log)
+            _blacklist(offer)
+            on_instance_created(None)
+            continue
+
+        return instance_id, test_url, auth_token
+
+    log(f"Exhausted offers ({attempts} attempts, last error: {last_error or 'none'})")
+    return None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Launch a Vast.ai instance from a template and stream test results."
+    )
+    parser.add_argument("template_hash", help="Vast template hash to test")
+    parser.add_argument("--api-key", metavar="KEY", help="Vast API key (default: $VAST_API_KEY)")
+    parser.add_argument("--offer", type=int, metavar="ID", help="Use specific offer ID (skip search)")
+    parser.add_argument("--gpu", metavar="GPU", help="Filter to specific GPU model")
+    parser.add_argument("--arch", metavar="ARCH", default="amd64",
+                        help="CPU arch of the host (default: amd64). arm64 is opt-in "
+                             "and untested by QA — availability/reliability not yet characterised.")
+    parser.add_argument("--require-floor", action="store_true",
+                        help="Fail (config_error) if the template declares no parseable "
+                             "compute_cap floor — for gating runs (ADR 0005 cond 10).")
+    parser.add_argument("--label", metavar="LABEL",
+                        help="Stamp the launched instance with this Vast label so the "
+                             "reaper can positively identify QA-owned instances.")
+    parser.add_argument("--max-price", type=float, metavar="PRICE", help="Max $/hr filter")
+    parser.add_argument("--disk", type=float, metavar="GB", help="Override template's recommended_disk")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TEST_TIMEOUT, metavar="SECS",
+                        help=f"Max wait for tests to complete (default: {DEFAULT_TEST_TIMEOUT})")
+    cleanup_group = parser.add_mutually_exclusive_group()
+    cleanup_group.add_argument("--destroy", action="store_true",
+                               help="Destroy instance after test (default: stop)")
+    cleanup_group.add_argument("--keep", action="store_true",
+                               help="Keep instance running after test (skip stop/destroy)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show selected offer and exit without launching")
+    parser.add_argument("--force", action="store_true",
+                        help="Skip image validation (allow non-vastai images)")
+    parser.add_argument("--raw", action="store_true",
+                        help="Output final JSON result to stdout (streaming output goes to stderr)")
+    parser.add_argument("--log", metavar="PATH", action="append", default=[],
+                        help="Tail a log file on the instance (repeatable, e.g. --log /var/log/portal --log /var/log/vllm)")
+    parser.add_argument("--env", metavar="KEY=VAL", action="append", default=[],
+                        help="Set instance env var (repeatable). Timeout overrides: "
+                             "PROV_TIMEOUT, VLLM_HEALTH_TIMEOUT, INSTANCE_TEST_DEFAULT_TIMEOUT")
+    return parser.parse_args()
+
+
+def main():
+    global _RAW_MODE
+    args = parse_args()
+    _RAW_MODE = args.raw
+    api_key = args.api_key or os.environ.get("VAST_API_KEY")
+    if not api_key:
+        print("No API key provided. Use --api-key or set $VAST_API_KEY", file=sys.stderr)
+        emit_outcome("config_error", EXIT_CONFIG_ERROR, reason="no api key")
+
+    # All human-readable output goes to stderr so stdout is clean for --raw JSON
+    def log(msg="", **kwargs):
+        print(msg, file=sys.stderr, **kwargs)
+
+    api = VastAPI(api_key)
+    # Mutable state shared with signal handler, monitor thread, and the
+    # retry helper — SimpleNamespace lets nested functions assign attributes.
+    # ctx.instance_id tracks the currently booting or running instance so
+    # the signal handler can clean up mid-retry.
+    ctx = types.SimpleNamespace(panel=None, dead_reason="", instance_id=None)
+
+    def cleanup(destroy=False):
+        if ctx.panel:
+            ctx.panel.cleanup()
+        if ctx.instance_id is None:
+            return
+        if args.keep and not destroy:
+            log(f"Instance {ctx.instance_id} kept running (--keep)")
+            return
+        try:
+            if destroy or args.destroy:
+                api.destroy_instance(ctx.instance_id)
+                log(f"Instance {ctx.instance_id} destroyed.")
+            else:
+                api.stop_instance(ctx.instance_id)
+                log(f"Instance {ctx.instance_id} stopped.")
+        except Exception as e:
+            log(f"Cleanup error: {e}")
+
+    def sighandler(sig, frame):
+        log("\nInterrupted — destroying instance...")
+        cleanup(destroy=True)
+        emit_outcome("interrupted", EXIT_INTERRUPTED, reason="signal")
+
+    signal.signal(signal.SIGINT, sighandler)
+    signal.signal(signal.SIGTERM, sighandler)
+
+    # 1. Fetch template
+    template = api.get_template(args.template_hash)
+    image = template.get("image", "")
+    tag = template.get("tag") or template.get("default_tag") or ""
+    image_full = f"{image}:{tag}" if tag else image
+    name = template.get("name", args.template_hash)
+
+    # Validate image — only vastai/ and robatvastai/ images have the test suite
+    ALLOWED_PREFIXES = ("vastai/", "robatvastai/")
+    if "kvm" in image.lower():
+        log(f"Image '{image_full}' is a KVM image — virtual machines are not supported")
+        emit_outcome("config_error", EXIT_CONFIG_ERROR, reason="kvm image unsupported")
+    if not args.force and not any(image.startswith(p) for p in ALLOWED_PREFIXES):
+        log(f"Image '{image_full}' is not a known test-suite image "
+            f"(expected {' or '.join(ALLOWED_PREFIXES)})\n"
+            f"Use --force to override")
+        emit_outcome("config_error", EXIT_CONFIG_ERROR, reason="non-vastai image")
+
+    # Detect serverless templates — SERVERLESS=true appears in the env string
+    # (e.g. "-e SERVERLESS=true") or in onstart (e.g. "export SERVERLESS=true").
+    template_env = template.get("env", "") or ""
+    template_onstart = template.get("onstart", "") or ""
+    is_serverless = ("SERVERLESS=true" in template_env
+                     or "SERVERLESS=true" in template_onstart)
+
+    extra_filters_raw = template.get("extra_filters", "{}")
+    if isinstance(extra_filters_raw, str):
+        extra_filters = json.loads(extra_filters_raw) if extra_filters_raw else {}
+    else:
+        extra_filters = extra_filters_raw or {}
+
+    disk = args.disk or template.get("recommended_disk_space") or 40
+
+    log(f"Template: {name} (hash: {args.template_hash})")
+    log(f"Image: {image_full}")
+    log(f"Disk: {disk} GB")
+
+    # 2. Build instance env overrides.  With template_hash_id, the server
+    # uses the template's full config; we only send our additions.
+    port_map = f"-p {TEST_SERVER_PORT}:{TEST_SERVER_PORT}"
+    env = {"INSTANCE_TEST": "true", port_map: "1"}
+    # Non-serverless templates already have OPEN_BUTTON_TOKEN=1 in their config.
+    # For serverless templates we must send it as an override so the backend
+    # generates an auth token (jupyter_token) we can use to connect.
+    if is_serverless:
+        env["OPEN_BUTTON_TOKEN"] = "1"
+    if args.log:
+        env["INSTANCE_TEST_SYSTEM_LOG"] = ",".join(args.log)
+    for kv in args.env:
+        if "=" not in kv:
+            log(f"Invalid --env format (expected KEY=VAL): {kv}")
+            emit_outcome("config_error", EXIT_CONFIG_ERROR, reason="bad --env format")
+        k, v = kv.split("=", 1)
+        env[k] = v
+
+    # Auto-adjust client --timeout based on instance-side timeout env vars.
+    # The instance runs provisioning first, then tests sequentially.  The
+    # client timeout must exceed the sum of the largest sequential phases
+    # so we don't give up before the instance does.
+    timeout_was_default = (args.timeout == DEFAULT_TEST_TIMEOUT)
+    instance_timeouts = {}
+    for env_name, default in INSTANCE_TIMEOUT_ENVS.items():
+        if env_name in env:
+            try:
+                instance_timeouts[env_name] = int(env[env_name])
+            except ValueError:
+                pass
+        else:
+            instance_timeouts[env_name] = default
+
+    # Provisioning and the longest derivative test run sequentially.
+    # INSTANCE_TEST_DEFAULT_TIMEOUT is per-test but most are fast — only
+    # count it once as a floor for derivative test timeouts.
+    prov = instance_timeouts.get("PROV_TIMEOUT", 3600)
+    derivative = max(
+        instance_timeouts.get("VLLM_HEALTH_TIMEOUT", 3600),
+        instance_timeouts.get("INSTANCE_TEST_DEFAULT_TIMEOUT", 3600),
+    )
+    min_timeout = prov + derivative + TIMEOUT_HEADROOM
+
+    # The test results server only binds its port after provisioning
+    # finishes (boot runs 75-provisioning-manifest.sh before
+    # 85-instance-test.sh), so the connectivity probe must tolerate the
+    # full provisioning window once it has confirmed the host is reachable.
+    server_probe_timeout = prov + TIMEOUT_HEADROOM
+
+    if args.timeout < min_timeout:
+        # Always lift a too-short timeout — keeping it (even when set explicitly)
+        # makes the client give up mid-provision and report a spurious "failed",
+        # a false BLOCK. A caller wanting a true cost cap should use --max-price,
+        # not a timeout below the instance's own provisioning budget.
+        origin = "default" if timeout_was_default else f"explicit {args.timeout}s is below"
+        log(f"Auto-adjusting --timeout: {args.timeout}s → {min_timeout}s "
+            f"({origin} the instance's need: prov={prov}s + derivative={derivative}s "
+            f"+ headroom={TIMEOUT_HEADROOM}s)")
+        args.timeout = min_timeout
+
+    # ADR 0005 cond 10: don't trust the linter ran. On a gating run a missing or
+    # unparseable compute_cap floor would silently select a random GPU generation
+    # — refuse it loudly. Checked BEFORE the --offer split so --offer can't bypass it.
+    required_compute_cap = _required_floor(extra_filters, "compute_cap")
+    if args.require_floor and required_compute_cap is None:
+        emit_outcome("config_error", EXIT_CONFIG_ERROR,
+                     reason="--require-floor: template declares no parseable compute_cap floor")
+
+    # 3. Find candidate offers.  When --offer is given, skip search and use
+    # a single-element candidate list with only one allowed attempt.
+    if args.offer:
+        candidate_offers = [{"id": args.offer}]
+        max_attempts = 1
+        log(f"Using offer {args.offer}")
+        if args.dry_run:
+            return
+    else:
+        filters = {
+            "verified": {"eq": True},
+            "external": {"eq": False},
+            "rentable": {"eq": True},
+            "rented": {"eq": False},
+            **extra_filters,
+            # ADR 0005 cond 4: restrict to amd64 — set AFTER the extra_filters
+            # spread so a template cannot override the arch guard and silently
+            # land QA on an arm host.
+            "cpu_arch": {"eq": args.arch},
+        }
+        if args.gpu:
+            filters["gpu_name"] = {"eq": args.gpu}
+        if args.max_price:
+            filters["dph_total"] = {"lte": args.max_price}
+        # Bound the VRAM search above the declared floor (don't test a small
+        # claim on a huge box). Templates with an explicit lte are left alone.
+        filters = apply_vram_ceiling(filters, VRAM_CEILING_MULTIPLIER)
+
+        log(f"Filters: {format_filters(filters)}")
+
+        # Sort: smallest VRAM above floor, then lowest compute_cap, then fanout/price.
+        result = api.search_offers(filters)
+        offers = result.get("offers", [])
+        if not offers:
+            log("No matching offers found")
+            emit_outcome("no_offers", EXIT_NO_OFFERS, reason="no matching offers in VRAM/arch band")
+
+        required_total_mb = _required_floor(extra_filters, "gpu_total_ram")
+        required_per_gpu_mb = _required_floor(extra_filters, "gpu_ram")
+        offers.sort(key=make_offer_sort_key(
+            required_total_mb, required_per_gpu_mb, required_compute_cap))
+        candidate_offers = offers[:OFFER_CANDIDATE_POOL]
+        max_attempts = MAX_LAUNCH_ATTEMPTS
+
+        top = candidate_offers[0]
+        log(f"Selected offer {top['id']}: {top.get('gpu_name', '?')} x{top.get('num_gpus', '?')} "
+            f"(cc {top.get('compute_cap', 0)}, arch {top.get('cpu_arch', '?')}) "
+            f"@ ${top.get('dph_total', 0):.3f}/hr "
+            f"(vram: {top.get('gpu_total_ram', 0)/1024:.0f} GB, "
+            f"inet: {top.get('inet_down', 0):.0f}/{top.get('inet_up', 0):.0f} Mbps)")
+        if required_total_mb:
+            overshoot = (top.get("gpu_total_ram", 0) - required_total_mb) / required_total_mb * 100
+            ceiling = required_total_mb * VRAM_CEILING_MULTIPLIER / 1024
+            log(f"  Template floor: gpu_total_ram in [{required_total_mb/1024:.0f}, "
+                f"{ceiling:.0f}] GB (selected {top.get('gpu_total_ram', 0)/1024:.0f} GB, "
+                f"overshoot {overshoot:.0f}%, {len(candidate_offers)} candidates in retry pool)")
+        if required_compute_cap:
+            log(f"  Template floor: compute_cap >= {required_compute_cap:.0f} "
+                f"(selected {top.get('compute_cap', 0)})")
+
+        if args.dry_run:
+            return
+
+    # 4. Launch with retry — walk candidate_offers until one yields a running
+    # instance with adequate disk.  Each failed attempt is destroyed and its
+    # offer blacklisted.
+    def _payload_factory(offer):
+        payload = {
+            "client_id": "me",
+            "image": image_full,
+            "disk": disk,
+            "template_hash_id": args.template_hash,
+            "env": env,
+        }
+        # Stamp a label so the reaper can positively identify QA-owned instances
+        # and never touch a good non-test instance on the account.
+        if args.label:
+            payload["label"] = args.label
+        return payload
+
+    def _track_instance(new_id):
+        ctx.instance_id = new_id
+
+    launch = launch_with_retry(api, candidate_offers, _payload_factory, disk,
+                               max_attempts, _track_instance, log,
+                               server_probe_timeout=server_probe_timeout)
+    if launch is None:
+        log("Could not launch a usable instance on any candidate offer")
+        emit_outcome("bad_instance", EXIT_BAD_INSTANCE, reason="exhausted launch attempts")
+
+    instance_id, test_url, auth_token = launch
+
+    # 6. Monitor instance health in background.
+    # Detects if instance goes non-running, disappears, or enters a terminal state.
+    # Runs through the full lifecycle (streaming + post-test polling).
+    instance_dead = threading.Event()
+    _dead_lock = threading.Lock()
+    def _set_dead(reason):
+        with _dead_lock:
+            ctx.dead_reason = reason
+        instance_dead.set()
+
+    def _get_dead_reason():
+        with _dead_lock:
+            return ctx.dead_reason
+
+    monitor = threading.Thread(
+        target=monitor_instance_health,
+        args=(api, instance_id, instance_dead, _set_dead),
+        daemon=True,
+    )
+    monitor.start()
+
+    # Stream SSE results
+    # The server sends event types:
+    #   event: output  — raw test output lines (printed to stderr)
+    #   event: log     — system log lines, e.g. /var/log/portal (with --log)
+    #   event: result  — final JSON summary (used for exit code + --raw stdout)
+    stream_url = f"{test_url}/test-stream?log=1"
+    log(f"Streaming results from {stream_url} ...\n")
+    final_state = "failed"
+    final_result = None
+
+    # Split terminal: test output in top scroll region, logs in fixed bottom panel.
+    # Only activates when --log is used and stderr is a TTY.
+    panel = LogPanel(enabled=bool(args.log))
+    ctx.panel = panel
+
+    # Track per-test outcomes from the output stream — the runner prints
+    # "─── Running: base/XX-name ───" before each test and
+    # "→ PASSED", "→ FAILED", "→ SKIPPED" after each test.
+    # This is more reliable than the JSON file (which has write-race issues).
+    # COUPLING: uses Unicode chars ─ (U+2500) and → (U+2192) from runner.sh
+    # output format.  Update both sides if the format ever changes.
+    stream_counts = {"passed": 0, "failed": 0, "skipped": 0}
+    stream_tests = []  # list of {"name": ..., "state": ...}
+    current_test_name = None
+
+    got_result_event = False
+    for event in stream_sse(stream_url, timeout=args.timeout, token=auth_token):
+        # Check if instance died unexpectedly
+        if instance_dead.is_set():
+            panel.cleanup()
+            log(f"\nInstance {instance_id} went to '{_get_dead_reason()}' during testing")
+            final_state = "error"
+            break
+
+        if event.get("_timeout"):
+            panel.cleanup()
+            log("\nTest timeout reached")
+            break
+        if event.get("_error"):
+            panel.cleanup()
+            # Check if the SSE error is because the instance died
+            if instance_dead.is_set():
+                log(f"\nInstance {instance_id} went to '{_get_dead_reason()}' during testing")
+            else:
+                log(f"\nSSE error: {event['_error']}")
+            final_state = "error"
+            break
+
+        if event.get("_event") == "output":
+            line = event.get("_data", "")
+            panel.write_output(line)
+            stripped = line.strip()
+            # Track current test name from runner's "── Running: base/XX ──" header
+            if stripped.startswith("\u2500\u2500\u2500 Running:") and stripped.endswith("\u2500\u2500\u2500"):
+                current_test_name = stripped.split("Running:")[1].strip().rstrip(" \u2500")
+            elif stripped.startswith("\u2192"):
+                state = None
+                if "PASSED" in stripped:
+                    state = "passed"
+                    stream_counts["passed"] += 1
+                elif "FAILED" in stripped:
+                    state = "failed"
+                    stream_counts["failed"] += 1
+                elif "SKIPPED" in stripped:
+                    state = "skipped"
+                    stream_counts["skipped"] += 1
+                if state and current_test_name:
+                    stream_tests.append({"name": current_test_name, "state": state})
+                    current_test_name = None
+        elif event.get("_event") == "log":
+            # Log events: {"src": "portal", "line": "..."} or plain string (compat)
+            if "line" in event:
+                panel.write_log(event["line"], src=event.get("src", ""),
+                               overwrite=event.get("overwrite", False))
+            else:
+                panel.write_log(event.get("_data", ""))
+        elif event.get("_event") == "result":
+            got_result_event = True
+            final_result = event
+            final_state = event.get("state", "failed")
+            break
+
+    panel.cleanup()
+    # Don't stop monitor yet — we still need instance-death detection during
+    # the post-test /test-status polling phase.
+
+    # Fetch elapsed time and authoritative overall state from /test-status.
+    # Don't overwrite final_result — the JSON's per-test states have a write
+    # race and often show "running"; stream-tracked data is authoritative.
+    elapsed = None
+    if not got_result_event:
+        time.sleep(2)  # give runner time to write final state
+    for attempt in range(10):
+        if instance_dead.is_set():
+            reason = _get_dead_reason() or "unknown"
+            log(f"Instance {instance_id} went to '{reason}' during post-test polling")
+            final_state = "error"
+            break
+        try:
+            status = VastAPI.get_status(test_url, token=auth_token)
+            if status.get("state") in ("passed", "failed"):
+                final_state = status["state"]
+                elapsed = status.get("elapsed_s")
+                if final_result is None:
+                    final_result = status
+                break
+        except Exception:
+            pass
+        time.sleep(2)
+
+    instance_dead.set()  # stop the monitor thread
+
+    if final_result and elapsed is None:
+        elapsed = final_result.get("elapsed_s")
+
+    # Build authoritative per-test results from stream data.
+    # Patch into final_result so --raw JSON has correct per-test states.
+    if stream_tests:
+        stream_test_map = {t["name"]: t["state"] for t in stream_tests}
+        if final_result and "tests" in final_result:
+            for t in final_result["tests"]:
+                if t["name"] in stream_test_map:
+                    t["state"] = stream_test_map[t["name"]]
+        else:
+            if final_result is None:
+                final_result = {"state": final_state}
+            final_result["tests"] = stream_tests
+
+    failed_names = [t["name"] for t in stream_tests if t["state"] == "failed"]
+    log(f"\n{format_summary(final_state, stream_counts, elapsed, failed_names)}")
+
+    # The verdict CI acts on: passed only counts as a FULL pass if the runner
+    # actually delivered a result event; a "passed" with got_result_event False
+    # means we inferred state from a post-test poll and should be treated with
+    # suspicion (ADR 0005 condition 2 — auto-promote requires both).
+    exit_state, exit_code = classify_outcome(final_state)
+
+    # --raw: emit clean JSON to stdout for programmatic consumers
+    if args.raw:
+        raw_output = final_result or {"state": final_state, "tests": []}
+        raw_output.pop("_event", None)
+        raw_output["state"] = exit_state
+        raw_output["got_result_event"] = got_result_event
+        raw_output["exit_code"] = exit_code
+        raw_output["stream_counts"] = stream_counts
+        print(json.dumps(raw_output))
+
+    # 7. Cleanup — destroy if instance died or connection was lost
+    if _get_dead_reason() or final_state == "error":
+        cleanup(destroy=True)
+    else:
+        cleanup()
+        if args.keep and instance_id:
+            log(f"Instance {instance_id} still running — "
+                f"'vastai stop instance {instance_id}' when done")
+        elif not args.destroy and instance_id:
+            log(f"Tip: 'vastai start instance {instance_id}' to restart for interactive testing")
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/template_manager/test_template.py
+++ b/tools/template_manager/test_template.py
@@ -639,6 +639,24 @@ def _required_floor(extra_filters, key):
         return None
 
 
+def _coerce_extra_filters(raw):
+    """Coerce a template's ``extra_filters`` (JSON string or dict) to a dict.
+
+    ``extra_filters`` is template-controlled input that reaches us from the Vast
+    API, so a malformed publish can make it a non-JSON string or a non-object.
+    Raise ``ValueError``/``JSONDecodeError`` here so the caller can map it to a
+    clean ``config_error`` verdict instead of crashing with a raw traceback.
+    """
+    if isinstance(raw, str):
+        parsed = json.loads(raw) if raw else {}
+    else:
+        parsed = raw or {}
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"extra_filters must be an object, got {type(parsed).__name__}")
+    return parsed
+
+
 def _base_offer_score(o):
     """Legacy inet/price score; used as the final tie-breaker in sort key."""
     inet = o.get("inet_down", 0) + o.get("inet_up", 0)
@@ -1048,11 +1066,11 @@ def main():
     is_serverless = ("SERVERLESS=true" in template_env
                      or "SERVERLESS=true" in template_onstart)
 
-    extra_filters_raw = template.get("extra_filters", "{}")
-    if isinstance(extra_filters_raw, str):
-        extra_filters = json.loads(extra_filters_raw) if extra_filters_raw else {}
-    else:
-        extra_filters = extra_filters_raw or {}
+    try:
+        extra_filters = _coerce_extra_filters(template.get("extra_filters", "{}"))
+    except (json.JSONDecodeError, ValueError) as e:
+        emit_outcome("config_error", EXIT_CONFIG_ERROR,
+                     reason=f"malformed extra_filters: {e}")
 
     disk = args.disk or template.get("recommended_disk_space") or 40
 

--- a/tools/template_manager/tests/conftest.py
+++ b/tools/template_manager/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Put the flat tool modules (models/template_manager/create) on sys.path.
+
+Run: cd tools/template_manager && PYTHONPATH=. python -m pytest -q
+(requires the dev deps from requirements.txt: pydantic, httpx, pyyaml, python-dotenv)
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tools/template_manager/tests/conftest.py
+++ b/tools/template_manager/tests/conftest.py
@@ -1,7 +1,7 @@
 """Put the flat tool modules (models/template_manager/create) on sys.path.
 
 Run: cd tools/template_manager && PYTHONPATH=. python -m pytest -q
-(requires the dev deps from requirements.txt: pydantic, httpx, pyyaml, python-dotenv)
+(requires the dev deps from requirements.txt: pydantic, pyyaml, python-dotenv)
 """
 import sys
 from pathlib import Path

--- a/tools/template_manager/tests/test_create.py
+++ b/tools/template_manager/tests/test_create.py
@@ -99,3 +99,12 @@ def test_stamp_only_readme_does_not_accumulate(tmp_path):
     p = _readme(tmp_path, "updated 2020-01-01 00:00")
     out = inject_readme(VastTemplate(name="t"), p, "t")
     assert len(re.findall(r"updated \d{4}-\d{2}-\d{2} \d{2}:\d{2}", out.readme)) == 1
+
+
+def test_stamp_only_readme_has_no_leading_newline(tmp_path):
+    # When the body empties after stripping the old stamp, the fresh stamp must
+    # not be prefixed with a blank line.
+    p = _readme(tmp_path, "updated 2020-01-01 00:00")
+    out = inject_readme(VastTemplate(name="t"), p, "t")
+    assert not out.readme.startswith("\n")
+    assert out.readme.startswith("updated ")

--- a/tools/template_manager/tests/test_create.py
+++ b/tools/template_manager/tests/test_create.py
@@ -1,0 +1,101 @@
+"""create.py: inject_readme, the --image/--tag override, and single-file mode."""
+import re
+
+import create
+from create import inject_readme, process_template_dir, process_single_file
+from models import VastTemplate
+
+
+class _RecordingManager:
+    """Minimal stand-in: records the templates handed to create_or_preview.
+
+    In dry-run, process_* only calls create_or_preview (the referral/get_user_id
+    path is skipped), so this is all that's needed to assert on the result.
+    """
+    def __init__(self):
+        self.created = []
+
+    def create_or_preview(self, template, dry_run=False):
+        self.created.append(template)
+        return None
+
+
+def _readme(tmp_path, text):
+    p = tmp_path / "README.md"
+    p.write_text(text)
+    return p
+
+
+def test_image_tag_override_reflected_in_payload():
+    # The CI override mutates a pydantic extra="forbid" model; assignment must
+    # work and to_api_dict must reflect the new image/tag.
+    t = VastTemplate(name="t", image="orig", tag="t1")
+    t.image, t.tag = "staging-ns/comfy", "ref-cuda-12.9-py312-amd64"
+    d = t.to_api_dict()
+    assert d["image"] == "staging-ns/comfy"
+    assert d["tag"] == "ref-cuda-12.9-py312-amd64"
+
+
+def test_override_applied_through_process_template_dir(tmp_path):
+    d = tmp_path / "tpl"
+    d.mkdir()
+    (d / "template.yml").write_text("name: T\nimage: orig\ntag: t1\n")
+    mgr = _RecordingManager()
+    process_template_dir(d, mgr, dry_run=True,
+                         image_override="newimg", tag_override="newtag")
+    assert mgr.created[0].image == "newimg"
+    assert mgr.created[0].tag == "newtag"
+
+
+def test_single_file_mode_does_not_inject_sibling_readme(tmp_path):
+    (tmp_path / "my.yml").write_text("name: T\nimage: i\n")
+    (tmp_path / "README.md").write_text("sibling readme that must NOT be used")
+    mgr = _RecordingManager()
+    results = process_single_file(tmp_path / "my.yml", mgr, dry_run=True)
+    assert mgr.created[0].readme is None        # __no_readme__ sentinel honored
+    assert "dir" not in results[0]              # single-file mode strips the dir key
+
+
+def test_missing_readme_leaves_template_unchanged(tmp_path):
+    t = VastTemplate(name="t")
+    out = inject_readme(t, tmp_path / "nope.md", "t")
+    assert out.readme is None
+
+
+def test_dry_run_uses_placeholder(tmp_path):
+    p = _readme(tmp_path, "launch: <<LAUNCH_LINK>>")
+    out = inject_readme(VastTemplate(name="t"), p, "t", dry_run=True)
+    assert "[LAUNCH_LINK_PLACEHOLDER]" in out.readme
+    assert "<<LAUNCH_LINK>>" not in out.readme
+
+
+def test_live_substitutes_referral_url(tmp_path):
+    p = _readme(tmp_path, "launch: <<LAUNCH_LINK>>")
+    out = inject_readme(VastTemplate(name="t"), p, "t", referral_url="https://x/y")
+    assert "https://x/y" in out.readme
+
+
+def test_template_name_substituted(tmp_path):
+    p = _readme(tmp_path, "Welcome to <<TEMPLATE_NAME>>")
+    out = inject_readme(VastTemplate(name="t"), p, "My Image")
+    assert "Welcome to My Image" in out.readme
+
+
+def test_appends_single_updated_stamp(tmp_path):
+    p = _readme(tmp_path, "body")
+    out = inject_readme(VastTemplate(name="t"), p, "t")
+    assert len(re.findall(r"updated \d{4}-\d{2}-\d{2} \d{2}:\d{2}", out.readme)) == 1
+
+
+def test_existing_stamp_is_replaced_not_duplicated(tmp_path):
+    p = _readme(tmp_path, "body\nupdated 2020-01-01 00:00")
+    out = inject_readme(VastTemplate(name="t"), p, "t")
+    assert len(re.findall(r"updated \d{4}-\d{2}-\d{2} \d{2}:\d{2}", out.readme)) == 1
+    assert "2020-01-01 00:00" not in out.readme
+
+
+def test_stamp_only_readme_does_not_accumulate(tmp_path):
+    # A README that is *only* an updated-line must not gain a second stamp.
+    p = _readme(tmp_path, "updated 2020-01-01 00:00")
+    out = inject_readme(VastTemplate(name="t"), p, "t")
+    assert len(re.findall(r"updated \d{4}-\d{2}-\d{2} \d{2}:\d{2}", out.readme)) == 1

--- a/tools/template_manager/tests/test_models.py
+++ b/tools/template_manager/tests/test_models.py
@@ -1,0 +1,45 @@
+"""VastTemplate: payload shaping, extra_filters parsing, strict-key rejection."""
+import pytest
+from pydantic import ValidationError
+
+from models import VastTemplate
+
+
+def test_to_api_dict_drops_load_only_ports():
+    t = VastTemplate(name="t", ports=["1111:1111"], env="-p 1111:1111")
+    d = t.to_api_dict()
+    assert "ports" not in d          # load-only, already folded into env
+    assert d["env"] == "-p 1111:1111"
+    assert d["name"] == "t"
+
+
+def test_to_api_dict_omits_vm_and_autoscaler_when_unset():
+    d = VastTemplate(name="t").to_api_dict()
+    assert "vm" not in d
+    assert "autoscaler" not in d
+
+
+def test_to_api_dict_includes_vm_when_explicitly_set():
+    d = VastTemplate(name="t", vm=True).to_api_dict()
+    assert d["vm"] is True
+
+
+def test_extra_filters_json_string_is_parsed_to_dict():
+    t = VastTemplate(name="t", extra_filters='{"gpu_ram": ">=24"}')
+    assert t.extra_filters == {"gpu_ram": ">=24"}
+
+
+def test_extra_filters_dict_passes_through():
+    t = VastTemplate(name="t", extra_filters={"gpu_ram": ">=24"})
+    assert t.extra_filters == {"gpu_ram": ">=24"}
+
+
+def test_extra_filters_malformed_json_left_as_string():
+    t = VastTemplate(name="t", extra_filters="{not json")
+    assert t.extra_filters == "{not json"
+
+
+def test_unknown_key_is_rejected():
+    # extra="forbid": a typo'd or attacker-supplied field must not reach the API.
+    with pytest.raises(ValidationError):
+        VastTemplate(name="t", definitely_not_a_field=1)

--- a/tools/template_manager/tests/test_offer_select.py
+++ b/tools/template_manager/tests/test_offer_select.py
@@ -1,5 +1,6 @@
 """Offer selection (ADR 0005): VRAM-primary, compute_cap floor, bounded search."""
-from test_template import _required_floor, make_offer_sort_key, apply_vram_ceiling
+from test_template import (VRAM_CEILING_MULTIPLIER, _required_floor,
+                           apply_vram_ceiling, make_offer_sort_key)
 
 
 def _o(cc=800, total_mb=24576, per_gpu_mb=24576, num_gpus=1, dph=0.5):
@@ -68,3 +69,17 @@ def test_vram_ceiling_does_not_mutate_input():
     f = {"gpu_total_ram": {"gte": 12288}}
     apply_vram_ceiling(f, 2.0)
     assert f == {"gpu_total_ram": {"gte": 12288}}  # original unchanged
+
+
+def test_production_multiplier_admits_consumer_tier_excludes_datacenter():
+    # The cost guardrail (now the price filter is gone): with the shipped
+    # multiplier, an 8 GB floor must reach the abundant 24 GB consumer tier
+    # (RTX 3090/4090) to keep the market from going thin, but must NOT reach the
+    # 32 GB+ datacenter cards (V100-32 / A100 / H100). If someone widens the
+    # multiplier into datacenter range, this fails.
+    floor_mb = 8192
+    ceiling_mb = apply_vram_ceiling(
+        {"gpu_total_ram": {"gte": floor_mb}}, VRAM_CEILING_MULTIPLIER
+    )["gpu_total_ram"]["lte"]
+    assert ceiling_mb >= 24576       # includes a 24 GB 4090
+    assert ceiling_mb < 32768        # excludes a 32 GB datacenter card

--- a/tools/template_manager/tests/test_offer_select.py
+++ b/tools/template_manager/tests/test_offer_select.py
@@ -1,6 +1,11 @@
 """Offer selection (ADR 0005): VRAM-primary, compute_cap floor, bounded search."""
-from test_template import (VRAM_CEILING_MULTIPLIER, _required_floor,
-                           apply_vram_ceiling, make_offer_sort_key)
+import json
+
+import pytest
+
+from test_template import (VRAM_CEILING_MULTIPLIER, _coerce_extra_filters,
+                           _required_floor, apply_vram_ceiling,
+                           make_offer_sort_key)
 
 
 def _o(cc=800, total_mb=24576, per_gpu_mb=24576, num_gpus=1, dph=0.5):
@@ -83,3 +88,32 @@ def test_production_multiplier_admits_consumer_tier_excludes_datacenter():
     )["gpu_total_ram"]["lte"]
     assert ceiling_mb >= 24576       # includes a 24 GB 4090
     assert ceiling_mb < 32768        # excludes a 32 GB datacenter card
+
+
+# --- _coerce_extra_filters: template-controlled input must fail cleanly --------
+
+def test_coerce_extra_filters_dict_passthrough():
+    assert _coerce_extra_filters({"compute_cap": {"gte": 800}}) == {"compute_cap": {"gte": 800}}
+
+
+def test_coerce_extra_filters_json_string():
+    assert _coerce_extra_filters('{"gpu_total_ram": {"gte": 8192}}') == {"gpu_total_ram": {"gte": 8192}}
+
+
+def test_coerce_extra_filters_empty_forms():
+    assert _coerce_extra_filters("") == {}
+    assert _coerce_extra_filters(None) == {}
+    assert _coerce_extra_filters("{}") == {}
+
+
+def test_coerce_extra_filters_malformed_json_raises():
+    with pytest.raises(json.JSONDecodeError):
+        _coerce_extra_filters("{not json")
+
+
+def test_coerce_extra_filters_non_object_raises():
+    # valid JSON, but not an object — would crash _required_floor() downstream
+    with pytest.raises(ValueError):
+        _coerce_extra_filters("[1, 2, 3]")
+    with pytest.raises(ValueError):
+        _coerce_extra_filters("42")

--- a/tools/template_manager/tests/test_offer_select.py
+++ b/tools/template_manager/tests/test_offer_select.py
@@ -1,0 +1,70 @@
+"""Offer selection (ADR 0005): VRAM-primary, compute_cap floor, bounded search."""
+from test_template import _required_floor, make_offer_sort_key, apply_vram_ceiling
+
+
+def _o(cc=800, total_mb=24576, per_gpu_mb=24576, num_gpus=1, dph=0.5):
+    return {"compute_cap": cc, "gpu_total_ram": total_mb, "gpu_ram": per_gpu_mb,
+            "num_gpus": num_gpus, "dph_total": dph, "inet_down": 1000, "inet_up": 1000}
+
+
+def _pick(offers, *, cap=None, total=None, per_gpu=None):
+    return sorted(offers, key=make_offer_sort_key(total, per_gpu, cap))
+
+
+def test_required_floor_shapes():
+    assert _required_floor({"compute_cap": {"gte": 700}}, "compute_cap") == 700.0
+    assert _required_floor({"compute_cap": {"gt": 800}}, "compute_cap") == 800.0
+    assert _required_floor({"compute_cap": {"eq": 900}}, "compute_cap") == 900.0
+    assert _required_floor({"compute_cap": 750}, "compute_cap") == 750.0
+    assert _required_floor({}, "compute_cap") is None
+
+
+def test_smallest_vram_above_floor_wins():
+    offers = [_o(total_mb=80000), _o(total_mb=16000), _o(total_mb=24000)]
+    assert _pick(offers, total=8192)[0]["gpu_total_ram"] == 16000
+
+
+def test_below_vram_floor_sinks():
+    too_small = _o(total_mb=4096)   # below an 8GB floor
+    ok = _o(total_mb=16000)
+    assert _pick([too_small, ok], total=8192)[0] is ok
+
+
+def test_vram_dominates_compute_cap():
+    # VRAM is primary: a small high-cc box beats a large low-cc box.
+    small_high = _o(cc=890, total_mb=16000)
+    big_low = _o(cc=800, total_mb=80000)
+    assert _pick([big_low, small_high], cap=700, total=8192)[0] is small_high
+
+
+def test_compute_cap_breaks_vram_ties():
+    # Within one VRAM size, prefer the lowest compute_cap above the floor.
+    a = _o(cc=900, total_mb=24000)
+    b = _o(cc=800, total_mb=24000)
+    assert _pick([a, b], cap=700, total=8192)[0] is b
+
+
+def test_below_compute_floor_sinks_to_end():
+    below = _o(cc=600, total_mb=16000)   # below a 700 cc floor
+    ok = _o(cc=890, total_mb=16000)
+    assert _pick([below, ok], cap=700, total=8192)[0] is ok
+
+
+def test_vram_ceiling_adds_lte_when_only_gte():
+    out = apply_vram_ceiling({"gpu_total_ram": {"gte": 12288}}, 2.0)
+    assert out["gpu_total_ram"] == {"gte": 12288, "lte": 24576.0}
+
+
+def test_vram_ceiling_respects_explicit_lte():
+    f = {"gpu_total_ram": {"gte": 12288, "lte": 16384}}
+    assert apply_vram_ceiling(f, 2.0) == f
+
+
+def test_vram_ceiling_noop_without_floor():
+    assert apply_vram_ceiling({"verified": {"eq": True}}, 2.0) == {"verified": {"eq": True}}
+
+
+def test_vram_ceiling_does_not_mutate_input():
+    f = {"gpu_total_ram": {"gte": 12288}}
+    apply_vram_ceiling(f, 2.0)
+    assert f == {"gpu_total_ram": {"gte": 12288}}  # original unchanged

--- a/tools/template_manager/tests/test_qa_gate_floor_guard.py
+++ b/tools/template_manager/tests/test_qa_gate_floor_guard.py
@@ -1,0 +1,45 @@
+"""Guard: the QA gate's compute_cap-floor enforcement must stay enabled by default.
+
+CON-1585 split the live-GPU QA gate (this tool) from the invariant linter into a
+separate PR that can land first. That makes the gate's *runtime* ``--require-floor``
+the sole pre-merge guard that a QA template declares a usable ``compute_cap`` floor
+(linter rule L050 is the earlier *static* catch and may merge later). If
+``qa-gate.yml``'s ``require_floor`` default were silently flipped to false, or the
+``--require-floor`` wiring removed, the gate could rent an unbounded/expensive box
+against a floor-less template. Lock both down. (Surfaced by a critical review of the decouple; ADR 0005.)
+"""
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[3]
+QA_GATE = REPO / ".github" / "workflows" / "qa-gate.yml"
+
+
+def _workflow_call_inputs():
+    data = yaml.safe_load(QA_GATE.read_text())
+    # YAML 1.1 resolves a bare ``on:`` key to the boolean True.
+    on = data.get("on", data.get(True))
+    return on["workflow_call"]["inputs"]
+
+
+def test_qa_gate_yml_present():
+    assert QA_GATE.is_file(), f"missing {QA_GATE}"
+
+
+def test_require_floor_defaults_true():
+    spec = _workflow_call_inputs()["require_floor"]
+    assert spec.get("default") is True, (
+        "qa-gate.yml require_floor default must stay true — it is the sole "
+        "pre-merge compute_cap-floor guard when the QA gate ships ahead of the linter"
+    )
+
+
+def test_require_floor_is_wired_to_the_cli():
+    # A true default is inert if the arg is never passed: the test step must add
+    # --require-floor when inputs.require_floor is true.
+    text = QA_GATE.read_text()
+    assert "--require-floor" in text, "qa-gate.yml no longer passes --require-floor"
+    assert "inputs.require_floor" in text, (
+        "qa-gate.yml --require-floor is not keyed on the require_floor input"
+    )

--- a/tools/template_manager/tests/test_qa_reaper.py
+++ b/tools/template_manager/tests/test_qa_reaper.py
@@ -6,6 +6,8 @@ other tested module here: prove it (a) reaps a labeled, over-age orphan and
 (b) refuses anything outside scope or under age. The threshold tests pin it above
 test_template.py's healthy-run budget so a sweep can never clip a live instance.
 """
+import urllib.error
+
 import reap_orphans
 import test_template
 
@@ -121,6 +123,43 @@ def test_old_out_of_scope_empty_when_all_young_or_in_scope():
         inst(id=2, label="prod", uptime=10.0),             # out of scope but young
     ]
     assert reap_orphans.old_out_of_scope(instances, 260.0, "base-image-qa", None) == []
+
+
+# --- destroy classification (404 = already gone, not a leak) --------------
+
+def _http_error(code):
+    return urllib.error.HTTPError("https://x", code, "err", {}, None)
+
+
+def test_destroy_success_is_reaped(monkeypatch):
+    monkeypatch.setattr(reap_orphans, "_request", lambda *a, **k: {})
+    assert reap_orphans.destroy_instance(1, "key") == ("reaped", None)
+
+
+def test_destroy_404_is_gone_not_failure(monkeypatch):
+    # Already destroyed (concurrent --destroy / prior pass / spot reclaim) is the
+    # goal state — it must not be counted as a leak or it cries wolf.
+    def boom(*a, **k):
+        raise _http_error(404)
+    monkeypatch.setattr(reap_orphans, "_request", boom)
+    status, detail = reap_orphans.destroy_instance(1, "key")
+    assert status == "gone"
+
+
+def test_destroy_5xx_is_failure(monkeypatch):
+    def boom(*a, **k):
+        raise _http_error(500)
+    monkeypatch.setattr(reap_orphans, "_request", boom)
+    status, detail = reap_orphans.destroy_instance(1, "key")
+    assert status == "failed"
+    assert detail
+
+
+def test_destroy_transport_error_is_failure(monkeypatch):
+    def boom(*a, **k):
+        raise urllib.error.URLError("connection reset")
+    monkeypatch.setattr(reap_orphans, "_request", boom)
+    assert reap_orphans.destroy_instance(1, "key")[0] == "failed"
 
 
 # --- threshold drift guard ------------------------------------------------

--- a/tools/template_manager/tests/test_qa_reaper.py
+++ b/tools/template_manager/tests/test_qa_reaper.py
@@ -1,0 +1,147 @@
+"""Reaper scope/threshold logic — the cost-safety backstop (ADR 0005 cond 1).
+
+The reaper is the one thing between a hard-killed runner and an indefinitely
+billing GPU, so its selection predicate carries the same test burden as every
+other tested module here: prove it (a) reaps a labeled, over-age orphan and
+(b) refuses anything outside scope or under age. The threshold tests pin it above
+test_template.py's healthy-run budget so a sweep can never clip a live instance.
+"""
+import reap_orphans
+import test_template
+
+
+def inst(id=1, label="base-image-qa-comfyui", image="stagingns/comfyui:qa",
+         uptime=300.0, status="running"):
+    """A Vast instance record with the fields the reaper reads."""
+    return {"id": id, "label": label, "image_uuid": image,
+            "uptime_mins": uptime, "actual_status": status, "gpu_name": "RTX 4090"}
+
+
+# --- scope predicate -------------------------------------------------------
+
+def test_in_scope_label_prefix_matches():
+    assert reap_orphans.in_scope(inst(label="base-image-qa-x"), "base-image-qa", None)
+
+
+def test_in_scope_label_mismatch_excluded():
+    # A non-QA instance carries no QA label — it must never be in scope.
+    assert not reap_orphans.in_scope(inst(label="prod-inference"), "base-image-qa", None)
+
+
+def test_in_scope_missing_label_excluded():
+    assert not reap_orphans.in_scope(inst(label=None), "base-image-qa", None)
+
+
+def test_in_scope_image_prefix_is_anded():
+    # label matches but image prefix does not -> excluded (AND, not OR).
+    i = inst(label="base-image-qa-x", image="other/comfyui:qa")
+    assert not reap_orphans.in_scope(i, "base-image-qa", "stagingns/")
+
+
+def test_in_scope_falls_back_to_image_field():
+    # Vast may return the image under 'image' rather than 'image_uuid'.
+    i = {"label": "base-image-qa", "image": "stagingns/comfyui:qa"}
+    assert reap_orphans.in_scope(i, "base-image-qa", "stagingns/")
+
+
+def test_in_scope_no_filters_matches_everything():
+    # Both filters None = the --allow-no-scope age-only mode.
+    assert reap_orphans.in_scope(inst(label=None, image=""), None, None)
+
+
+# --- reapability: age AND scope -------------------------------------------
+
+def test_labeled_over_age_orphan_is_reaped():
+    # (a) the thing the reaper exists to catch.
+    i = inst(label="base-image-qa-comfyui", uptime=400.0)
+    assert reap_orphans.is_reapable(i, 260.0, "base-image-qa", None)
+
+
+def test_unlabeled_over_age_instance_is_refused():
+    # (b) an old non-QA instance must survive even though it is over age.
+    i = inst(label="prod-training", uptime=9999.0)
+    assert not reap_orphans.is_reapable(i, 260.0, "base-image-qa", None)
+
+
+def test_out_of_prefix_over_age_instance_is_refused():
+    i = inst(label="base-image-qa-x", image="other/x:qa", uptime=9999.0)
+    assert not reap_orphans.is_reapable(i, 260.0, "base-image-qa", "stagingns/")
+
+
+def test_in_scope_under_age_instance_is_refused():
+    # A live QA run that is younger than the threshold must not be reaped.
+    i = inst(label="base-image-qa-comfyui", uptime=120.0)
+    assert not reap_orphans.is_reapable(i, 260.0, "base-image-qa", None)
+
+
+def test_age_threshold_is_strict():
+    # Exactly at the threshold is kept; strictly over is reaped.
+    at = inst(uptime=260.0)
+    over = inst(uptime=260.1)
+    assert not reap_orphans.is_reapable(at, 260.0, "base-image-qa", None)
+    assert reap_orphans.is_reapable(over, 260.0, "base-image-qa", None)
+
+
+def test_malformed_uptime_keeps_instance():
+    # _age_min coerces None/missing/garbage to 0 -> never reapable. Fail safe:
+    # a malformed record must not be destroyed on a guessed age.
+    for bad in (None, "abc", {}):
+        i = inst(uptime=bad)
+        assert not reap_orphans.is_reapable(i, 260.0, "base-image-qa", None)
+
+
+def test_select_candidates_filters_mixed_set():
+    instances = [
+        inst(id=1, label="base-image-qa-comfyui", uptime=400.0),   # reap
+        inst(id=2, label="prod", uptime=400.0),                    # keep (scope)
+        inst(id=3, label="base-image-qa-vllm", uptime=10.0),       # keep (age)
+        inst(id=4, label="base-image-qa-vllm", uptime=999.0),      # reap
+    ]
+    got = {i["id"] for i in reap_orphans.select_candidates(
+        instances, 260.0, "base-image-qa", None)}
+    assert got == {1, 4}
+
+
+# --- silent under-reaping canary ------------------------------------------
+
+def test_old_out_of_scope_flags_unmatched_orphan():
+    # An over-age instance excluded only by scope (e.g. label failed to round-trip)
+    # is the signature of silent under-reaping — it must be surfaced.
+    instances = [
+        inst(id=1, label="base-image-qa", uptime=400.0),   # in scope, reaped normally
+        inst(id=2, label=None, uptime=400.0),              # over-age but unlabeled
+    ]
+    flagged = reap_orphans.old_out_of_scope(instances, 260.0, "base-image-qa", None)
+    assert [i["id"] for i in flagged] == [2]
+
+
+def test_old_out_of_scope_empty_when_all_young_or_in_scope():
+    instances = [
+        inst(id=1, label="base-image-qa", uptime=400.0),   # in scope
+        inst(id=2, label="prod", uptime=10.0),             # out of scope but young
+    ]
+    assert reap_orphans.old_out_of_scope(instances, 260.0, "base-image-qa", None) == []
+
+
+# --- threshold drift guard ------------------------------------------------
+
+def test_healthy_phase_constant_mirrors_test_template_budget():
+    # reap_orphans mirrors test_template's auto-lifted --timeout. If that budget
+    # changes (someone bumps PROV_TIMEOUT etc.), this fails so the mirror is kept
+    # in step rather than silently drifting below the real run lifetime.
+    envs = test_template.INSTANCE_TIMEOUT_ENVS
+    prov = envs["PROV_TIMEOUT"]
+    derivative = max(envs["VLLM_HEALTH_TIMEOUT"], envs["INSTANCE_TEST_DEFAULT_TIMEOUT"])
+    budget = prov + derivative + test_template.TIMEOUT_HEADROOM
+    assert reap_orphans._HEALTHY_TEST_PHASE_SEC == budget
+
+
+def test_default_threshold_stays_above_test_template_budget():
+    # The reaper must never undercut a healthy run + a safety margin, or it deletes
+    # a live instance mid-test (false BLOCK + wasted spend).
+    envs = test_template.INSTANCE_TIMEOUT_ENVS
+    prov = envs["PROV_TIMEOUT"]
+    derivative = max(envs["VLLM_HEALTH_TIMEOUT"], envs["INSTANCE_TEST_DEFAULT_TIMEOUT"])
+    budget_sec = prov + derivative + test_template.TIMEOUT_HEADROOM
+    safety_margin_sec = 3600   # 60 min over the healthy ceiling, minimum
+    assert reap_orphans.DEFAULT_MAX_AGE_MIN * 60 >= budget_sec + safety_margin_sec

--- a/tools/template_manager/tests/test_template_manager.py
+++ b/tools/template_manager/tests/test_template_manager.py
@@ -1,0 +1,68 @@
+"""Env-string building and YAML loading (the ports/env normalization)."""
+import pytest
+
+from template_manager import TemplateManager
+
+build = TemplateManager.build_env_string_from_lists
+
+
+def test_build_env_ports_and_dict():
+    assert build(ports=["1111:1111"], env_vars={"A": "b"}) == '-p 1111:1111 -e A="b"'
+
+
+def test_build_env_list_form():
+    assert build(env_vars=["A=b", "C=d"]) == '-e A="b" -e C="d"'
+
+
+def test_build_env_ports_only():
+    assert build(ports=["8080:8080", "5000:5000"]) == "-p 8080:8080 -p 5000:5000"
+
+
+def test_build_env_empty():
+    assert build() == ""
+
+
+def test_build_env_escapes_quotes_in_value():
+    assert build(env_vars={"A": 'x"y'}) == '-e A="x\\"y"'
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "template.yml"
+    p.write_text(text)
+    return p
+
+
+def test_load_folds_ports_and_dict_env(tmp_path):
+    p = _write(tmp_path, 'name: t\nports:\n  - "1111:1111"\nenv:\n  A: b\n')
+    (t,) = TemplateManager.load_templates_from_yaml(p)
+    assert t.env == '-p 1111:1111 -e A="b"'
+
+
+def test_load_mixed_ports_list_and_env_string(tmp_path):
+    p = _write(tmp_path, 'name: t\nports:\n  - "1111:1111"\nenv: "-e A=b"\n')
+    (t,) = TemplateManager.load_templates_from_yaml(p)
+    assert t.env == "-p 1111:1111 -e A=b"
+
+
+def test_load_env_string_passthrough(tmp_path):
+    p = _write(tmp_path, 'name: t\nenv: "-e A=b -p 9:9"\n')
+    (t,) = TemplateManager.load_templates_from_yaml(p)
+    assert t.env == "-e A=b -p 9:9"
+
+
+def test_load_list_of_templates(tmp_path):
+    p = _write(tmp_path, "- name: a\n- name: b\n")
+    templates = TemplateManager.load_templates_from_yaml(p)
+    assert [t.name for t in templates] == ["a", "b"]
+
+
+def test_load_empty_yaml_raises(tmp_path):
+    p = _write(tmp_path, "")
+    with pytest.raises(ValueError):
+        TemplateManager.load_templates_from_yaml(p)
+
+
+def test_load_non_mapping_entry_raises(tmp_path):
+    p = _write(tmp_path, "- just a string\n")
+    with pytest.raises(ValueError):
+        TemplateManager.load_templates_from_yaml(p)

--- a/tools/template_manager/tests/test_template_manager.py
+++ b/tools/template_manager/tests/test_template_manager.py
@@ -1,7 +1,8 @@
 """Env-string building and YAML loading (the ports/env normalization)."""
 import pytest
 
-from template_manager import TemplateManager
+import template_manager
+from template_manager import TemplateManager, _redact_secrets
 
 build = TemplateManager.build_env_string_from_lists
 
@@ -77,3 +78,30 @@ def test_load_non_mapping_entry_raises(tmp_path):
     p = _write(tmp_path, "- just a string\n")
     with pytest.raises(ValueError):
         TemplateManager.load_templates_from_yaml(p)
+
+
+# --- _redact_secrets: must mask at any depth (matches the docstring claim) -----
+
+def test_redact_secrets_nested():
+    payload = {"top_token": "s", "plain": "keep",
+               "nested": {"api_key": "s", "ok": 1, "deep": [{"x_pass": "s"}]}}
+    out = _redact_secrets(payload)
+    assert out["top_token"] == "***redacted***"
+    assert out["plain"] == "keep"
+    assert out["nested"]["api_key"] == "***redacted***"
+    assert out["nested"]["ok"] == 1
+    assert out["nested"]["deep"][0]["x_pass"] == "***redacted***"
+    # input is not mutated (returns a copy)
+    assert payload["nested"]["api_key"] == "s"
+
+
+# --- _request_with_retry: the first attempt fires immediately, no backoff ------
+
+def test_request_with_retry_no_sleep_on_first_attempt(monkeypatch):
+    mgr = TemplateManager("k")
+    slept = []
+    monkeypatch.setattr(template_manager.time, "sleep", slept.append)
+    monkeypatch.setattr(mgr, "_open", lambda method, url, payload: {"ok": True})
+    out = mgr._request_with_retry("POST", "http://x", payload={}, label="t")
+    assert out == {"ok": True}
+    assert slept == []   # no unconditional per-request latency

--- a/tools/template_manager/tests/test_template_manager.py
+++ b/tools/template_manager/tests/test_template_manager.py
@@ -50,6 +50,17 @@ def test_load_env_string_passthrough(tmp_path):
     assert t.env == "-e A=b -p 9:9"
 
 
+@pytest.mark.parametrize("body", ["env: []\n", "env: {}\n"])
+def test_load_empty_list_or_dict_env_folds_to_empty_string(tmp_path, body):
+    # Regression: an empty `env: []`/`env: {}` is falsy, so the fold guard used to
+    # skip folding and assign the raw list/dict straight to entry['env'], which
+    # VastTemplate (env: Optional[str]) then rejected with a confusing
+    # ValidationError. Empty containers must fold to '' like any other shape.
+    p = _write(tmp_path, "name: t\n" + body)
+    (t,) = TemplateManager.load_templates_from_yaml(p)
+    assert t.env == ""
+
+
 def test_load_list_of_templates(tmp_path):
     p = _write(tmp_path, "- name: a\n- name: b\n")
     templates = TemplateManager.load_templates_from_yaml(p)

--- a/tools/template_manager/tests/test_verdict.py
+++ b/tools/template_manager/tests/test_verdict.py
@@ -1,0 +1,27 @@
+"""Verdict mapping (ADR 0005 condition 2): final_state -> (state, exit code)."""
+from test_template import (
+    classify_outcome, EXIT_PASSED, EXIT_FAILED, EXIT_INSTANCE_ERROR,
+)
+
+
+def test_passed():
+    assert classify_outcome("passed") == ("passed", EXIT_PASSED)
+
+
+def test_failed():
+    assert classify_outcome("failed") == ("failed", EXIT_FAILED)
+
+
+def test_error_is_instance_error_not_inconclusive():
+    # A crash mid-test must not be soft-passed as inconclusive.
+    assert classify_outcome("error") == ("instance_error", EXIT_INSTANCE_ERROR)
+
+
+def test_unexpected_state_is_instance_error():
+    assert classify_outcome("running") == ("instance_error", EXIT_INSTANCE_ERROR)
+    assert classify_outcome(None) == ("instance_error", EXIT_INSTANCE_ERROR)
+
+
+def test_exit_codes_are_distinct():
+    # The codes CI keys on must not collide.
+    assert len({EXIT_PASSED, EXIT_FAILED, EXIT_INSTANCE_ERROR}) == 3


### PR DESCRIPTION
CON-1591 — the live-GPU QA layer. **Independent of the linter PR (#206)** — the two are file-disjoint and can merge in either order (verified that both merge orders lint clean).

## What's in it

**Template publish + live-test tooling** — [ADR 0008](https://github.com/vast-ai/base-image/blob/75dbfec81a9afb02a413fb9b520ebafd918b32ff/docs/adr/0008-template-publish-tooling.md) — `tools/template_manager/`:
- `create.py` — create a Vast template from `<name>/{template.yml,README.md}`.
- `test_template.py` — launch a real GPU instance from a template, stream the in-instance test harness over SSE, then **destroy** it.
- Holds the Vast API key (`Authorization: Bearer`, redacted; `.env` gitignored); strict `extra="forbid"` models; stdlib `urllib`.

**Live-GPU QA gate** — [ADR 0005](https://github.com/vast-ai/base-image/blob/75dbfec81a9afb02a413fb9b520ebafd918b32ff/docs/adr/0005-live-gpu-qa-gate.md) — reusable `qa-gate.yml` on the `build → qa → merge-manifests` seam; promotion is **gated** on the verdict. Smallest-viable-box selection (amd64, VRAM-primary within a bounded band, respecting the template's `compute_cap` floor); machine-readable verdict with distinct exit codes.
- **Two proven consumers**, both green end-to-end on real GPUs: **ComfyUI** (generated an SD1.5 image) and **vLLM** (served a model + ran inference).
- **Label-scoped reaper** (`reap_orphans.py` + `qa-reaper.yml`) — backstop for a leaked paid instance.

## Relationship to #206 (soft, not blocking)
`L050` (in #206) is a *static, lint-time* catch that every shipped QA template declares a `compute_cap` floor. **This PR enforces the same floor at runtime itself**: `qa-gate.yml` defaults `require_floor: true`, and `test_template.py` refuses a floor-less template (`config_error`, before any GPU is rented). So the gate is self-sufficient — #206 only adds an earlier, cheaper static catch. A regression test here locks the runtime default in place. Recommend #206 still merges reasonably promptly so the static catch (and its cited ADR 0005) isn't dangling.

## Risk surface (review focus)
This is the half that holds a cloud key, spends real money, and auto-destroys instances. The close-look items: `reap_orphans.py` scope-gating (label `startswith` + `--max-reap` ceiling + fail-closed guard) and `test_template.py`'s rent/destroy lifecycle.