### PR TITLE
fix(templates): point marketplace launch links at the Template Team account (525202)

### DIFF
--- a/derivatives/linux-desktop/README.template.md
+++ b/derivatives/linux-desktop/README.template.md
@@ -1,5 +1,5 @@
 # Linux Desktop
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Linux%20Desktop)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Linux%20Desktop)**
 
 ## What is this template?
 
@@ -36,7 +36,7 @@ This is **perfect** if you:
 ## Quick Start Guide
 
 ### **Step 1: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Linux%20Desktop)"** when you've found an instance that works for you
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Linux%20Desktop)"** when you've found an instance that works for you
 
 ### **Step 2: Wait for Setup**
 The desktop environment will initialize automatically *(this takes a couple of minutes on first boot)*
@@ -195,7 +195,7 @@ This desktop runs inside a Docker container, which provides excellent performanc
 
 ### Need Full VM Capabilities?
 
-If your workflow requires features that don't work in a container, try the **[Ubuntu Desktop (VM)](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Ubuntu%20Desktop%20(VM))** template instead. The VM template provides a full virtual machine with complete isolation and no container restrictions.
+If your workflow requires features that don't work in a container, try the **[Ubuntu Desktop (VM)](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Ubuntu%20Desktop%20(VM))** template instead. The VM template provides a full virtual machine with complete isolation and no container restrictions.
 
 ---
 

--- a/derivatives/llama-cpp/README.template.md
+++ b/derivatives/llama-cpp/README.template.md
@@ -1,6 +1,6 @@
 # Llama.cpp
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Llama.cpp)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Llama.cpp)**
 
 ## What is this template?
 
@@ -48,7 +48,7 @@ Set the `LLAMA_MODEL` environment variable with your desired HuggingFace model:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Llama.cpp)"** when you've found an instance that works for you
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Llama.cpp)"** when you've found an instance that works for you
 
 ### **Step 3: Wait for Setup**
 The llama-server will start and your chosen model will be downloaded automatically *(this might take a few minutes depending on model size)*

--- a/derivatives/pytorch/derivatives/ace-step/README.template.md
+++ b/derivatives/pytorch/derivatives/ace-step/README.template.md
@@ -1,6 +1,6 @@
 # ACE-Step 1.5
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=ACE-Step+1.5)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=ACE-Step+1.5)**
 
 ## What is this template?
 
@@ -48,7 +48,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=ACE-Step+1.5)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=ACE-Step+1.5)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Startup**
 The API server starts first, followed by the UI once the API is ready. Models are downloaded on first generation.

--- a/derivatives/pytorch/derivatives/aio-studio/README.template.md
+++ b/derivatives/pytorch/derivatives/aio-studio/README.template.md
@@ -1,6 +1,6 @@
 # AIO Studio
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=AIO+Studio)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=AIO+Studio)**
 
 ## What is this template?
 
@@ -55,7 +55,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=AIO+Studio)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=AIO+Studio)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 The container will start with Instance Portal and Jupyter ready. Applications are installed but not running yet.

--- a/derivatives/pytorch/derivatives/comfyui/README.template.md
+++ b/derivatives/pytorch/derivatives/comfyui/README.template.md
@@ -1,6 +1,6 @@
 # ComfyUI
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=ComfyUI)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=ComfyUI)**
 
 ## What is this template?
 
@@ -53,7 +53,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=ComfyUI)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=ComfyUI)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 ComfyUI will be ready automatically with ComfyUI-Manager pre-installed *(initial model downloads may take additional time)*

--- a/derivatives/pytorch/derivatives/fluxgym/README.template.md
+++ b/derivatives/pytorch/derivatives/fluxgym/README.template.md
@@ -1,6 +1,6 @@
 # FluxGym
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=FluxGym)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=FluxGym)**
 
 ## What is this template?
 
@@ -34,7 +34,7 @@ This is **perfect** if you:
 ## Quick Start Guide
 
 ### **Step 1: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=FluxGym)"** when you've found a suitable GPU instance.
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=FluxGym)"** when you've found a suitable GPU instance.
 
 ### **Step 2: Access Your Instance**
 Click the **"Open"** button to reach the FluxGym UI.

--- a/derivatives/pytorch/derivatives/invokeai/README.template.md
+++ b/derivatives/pytorch/derivatives/invokeai/README.template.md
@@ -1,6 +1,6 @@
 # InvokeAI
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=InvokeAI)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=InvokeAI)**
 
 ## What is this template?
 
@@ -52,7 +52,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=InvokeAI)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=InvokeAI)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 InvokeAI will be ready automatically with all required dependencies pre-installed *(initial setup may take additional time)*

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/README.template.md
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/README.template.md
@@ -1,6 +1,6 @@
 # Ostris AI Toolkit
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Ostris%20AI%20Toolkit)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Ostris%20AI%20Toolkit)**
 
 ## What is this template?
 
@@ -52,7 +52,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Ostris%20AI%20Toolkit)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Ostris%20AI%20Toolkit)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 The Ostris AI Toolkit will be ready automatically with all required dependencies pre-installed *(initial setup may take additional time)*

--- a/derivatives/pytorch/derivatives/sd-forge/README.template.md
+++ b/derivatives/pytorch/derivatives/sd-forge/README.template.md
@@ -1,6 +1,6 @@
 # Stable Diffusion WebUI Forge
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=SD%20Forge)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=SD%20Forge)**
 
 ## What is this template?
 
@@ -69,7 +69,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Want to modify this setup? Click **edit**, make your changes, and save as your own template. Find it later in **"My Templates"**. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=SD%20Forge)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=SD%20Forge)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 Forge will be ready automatically *(initial model downloads may take additional time)*

--- a/derivatives/pytorch/derivatives/unsloth-studio/README.template.md
+++ b/derivatives/pytorch/derivatives/unsloth-studio/README.template.md
@@ -1,6 +1,6 @@
 # Unsloth Studio
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Unsloth+Studio)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Unsloth+Studio)**
 
 ## What is this template?
 
@@ -45,7 +45,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Unsloth+Studio)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Unsloth+Studio)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 Unsloth Studio will be ready automatically with llama.cpp pre-built for GGUF inference

--- a/derivatives/pytorch/derivatives/voicebox/README.template.md
+++ b/derivatives/pytorch/derivatives/voicebox/README.template.md
@@ -1,6 +1,6 @@
 # Voicebox
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Voicebox)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Voicebox)**
 
 ## What is this template?
 
@@ -50,7 +50,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Voicebox)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Voicebox)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 Voicebox will be ready automatically *(initial model downloads happen on first use and may take additional time)*

--- a/derivatives/pytorch/derivatives/wan2gp/README.template.md
+++ b/derivatives/pytorch/derivatives/wan2gp/README.template.md
@@ -1,6 +1,6 @@
 # Wan2GP
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Wan2GP)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Wan2GP)**
 
 ## What is this template?
 
@@ -41,7 +41,7 @@ Set your preferred configuration via environment variables:
 - **`PROVISIONING_SCRIPT`**: URL to auto-download dependencies on first boot
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Wan2GP)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Wan2GP)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 Wan2GP will be ready automatically with all required dependencies pre-installed *(initial model downloads may take additional time)*

--- a/derivatives/pytorch/derivatives/whisper/README.template.md
+++ b/derivatives/pytorch/derivatives/whisper/README.template.md
@@ -1,6 +1,6 @@
 # Whisper (API + UI)
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Whisper)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Whisper)**
 
 ## What is this template?
 
@@ -34,7 +34,7 @@ This is **perfect** if you:
 ## Quick Start Guide
 
 ### **Step 1: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Whisper)"** when you've found a suitable GPU instance.
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Whisper)"** when you've found a suitable GPU instance.
 
 ### **Step 2: Access Your Instance**
 Click the **"Open"** button to reach the Whisper WebUI, or use the API endpoint directly (see port reference below).

--- a/derivatives/pytorch/misc/README.template-acestep-v1.5.md
+++ b/derivatives/pytorch/misc/README.template-acestep-v1.5.md
@@ -1,6 +1,6 @@
 # ACE-Step 1.5
 
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=ACE-Step+1.5)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=ACE-Step+1.5)**
 
 ## What is this template?
 
@@ -50,7 +50,7 @@ Set your preferred configuration via environment variables:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=ACE-Step+1.5)"** when you've found a suitable GPU instance
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=ACE-Step+1.5)"** when you've found a suitable GPU instance
 
 ### **Step 3: Wait for Setup**
 The provisioning script will automatically clone and install ACE-Step 1.5 and its web UI. The API server starts first, followed by the UI once the API is ready. *(Initial setup may take several minutes as models are downloaded)*

--- a/external/ollama/README.template.md
+++ b/external/ollama/README.template.md
@@ -1,5 +1,5 @@
 # Ollama
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Ollama)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Ollama)**
 
 ## What is this template?
 
@@ -47,7 +47,7 @@ Set the `OLLAMA_MODEL` environment variable with your desired model:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Ollama)"** when you've found an instance that works for you
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Ollama)"** when you've found an instance that works for you
 
 ### **Step 3: Wait for Setup**
 Ollama will start and your chosen model will be pulled automatically *(this might take a few minutes depending on model size)*

--- a/external/openwebui/README.template.md
+++ b/external/openwebui/README.template.md
@@ -1,5 +1,5 @@
 # Open WebUI
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Open+WebUI)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Open+WebUI)**
 
 ## What is this template?
 
@@ -50,7 +50,7 @@ Set the `OLLAMA_MODEL` environment variable with your desired model:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Open+WebUI)"** when you've found an instance that works for you
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=Open+WebUI)"** when you've found an instance that works for you
 
 ### **Step 3: Wait for Setup**
 Ollama will start first and pull your chosen model automatically. Open WebUI launches once Ollama is fully ready *(this might take a few minutes depending on model size)*

--- a/external/sglang/README.template.md
+++ b/external/sglang/README.template.md
@@ -1,5 +1,5 @@
 # SGLang Inference Engine
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=SGLang)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=SGLang)**
 
 ## What is this template?
 
@@ -49,7 +49,7 @@ Set the `SGLANG_MODEL` environment variable with your desired model:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=SGLang)"** when you've found an instance that works for you
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=SGLang)"** when you've found an instance that works for you
 
 ### **Step 3: Wait for Setup**
 SGLang and your chosen model will download and start automatically *(this might take a few minutes depending on model size)*

--- a/external/vllm-omni/README.template.md
+++ b/external/vllm-omni/README.template.md
@@ -1,5 +1,5 @@
 # vLLM-Omni Inference Engine
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=vLLM-Omni)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=vLLM-Omni)**
 
 ## What is this template?
 
@@ -48,7 +48,7 @@ Set the `VLLM_MODEL` environment variable with your desired model:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=vLLM-Omni)"** when you've found an instance that works for you
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=vLLM-Omni)"** when you've found an instance that works for you
 
 ### **Step 3: Wait for Setup**
 vLLM-Omni and your chosen model will download and start automatically *(this might take a few minutes depending on model size)*

--- a/external/vllm/README.template.md
+++ b/external/vllm/README.template.md
@@ -1,5 +1,5 @@
 # vLLM Inference Engine
-> **[Create an Instance](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=vLLM)**
+> **[Create an Instance](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=vLLM)**
 
 ## What is this template?
 
@@ -48,7 +48,7 @@ Set the `VLLM_MODEL` environment variable with your desired model:
 > **Template Customization:** Templates can't be changed directly, but you can easily make your own version! Just click **edit**, make your changes, and save it as your own template. You'll find it in your **"My Templates"** section later. [Full guide here](https://docs.vast.ai/templates)
 
 ### **Step 2: Launch Instance**
-Click **"[Rent](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=vLLM)"** when you've found an instance that works for you
+Click **"[Rent](https://cloud.vast.ai/?ref_id=525202&creator_id=525202&name=vLLM)"** when you've found an instance that works for you
 
 ### **Step 3: Wait for Setup**
 vLLM and your chosen model will download and start automatically *(this might take a few minutes depending on model size)*


### PR DESCRIPTION
Repoints the launch links in all marketplace `README.template.md` files from a stale referral ID (`62897`) to the internal **Template Team** account (`525202`), which owns all recommended-template creations — so every *Create an Instance* / *Rent* link resolves to a real, published template.

**What:** 39 launch links across 19 files, `62897`→`525202` (78 ID swaps); URL structure and per-template `name=` preserved; 0 remaining `62897`.

**Interim vs end-goal:** deliberate interim tradeoff — hardcoding the owning account keeps links working now. The end goal (base-image as source of truth with per-user `<<LAUNCH_LINK>>` templating) is under consideration; these revert to the placeholder when that lands.