### PR TITLE
feat(boot): container-aware CPU thread caps — low-pids safety valve (ADR 0014)

### DIFF
--- a/ROOT/etc/vast_boot.d/12-cpu-thread-limits.sh
+++ b/ROOT/etc/vast_boot.d/12-cpu-thread-limits.sh
@@ -17,10 +17,15 @@
 # the thread pools to the CPU entitlement so pools stay within the pid budget.
 #
 # It is SOURCED by boot_default.sh after 10-prep-env.sh (which creates
-# /etc/environment). It writes a managed block into /etc/environment — recomputed
-# every boot — which every supervisor service re-reads (utils/environment.sh),
-# so a capped service that restarts still sees the caps. User/template values are
-# never overwritten.
+# /etc/environment AND, with export_env=true, sources /etc/environment + the
+# user's ${WORKSPACE}/.env into the boot shell). It writes a managed block into
+# /etc/environment — recomputed every boot — which every supervisor service
+# re-reads (utils/environment.sh), so a capped service that restarts still sees
+# the caps. User/template values are never overwritten. When a formerly-capped
+# instance later boots on a healthy host (e.g. the host's pids.max is fixed), the
+# stale block is removed AND the vars it set are cleared from the boot shell (so
+# supervisord, launched later in this same shell, does not inherit them), while
+# any real user value in /etc/environment or ${WORKSPACE}/.env is preserved.
 
 # ── Pure decision (unit-tested with synthetic inputs) ────────────────
 # Given pids_max, visible cores, and quota cores, echo the cap to apply, or echo
@@ -73,39 +78,56 @@ _vast_read_quota_cores() {
     echo $(( (q + p / 2) / p ))                                    # rounded to whole cores
 }
 
-# Vars this hook manages, and the managed-block markers.
+# ── Managed-block plumbing ────────────────────────────────────────────
 _VAST_TCAP_VARS=(OMP_NUM_THREADS OPENBLAS_NUM_THREADS MKL_NUM_THREADS
                  NUMEXPR_NUM_THREADS NUMEXPR_MAX_THREADS VECLIB_MAXIMUM_THREADS
                  RAYON_NUM_THREADS HF_HUB_DISABLE_XET)
 _VAST_TCAPS_BEGIN="# VAST_CPU_THREAD_CAPS_BEGIN (ADR 0014, managed — do not edit)"
 _VAST_TCAPS_END="# VAST_CPU_THREAD_CAPS_END"
 
-# True if VAR is already set by the user/template/launch env — i.e. present in
-# <file> OUTSIDE this hook's managed block (10-prep-env.sh dumps the launch env
-# into /etc/environment, so `-e VAR=...` at launch lands there).
+# True if VAR is set by the user/template/launch env — i.e. present OUTSIDE this
+# hook's managed block, in /etc/environment (10-prep-env.sh dumps the launch env
+# there, so `-e VAR=...` at first launch lands there) OR in ${WORKSPACE}/.env (the
+# documented per-instance override). Consulting both is what stops the no-op path
+# from clobbering a legitimate user value that never appears in /etc/environment.
 _vast_user_set() {
-    local var="$1" file="${2:-/etc/environment}"
-    [[ -f "$file" ]] || return 1
-    sed "/VAST_CPU_THREAD_CAPS_BEGIN/,/VAST_CPU_THREAD_CAPS_END/d" "$file" \
-        | grep -qE "^[[:space:]]*(export[[:space:]]+)?${var}="
+    local var="$1" file="${2:-/etc/environment}" envf="${WORKSPACE:-/workspace}/.env"
+    if [[ -f "$file" ]] && sed "/VAST_CPU_THREAD_CAPS_BEGIN/,/VAST_CPU_THREAD_CAPS_END/d" "$file" \
+            | grep -qE "^[[:space:]]*(export[[:space:]]+)?${var}="; then return 0; fi
+    [[ -f "$envf" ]] && grep -qE "^[[:space:]]*(export[[:space:]]+)?${var}=" "$envf"
 }
 
-# Write the managed cap block into <file> (default /etc/environment), and export
-# each capped var into the current shell so supervisord (launched later this boot)
-# inherits it. Idempotent and migration-safe: strips any prior managed block first,
-# so a cap computed on a previous host never persists after a stop/start onto
-# different hardware. Never overwrites a user/template value. Testable off-host by
-# passing a temp file.
+# Echo the variable names actually assigned inside the managed block of <file>.
+# (The block records exactly what we set; unsetting by this parsed list — not the
+# static _VAST_TCAP_VARS — keeps strip and unset symmetric across hook versions
+# and can never touch a var the user set outside the block.)
+_vast_block_vars() {
+    local file="${1:-/etc/environment}"
+    [[ -f "$file" ]] || return 0
+    sed -n '/VAST_CPU_THREAD_CAPS_BEGIN/,/VAST_CPU_THREAD_CAPS_END/p' "$file" 2>/dev/null \
+        | grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' | tr -d '[:blank:]='
+}
+
+# Remove the managed block from <file> (idempotent). Guarded by a presence check
+# so a clean file is never rewritten.
+_vast_strip_caps() {
+    local file="${1:-/etc/environment}"
+    [[ -f "$file" ]] && grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" "$file" \
+        && sed -i "/VAST_CPU_THREAD_CAPS_BEGIN/,/VAST_CPU_THREAD_CAPS_END/d" "$file"
+    return 0
+}
+
+# Write a fresh managed block to <file>, stripping any prior one first (migration-
+# safe). Exports each capped var into the current shell so supervisord (launched
+# later this boot) inherits it; leaves user/template vars untouched.
 _vast_write_caps() {
-    local cap="$1" file="${2:-/etc/environment}" var
+    local cap="$1" file="${2:-/etc/environment}" var val
     [[ -n "$cap" ]] || return 0
-    if [[ -f "$file" ]] && grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" "$file"; then
-        sed -i "/VAST_CPU_THREAD_CAPS_BEGIN/,/VAST_CPU_THREAD_CAPS_END/d" "$file"
-    fi
+    _vast_strip_caps "$file"
     {
         echo "$_VAST_TCAPS_BEGIN"
         for var in "${_VAST_TCAP_VARS[@]}"; do
-            local val="$cap"
+            val="$cap"
             # hf_xet's Rust pool ignores the thread-count vars, so disable xet on
             # these hosts (its only cost — slower dedup transfer — applies solely
             # where it would otherwise crash). Not relied on being governed by
@@ -122,20 +144,51 @@ _vast_write_caps() {
     } >> "$file"
 }
 
+# The whole side-effecting decision, given the computed cap ("" == no-op host):
+#  - cap set  -> write/refresh the managed block.
+#  - cap empty but a stale block exists (formerly-capped instance now on a healthy
+#    host) -> remove the block, unset ONLY the vars that block set from the boot
+#    shell, then re-source the authoritative files so any real user value
+#    (including one added to .env since the cap was written) is restored.
+_vast_apply_caps() {
+    local cap="$1" file="${2:-/etc/environment}" var
+    if [[ -n "$cap" ]]; then
+        _vast_write_caps "$cap" "$file"
+        return 0
+    fi
+    [[ -f "$file" ]] && grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" "$file" || return 0
+    local stale=(); mapfile -t stale < <(_vast_block_vars "$file")
+    _vast_strip_caps "$file"
+    for var in "${stale[@]}"; do [[ -n "$var" ]] && unset "$var"; done
+    set -a
+    . "$file" 2>/dev/null
+    [[ -f "${WORKSPACE:-/workspace}/.env" ]] && . "${WORKSPACE:-/workspace}/.env" 2>/dev/null
+    set +a
+    return 0
+}
+
+# Read the live cgroup state, decide, and apply to <file>. The whole compute->apply
+# wiring in one testable place: the test stubs the readers/nproc and drives this
+# against a temp file (so the no-op path's strip is covered, not just applied when
+# a cap exists). Always calls _vast_apply_caps — that is what makes a formerly
+# capped instance shed its block on a later healthy boot.
+_vast_run() {
+    local file="${1:-/etc/environment}" pm vis q cap
+    pm=$(_vast_read_pids_max)
+    vis=$(nproc 2>/dev/null)
+    q=$(_vast_read_quota_cores)
+    cap=$(_vast_thread_cap "${pm:-}" "${vis:-}" "${q:-}")
+    [[ -n "$cap" ]] && echo "[cpu-thread-limits] low pids budget (pids.max=${pm}, nproc=${vis}," \
+        "quota=${q:-none}) — capping thread pools to ${cap}"
+    _vast_apply_caps "$cap" "$file"
+}
+
 # Skip the boot action when sourced lib-only (the test loads functions this way).
 [[ -n "${_VAST_THREAD_HOOK_LIB_ONLY:-}" ]] && return 0
 
 # ── Act ───────────────────────────────────────────────────────────────
-{
-    _vast_pids_max=$(_vast_read_pids_max)
-    _vast_visible=$(nproc 2>/dev/null)
-    _vast_quota=$(_vast_read_quota_cores)
-    _vast_cap=$(_vast_thread_cap "${_vast_pids_max:-}" "${_vast_visible:-}" "${_vast_quota:-}")
-
-    if [[ -n "$_vast_cap" ]]; then
-        echo "[cpu-thread-limits] low pids budget (pids.max=${_vast_pids_max}, nproc=${_vast_visible}," \
-             "quota=${_vast_quota:-none}) — capping thread pools to ${_vast_cap}"
-        _vast_write_caps "$_vast_cap" /etc/environment
-    fi
-    unset _vast_pids_max _vast_visible _vast_quota _vast_cap
-} 2>/dev/null || echo "[cpu-thread-limits] skipped (unexpected error reading cgroup state)"
+# MUST remain a brace group, NOT a subshell — the unset/export/re-source inside
+# _vast_apply_caps have to reach this boot shell (which later launches supervisord
+# via 65-supervisor-launch.sh).
+{ _vast_run /etc/environment; } 2>/dev/null \
+    || echo "[cpu-thread-limits] skipped (unexpected error reading cgroup state)"

--- a/ROOT/etc/vast_boot.d/12-cpu-thread-limits.sh
+++ b/ROOT/etc/vast_boot.d/12-cpu-thread-limits.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# 12-cpu-thread-limits.sh — container-aware CPU thread caps (ADR 0014).
+#
+# A Vast instance is a cgroup-limited container. On some hosts the container sees
+# far more CPUs than it is entitled to (unrestricted cpuset -> nproc reports the
+# whole physical host, e.g. 384) while its CPU *quota* is a small slice (e.g. ~46
+# cores) AND its pids budget (pids.max) is pathologically low (e.g. 1024 instead
+# of the usual ~256/allocated-core). Native/ML runtimes (OpenMP, OpenBLAS, MKL,
+# torch, Rust rayon/hf_xet) size their thread pools to the *visible* core count,
+# so a few pools exhaust pids.max and pthread_create fails with EAGAIN
+# ("Resource temporarily unavailable") — crashing model downloads and inference.
+#
+# This hook is a SAFETY VALVE, not a fleet-wide tuner: it only intervenes when the
+# pids budget is dangerously low relative to the visible cores (see the trigger
+# below). On the overwhelming majority of hosts (healthy pids budget) it is a
+# no-op and leaves every runtime at its own defaults. When it does fire, it caps
+# the thread pools to the CPU entitlement so pools stay within the pid budget.
+#
+# It is SOURCED by boot_default.sh after 10-prep-env.sh (which creates
+# /etc/environment). It writes a managed block into /etc/environment — recomputed
+# every boot — which every supervisor service re-reads (utils/environment.sh),
+# so a capped service that restarts still sees the caps. User/template values are
+# never overwritten.
+
+# ── Pure decision (unit-tested with synthetic inputs) ────────────────
+# Given pids_max, visible cores, and quota cores, echo the cap to apply, or echo
+# nothing to mean "no-op / leave runtime defaults". Kept side-effect free so
+# tests/base/56-cpu-thread-limits.sh can exercise every branch off-host.
+_vast_thread_cap() {
+    local pids_max="$1" visible="$2" quota="$3"
+    local ceiling="${VAST_CPU_THREAD_CEILING:-16}"
+    # A finite, numeric pids budget and a visible core count are required to
+    # reason at all. "max"/unlimited/unreadable pids -> nothing to protect.
+    [[ "$pids_max" =~ ^[0-9]+$ ]] || return 0
+    [[ "$visible"  =~ ^[0-9]+$ ]] && (( visible > 0 )) || return 0
+    [[ "$ceiling"  =~ ^[0-9]+$ ]] && (( ceiling >= 2 )) || ceiling=16
+    # Trigger: only intervene when the budget is dangerously low. Healthy Vast
+    # hosts run ~30-120 pids per visible core (pids.max ~= 256/allocated-core,
+    # allocated << visible); the pathological host that motivated this ran 2.7.
+    # 16 sits well inside that gap.
+    (( pids_max >= visible * 16 )) && return 0
+    # Cap to the CPU entitlement, clamped: never above the ceiling (bounds a
+    # single pool's draw on the pid budget regardless of a generous quota), never
+    # below 2 (protect inference latency on a sub-2-core quota). No readable quota
+    # -> fall back to the ceiling (still far below the visible-core default).
+    local cap
+    if [[ "$quota" =~ ^[0-9]+$ ]] && (( quota > 0 )); then cap="$quota"; else cap="$ceiling"; fi
+    (( cap > ceiling )) && cap="$ceiling"
+    (( cap < 2 )) && cap=2
+    echo "$cap"
+}
+
+# ── cgroup readers (v2 first, then v1; empty/echo-nothing on absence) ──
+_vast_read_pids_max() {
+    if   [[ -r /sys/fs/cgroup/pids.max ]];       then cat /sys/fs/cgroup/pids.max        # v2
+    elif [[ -r /sys/fs/cgroup/pids/pids.max ]];  then cat /sys/fs/cgroup/pids/pids.max   # v1
+    fi
+}
+# Echo the container's CPU quota in whole cores (rounded), or nothing if unlimited.
+_vast_read_quota_cores() {
+    local q p
+    if [[ -r /sys/fs/cgroup/cpu.max ]]; then                       # v2: "<quota|max> <period>"
+        read -r q p < /sys/fs/cgroup/cpu.max
+        [[ "$q" == "max" ]] && return 0
+    elif [[ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]]; then        # v1
+        q=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null)
+        p=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null)
+        (( q <= 0 )) 2>/dev/null && return 0                       # -1 == unlimited
+    else
+        return 0
+    fi
+    [[ "$q" =~ ^[0-9]+$ ]] && [[ "$p" =~ ^[0-9]+$ ]] && (( p > 0 )) || return 0
+    echo $(( (q + p / 2) / p ))                                    # rounded to whole cores
+}
+
+# Vars this hook manages, and the managed-block markers.
+_VAST_TCAP_VARS=(OMP_NUM_THREADS OPENBLAS_NUM_THREADS MKL_NUM_THREADS
+                 NUMEXPR_NUM_THREADS NUMEXPR_MAX_THREADS VECLIB_MAXIMUM_THREADS
+                 RAYON_NUM_THREADS HF_HUB_DISABLE_XET)
+_VAST_TCAPS_BEGIN="# VAST_CPU_THREAD_CAPS_BEGIN (ADR 0014, managed — do not edit)"
+_VAST_TCAPS_END="# VAST_CPU_THREAD_CAPS_END"
+
+# True if VAR is already set by the user/template/launch env — i.e. present in
+# <file> OUTSIDE this hook's managed block (10-prep-env.sh dumps the launch env
+# into /etc/environment, so `-e VAR=...` at launch lands there).
+_vast_user_set() {
+    local var="$1" file="${2:-/etc/environment}"
+    [[ -f "$file" ]] || return 1
+    sed "/VAST_CPU_THREAD_CAPS_BEGIN/,/VAST_CPU_THREAD_CAPS_END/d" "$file" \
+        | grep -qE "^[[:space:]]*(export[[:space:]]+)?${var}="
+}
+
+# Write the managed cap block into <file> (default /etc/environment), and export
+# each capped var into the current shell so supervisord (launched later this boot)
+# inherits it. Idempotent and migration-safe: strips any prior managed block first,
+# so a cap computed on a previous host never persists after a stop/start onto
+# different hardware. Never overwrites a user/template value. Testable off-host by
+# passing a temp file.
+_vast_write_caps() {
+    local cap="$1" file="${2:-/etc/environment}" var
+    [[ -n "$cap" ]] || return 0
+    if [[ -f "$file" ]] && grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" "$file"; then
+        sed -i "/VAST_CPU_THREAD_CAPS_BEGIN/,/VAST_CPU_THREAD_CAPS_END/d" "$file"
+    fi
+    {
+        echo "$_VAST_TCAPS_BEGIN"
+        for var in "${_VAST_TCAP_VARS[@]}"; do
+            local val="$cap"
+            # hf_xet's Rust pool ignores the thread-count vars, so disable xet on
+            # these hosts (its only cost — slower dedup transfer — applies solely
+            # where it would otherwise crash). Not relied on being governed by
+            # RAYON_NUM_THREADS.
+            [[ "$var" == HF_HUB_DISABLE_XET ]] && val=1
+            if _vast_user_set "$var" "$file"; then
+                echo "# ${var}: left at user/template value"
+            else
+                echo "${var}=${val}"
+                export "${var}=${val}"
+            fi
+        done
+        echo "$_VAST_TCAPS_END"
+    } >> "$file"
+}
+
+# Skip the boot action when sourced lib-only (the test loads functions this way).
+[[ -n "${_VAST_THREAD_HOOK_LIB_ONLY:-}" ]] && return 0
+
+# ── Act ───────────────────────────────────────────────────────────────
+{
+    _vast_pids_max=$(_vast_read_pids_max)
+    _vast_visible=$(nproc 2>/dev/null)
+    _vast_quota=$(_vast_read_quota_cores)
+    _vast_cap=$(_vast_thread_cap "${_vast_pids_max:-}" "${_vast_visible:-}" "${_vast_quota:-}")
+
+    if [[ -n "$_vast_cap" ]]; then
+        echo "[cpu-thread-limits] low pids budget (pids.max=${_vast_pids_max}, nproc=${_vast_visible}," \
+             "quota=${_vast_quota:-none}) — capping thread pools to ${_vast_cap}"
+        _vast_write_caps "$_vast_cap" /etc/environment
+    fi
+    unset _vast_pids_max _vast_visible _vast_quota _vast_cap
+} 2>/dev/null || echo "[cpu-thread-limits] skipped (unexpected error reading cgroup state)"

--- a/ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh
+++ b/ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh
@@ -111,7 +111,7 @@ rm -rf "$_tmpws" "$_tmpenv"
   rm -f "$_t"; exit 0
 ) || fail_later "wiring" "_vast_run did not apply on the no-op path (stale block survived a healthy reboot)"
 
-# ── 3. Live consistency: /etc/environment matches the recomputed decision ──
+# ── 5. Live consistency: /etc/environment matches the recomputed decision ──
 _pm=$(_vast_read_pids_max); _vis=$(nproc 2>/dev/null); _q=$(_vast_read_quota_cores)
 _cap=$(_vast_thread_cap "${_pm:-}" "${_vis:-}" "${_q:-}")
 echo "  live: pids.max=${_pm:-?} nproc=${_vis:-?} quota=${_q:-none} -> cap=${_cap:-<no-op>}"
@@ -121,11 +121,17 @@ if [[ -z "$_cap" ]]; then
         fail_later "healthy-host" "managed block present on a host that should be a no-op"
     fi
 else
-    # Pathological host: block present and each unmanaged var at the cap.
+    # Pathological host: block present.
     grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" /etc/environment 2>/dev/null \
         || fail_later "patho-host" "expected a managed block (cap=${_cap}) but none in /etc/environment"
-    [[ "${OMP_NUM_THREADS:-}" == "$_cap" ]] \
-        || fail_later "patho-omp" "OMP_NUM_THREADS='${OMP_NUM_THREADS:-}' != cap ${_cap}"
+    # OMP equals the cap only when the user has NOT overridden it — the hook
+    # deliberately preserves a user/template/.env value, so gate on _vast_user_set.
+    if _vast_user_set OMP_NUM_THREADS; then
+        echo "  OMP_NUM_THREADS is user-set (${OMP_NUM_THREADS:-}); cap correctly not applied to it"
+    else
+        [[ "${OMP_NUM_THREADS:-}" == "$_cap" ]] \
+            || fail_later "patho-omp" "OMP_NUM_THREADS='${OMP_NUM_THREADS:-}' != cap ${_cap}"
+    fi
 fi
 
 report_failures

--- a/ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh
+++ b/ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh
@@ -62,6 +62,55 @@ grep -q '^MKL_NUM_THREADS=8$'   "$_tmpenv" || fail_later "recompute" "re-run did
 grep -q '^OMP_NUM_THREADS=99$'  "$_tmpenv" || fail_later "override-persist" "user OMP lost on re-run"
 rm -f "$_tmpenv"
 
+# A user override in ${WORKSPACE}/.env must be honoured by the write path too
+# (not just /etc/environment), so we never cap over a .env value.
+_tmpws=$(mktemp -d); echo "OMP_NUM_THREADS=64" > "$_tmpws/.env"
+_tmpenv=$(mktemp)
+( export WORKSPACE="$_tmpws"; _vast_write_caps 16 "$_tmpenv" )
+grep -q '^OMP_NUM_THREADS=16$' "$_tmpenv" && fail_later "env-override-write" ".env OMP_NUM_THREADS=64 was overwritten by the cap"
+grep -q '^MKL_NUM_THREADS=16$' "$_tmpenv" || fail_later "env-override-others" "non-.env vars still capped"
+rm -rf "$_tmpws" "$_tmpenv"
+
+# ── 3. No-op reconciliation: formerly-capped instance reboots healthy ──
+# A stale block is present and was sourced into the shell by 10-prep-env; a healthy
+# reboot (cap empty) must strip the block, unset ONLY the vars the block set, and
+# restore real user values — a user OMP in the file AND a user HF_HUB_DISABLE_XET
+# in ${WORKSPACE}/.env — while stale MKL/RAYON fall away.
+_tmpws=$(mktemp -d); echo "HF_HUB_DISABLE_XET=1" > "$_tmpws/.env"
+_tmpenv=$(mktemp)
+{ echo "OMP_NUM_THREADS=99"                       # user value, outside the block
+  echo "$_VAST_TCAPS_BEGIN"
+  echo "MKL_NUM_THREADS=16"; echo "RAYON_NUM_THREADS=16"; echo "HF_HUB_DISABLE_XET=1"
+  echo "$_VAST_TCAPS_END"; } > "$_tmpenv"
+_recon=$(
+    export WORKSPACE="$_tmpws"
+    # simulate 10-prep-env having exported the stale block + .env into the shell
+    export OMP_NUM_THREADS=99 MKL_NUM_THREADS=16 RAYON_NUM_THREADS=16 HF_HUB_DISABLE_XET=1
+    _vast_apply_caps "" "$_tmpenv"
+    echo "OMP=${OMP_NUM_THREADS:-UNSET};MKL=${MKL_NUM_THREADS:-UNSET};RAYON=${RAYON_NUM_THREADS:-UNSET};XET=${HF_HUB_DISABLE_XET:-UNSET}"
+)
+grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" "$_tmpenv" && fail_later "noop-strip" "managed block not stripped on no-op reboot"
+grep -q '^OMP_NUM_THREADS=99$' "$_tmpenv" || fail_later "noop-file-user" "user OMP=99 lost from file"
+[[ "$_recon" == *"MKL=UNSET"*   ]] || fail_later "noop-unset-mkl"  "stale MKL not cleared from shell ($_recon)"
+[[ "$_recon" == *"RAYON=UNSET"* ]] || fail_later "noop-unset-rayon" "stale RAYON not cleared from shell ($_recon)"
+[[ "$_recon" == *"OMP=99"*      ]] || fail_later "noop-restore-file" "user OMP=99 not restored to shell ($_recon)"
+[[ "$_recon" == *"XET=1"*       ]] || fail_later "noop-restore-env" "user .env HF_HUB_DISABLE_XET wrongly cleared ($_recon)"
+rm -rf "$_tmpws" "$_tmpenv"
+
+# ── 4. Wiring: _vast_run always applies (no-op host still sheds a stale block) ──
+# Stub the cgroup readers + nproc so we can drive both paths off-host against a
+# temp file. This guards the boot wiring itself, not just _vast_apply_caps.
+( # pathological: low pids -> block written with the cap
+  _vast_read_pids_max() { echo 1024; }; _vast_read_quota_cores() { echo 46; }; nproc() { echo 384; }
+  _t=$(mktemp); _vast_run "$_t" >/dev/null
+  grep -q '^OMP_NUM_THREADS=16$' "$_t" || { echo "WIRE-FAIL patho-write"; exit 1; }
+  # healthy reboot on the SAME file: high pids -> the stale block must be shed
+  _vast_read_pids_max() { echo 99999; }
+  _vast_run "$_t" >/dev/null
+  grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" "$_t" && { echo "WIRE-FAIL noop-shed"; exit 1; }
+  rm -f "$_t"; exit 0
+) || fail_later "wiring" "_vast_run did not apply on the no-op path (stale block survived a healthy reboot)"
+
 # ── 3. Live consistency: /etc/environment matches the recomputed decision ──
 _pm=$(_vast_read_pids_max); _vis=$(nproc 2>/dev/null); _q=$(_vast_read_quota_cores)
 _cap=$(_vast_thread_cap "${_pm:-}" "${_vis:-}" "${_q:-}")

--- a/ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh
+++ b/ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Test: container-aware CPU thread caps (ADR 0014).
+#
+# Two layers:
+#  1. Unit — exercise the pure decision _vast_thread_cap() with synthetic
+#     (pids_max, visible, quota) tuples, including the pathological host we can no
+#     longer rent on demand. This is the mutation-sensitive check: break the
+#     trigger or the clamp and these assertions fail.
+#  2. Live — recompute the decision from THIS host's real cgroup values and assert
+#     /etc/environment agrees (a managed block iff the host is pathological, with
+#     the vars at the computed cap; no block on a healthy host). Correct on either
+#     kind of host.
+source "$(dirname "$0")/../lib.sh"
+
+# Load the hook's functions without running its boot action.
+HOOK=/etc/vast_boot.d/12-cpu-thread-limits.sh
+[[ -r "$HOOK" ]] || HOOK="$(dirname "$0")/../../../../etc/vast_boot.d/12-cpu-thread-limits.sh"
+assert_file_exists "$HOOK"
+_VAST_THREAD_HOOK_LIB_ONLY=1 source "$HOOK" || test_fatal "could not source $HOOK in lib-only mode"
+declare -F _vast_thread_cap >/dev/null || test_fatal "_vast_thread_cap not defined after sourcing hook"
+
+# expect <label> <got> <want>
+expect() { [[ "$2" == "$3" ]] || fail_later "$1" "got '$2', want '$3'"; }
+
+# ── 1. Unit: the pure decision ───────────────────────────────────────
+# Pathological host that motivated the ADR: 384 visible, ~46 quota, pids.max=1024.
+expect "pathological caps to ceiling"   "$(_vast_thread_cap 1024 384 46)"  "16"
+# Healthy hosts (pids.max ~= 256/allocated-core) — all no-ops.
+expect "healthy 384/46/11776 no-op"     "$(_vast_thread_cap 11776 384 46)" ""
+expect "healthy 128/61/15616 no-op"     "$(_vast_thread_cap 15616 128 61)" ""
+expect "healthy 128/41/10240 no-op"     "$(_vast_thread_cap 10240 128 41)" ""
+# Unlimited / unreadable pids budget -> nothing to protect.
+expect "pids=max no-op"                 "$(_vast_thread_cap max 384 46)"   ""
+expect "pids empty no-op"               "$(_vast_thread_cap '' 384 46)"    ""
+# Trigger fires but quota unreadable -> fall back to ceiling.
+expect "low pids, no quota -> ceiling"  "$(_vast_thread_cap 1024 384 '')"  "16"
+# Quota below the floor is clamped up to 2 (latency floor).
+expect "sub-2 quota clamps to floor"    "$(_vast_thread_cap 500 384 1)"    "2"
+# Quota under the ceiling is honoured as-is.
+expect "small quota honoured"           "$(_vast_thread_cap 800 384 6)"    "6"
+# Boundary: pids.max exactly at the trigger threshold is treated as ample.
+expect "at-threshold is ample"          "$(_vast_thread_cap $((384*16)) 384 46)" ""
+# Ceiling is overridable.
+VAST_CPU_THREAD_CEILING=8 expect "ceiling override honoured" \
+    "$(VAST_CPU_THREAD_CEILING=8 _vast_thread_cap 1024 384 46)" "8"
+
+# ── 2. Write path: managed block, idempotency, override-preservation ──
+# Exercise _vast_write_caps against a temp file (no touch to real /etc/environment).
+_tmpenv=$(mktemp)
+echo "OMP_NUM_THREADS=99" > "$_tmpenv"   # pretend the user set OMP at launch
+_vast_write_caps 16 "$_tmpenv"
+# User's OMP preserved (commented in block, its real assignment untouched).
+[[ "$(grep -c '^OMP_NUM_THREADS=' "$_tmpenv")" == "1" ]] || fail_later "override-preserve" "user OMP_NUM_THREADS assignment altered/duplicated"
+grep -q '^OMP_NUM_THREADS=99$' "$_tmpenv" || fail_later "override-value" "user OMP_NUM_THREADS=99 not preserved"
+grep -q '^MKL_NUM_THREADS=16$'  "$_tmpenv" || fail_later "managed-set" "MKL_NUM_THREADS not set to cap in block"
+grep -q '^RAYON_NUM_THREADS=16$' "$_tmpenv" || fail_later "managed-rayon" "RAYON_NUM_THREADS not set to cap"
+grep -q '^HF_HUB_DISABLE_XET=1$' "$_tmpenv" || fail_later "managed-xet" "HF_HUB_DISABLE_XET not set to 1"
+# Idempotent: a second run (e.g. a restart, or a new host) must not stack blocks.
+_vast_write_caps 8 "$_tmpenv"
+[[ "$(grep -c 'VAST_CPU_THREAD_CAPS_BEGIN' "$_tmpenv")" == "1" ]] || fail_later "idempotent" "managed block stacked on re-run"
+grep -q '^MKL_NUM_THREADS=8$'   "$_tmpenv" || fail_later "recompute" "re-run did not recompute cap (8)"
+grep -q '^OMP_NUM_THREADS=99$'  "$_tmpenv" || fail_later "override-persist" "user OMP lost on re-run"
+rm -f "$_tmpenv"
+
+# ── 3. Live consistency: /etc/environment matches the recomputed decision ──
+_pm=$(_vast_read_pids_max); _vis=$(nproc 2>/dev/null); _q=$(_vast_read_quota_cores)
+_cap=$(_vast_thread_cap "${_pm:-}" "${_vis:-}" "${_q:-}")
+echo "  live: pids.max=${_pm:-?} nproc=${_vis:-?} quota=${_q:-none} -> cap=${_cap:-<no-op>}"
+if [[ -z "$_cap" ]]; then
+    # Healthy host: the hook must not have written a managed block.
+    if grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" /etc/environment 2>/dev/null; then
+        fail_later "healthy-host" "managed block present on a host that should be a no-op"
+    fi
+else
+    # Pathological host: block present and each unmanaged var at the cap.
+    grep -qF "VAST_CPU_THREAD_CAPS_BEGIN" /etc/environment 2>/dev/null \
+        || fail_later "patho-host" "expected a managed block (cap=${_cap}) but none in /etc/environment"
+    [[ "${OMP_NUM_THREADS:-}" == "$_cap" ]] \
+        || fail_later "patho-omp" "OMP_NUM_THREADS='${OMP_NUM_THREADS:-}' != cap ${_cap}"
+fi
+
+report_failures
+test_pass "cpu thread caps: decision, override-respect, and live state verified"

--- a/docs/adr/0014-container-aware-cpu-thread-caps.md
+++ b/docs/adr/0014-container-aware-cpu-thread-caps.md
@@ -1,0 +1,194 @@
+# ADR 0014 — Container-aware CPU thread caps at boot (low-pids safety valve)
+
+- **Status:** Proposed
+- **Date:** 2026-07-13
+- **Decision owner:** Rob Ballantyne
+
+## Context
+
+A Vast instance is a Docker container. Its kernel is shared; it sees the physical
+host's full CPU count (`nproc`/`os.cpu_count()`) but is *entitled* only to a CPU
+quota (a slice), and it has a hard container-wide thread/process cap
+(`pids.max`). Native/ML runtimes — OpenMP/`libgomp`, OpenBLAS, MKL, torch, Rust
+`rayon`/`hf_xet` — size their thread pools to the **visible** core count, not the
+quota. When `pids.max` is also low, a few such pools exhaust it and
+`pthread_create` fails with `EAGAIN` ("Resource temporarily unavailable").
+
+This surfaced as the **ACE-Step image failing every generation** on one host:
+
+- Model download crashed in `hf_xet` (Rust): `failed to spawn thread: WouldBlock`.
+- Inference crashed in `libgomp`: `Thread creation failed`.
+
+Confirmed mechanism on that box: `OMP_NUM_THREADS=8` dropped the API server from
+**363 → 20 threads**, and generation then completed end-to-end. The failure
+recurred on a **service restart**, not just first boot — relevant because
+`/etc/environment` is re-read by every supervisor service on restart.
+
+**We then sampled four hosts to test whether this is common or an outlier:**
+
+| host | cgroup | `nproc` | quota-cores | `pids.max` | pids ÷ visible-core |
+|------|--------|---------|-------------|------------|---------------------|
+| ACE-Step (crashed) | v1 | 384 | 46 | **1024** | **2.7** |
+| B | v2 | 384 | 46 | 11776 | 30.7 |
+| C | v2 | 128 | 61 | 15616 | 122 |
+| D | v2 | 128 | 41 | 10240 | 80 |
+
+Two facts fall out:
+
+1. **CPU oversubscription is universal** — every host sees the whole machine but is
+   entitled to a slice (you rent ~46 of 384 cores; `nproc` still says 384). So
+   oversized thread pools happen everywhere; on their own they only waste cycles.
+2. **The crash needs a pathologically low `pids.max`.** Healthy hosts follow
+   `pids.max ≈ 256 × allocated-cores` (B/C/D fit exactly: 46→11776, 61→15616,
+   41→10240) and sit at **30–122 pids per visible core**. The crashed host got
+   **1024 = 256 × 4** — a pids budget sized as if it had 4 cores, not the 46 it
+   rented. It is a misconfigured/rogue host (the only cgroup-v1 sample), not the
+   fleet default. At its budget (2.7 pids/visible-core) the oversized pools blow
+   the cap; at a healthy budget the identical pools have 10–45× headroom and never
+   do.
+
+So the reported crash is a **rare bad-host condition**, and — critically — the bad
+condition (cgroup version, `pids.max`) is **not visible in the rental offer**; you
+only learn it once booted. You cannot select against it. That makes a boot-time,
+on-box adaptation the only mechanism that can protect an unpredictable placement.
+This is the container-unaware-runtime problem the JVM (`UseContainerSupport`) and
+Go (`automaxprocs`) already solved for their runtimes.
+
+This is a **base-image `ROOT/` boot concern**, inherited by every derivative and
+external image. Boot hooks in `/etc/vast_boot.d/*.sh` are sourced in order (after
+`10-prep-env.sh`, which creates `/etc/environment`); `/etc/environment` is sourced
+by every supervisor service and re-read on service restart.
+
+## Options considered
+
+**Scope of intervention**
+- **A. A narrow low-pids *safety valve* (chosen).** Cap thread pools **only** on a
+  host whose pids budget is dangerously low; a no-op on every healthy host. Targets
+  exactly the failure, near-zero fleet blast radius.
+- **B. Fleet-wide "always cap pools to the quota" for perf hygiene. Rejected.**
+  Oversubscribed pools are wasteful everywhere, but capping every instance is a
+  broad, silent behavior change (a tenant on a big-but-throttled box suddenly sees
+  fewer BLAS threads) for a diffuse benefit — the weakest, most-contested idea in
+  review. Not worth the blast radius; the crash is what we must fix.
+- **C. Do nothing in the image; just report/avoid the bad host. Rejected as
+  sufficient.** You can't see `pids.max` before renting, so you can't avoid it;
+  reporting fixes one host but not the next random placement. (We still report it —
+  see Consequences — but it can't be the only defense.)
+
+**The trigger**
+- **D. Oversubscription ratio (`visible > quota × 1.5`). Rejected.** True on *all
+  four* hosts above — it fires on healthy hosts too, collapsing into option B.
+- **E. Pids headroom per visible core (`pids.max < nproc × 16`) (chosen).** Directly
+  measures the failure condition. The crashed host is 2.7; every healthy host is
+  30–122. The threshold 16 sits deep in that gap, so it fires on the bad host and no
+  other.
+
+**The cap value**
+- **F. Fixed 8 (the one tested value). Rejected:** cargo-cults one box; arbitrary
+  elsewhere.
+- **G. `floor(quota)`. Rejected:** quota-sized pools *stack* (libgomp + OpenBLAS +
+  MKL + torch intra/inter-op ≈ 180 threads/process; a multi-worker dataloader forks
+  that) and can still approach a low `pids.max`. Quota is the entitlement, not a safe
+  per-pool number.
+- **H. `clamp(round(quota), 2, ceiling=16)`, `VAST_CPU_THREAD_CEILING`-overridable
+  (chosen).** The ceiling bounds any single pool's draw on the pid budget regardless
+  of a generous quota; the floor of 2 protects inference latency on a sub-2-core
+  quota. 16 stays within a factor of the proven-safe 8 while returning some
+  throughput.
+
+**Xet (the download crash)**
+- **I. Rely on `RAYON_NUM_THREADS` to bound `hf_xet`. Rejected as load-bearing.** One
+  live test suggested it does, but adversarial review argues `hf_xet` is a **tokio**
+  runtime sized off the cpuset, which `RAYON_NUM_THREADS` does not govern. The
+  mechanism is unverified; do not depend on it.
+- **J. Set `HF_HUB_DISABLE_XET=1` on the safety-valve path (chosen).** Proven. Its
+  only cost — losing xet's dedup transfer speedup — applies solely on hosts where xet
+  otherwise **crashes**, so no real regression. On healthy hosts (valve not tripped)
+  xet stays enabled.
+
+**Codification**
+- **K. A linter `RULES` code (the repo's usual Bug→Invariant step). Rejected as
+  theater — called out explicitly.** "Effective cores, not visible cores, size the
+  pools" is a **runtime cgroup fact** invisible to a static analyzer over
+  Dockerfiles/`ROOT` files; a `RULES` code could only assert "the hook file exists,"
+  proving nothing about the arithmetic, trigger, or override logic.
+- **L. A pure decision function + on-box test + mutation test (chosen).** The
+  decision is factored into side-effect-free bash functions unit-tested with
+  synthetic `(pids.max, nproc, quota)` tuples — including the pathological host we
+  can no longer rent on demand — plus a live-host consistency check. Mutating the
+  hook (drop the clamp / the trigger / the idempotent strip / the override guard)
+  makes the test fail. This upholds the protocol's intent ("no mutation test = the
+  check doesn't count") at the layer where the invariant actually lives.
+
+## Decision
+
+Add `ROOT/etc/vast_boot.d/12-cpu-thread-limits.sh`, a **low-pids safety valve**.
+Every boot it:
+
+1. Reads the container's `pids.max` (cgroup v2 `/sys/fs/cgroup/pids.max`, v1
+   `/sys/fs/cgroup/pids/pids.max`), `nproc`, and CPU quota-cores (v2 `cpu.max`, v1
+   `cpu.cfs_quota_us`/`cpu.cfs_period_us`, rounded).
+2. **Intervenes only when `pids.max < nproc × 16`.** Any unreadable/unlimited pids
+   value, or an ample budget, is a **no-op**.
+3. Computes `cap = clamp(round(quota), 2, ${VAST_CPU_THREAD_CEILING:-16})` (no
+   readable quota ⇒ the ceiling), and for `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`,
+   `MKL_NUM_THREADS`, `NUMEXPR_NUM_THREADS`, `NUMEXPR_MAX_THREADS`,
+   `VECLIB_MAXIMUM_THREADS`, `RAYON_NUM_THREADS` writes the cap, plus
+   `HF_HUB_DISABLE_XET=1` — **only for vars the user/template has not set**.
+4. Writes them into a **delimited managed block** in `/etc/environment`, **stripping
+   its own prior block first** and recomputing every boot (migration-safe), and
+   `export`s them so supervisord (started later in the same boot) inherits them.
+
+Codified by `ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh` (unit +
+live + mutation-tested), not a linter rule.
+
+## Binding conditions
+
+Non-negotiable; if any is refused the decision is void.
+
+1. **Safety valve, not a fleet tuner.** No-op unless `pids.max < nproc × 16`. Healthy
+   hosts are untouched — no thread caps, xet stays enabled.
+2. **Recompute every boot via the managed block.** `/etc/environment` persists across
+   stop/start (overlayfs) and instances migrate hosts; strip-own-block-then-recompute
+   is mandatory so a cap from a prior host never lingers.
+3. **Respect explicit overrides.** A value set by the user/template/launch env (it
+   lands in `/etc/environment` via `10-prep-env.sh`) always wins; the hook fills only
+   unset vars.
+4. **Fail-safe.** Unreadable/ambiguous cgroup state ⇒ no-op; never fall back to
+   `nproc` as the cap basis.
+5. **Xet disabled only on the tripped path**, and never relied upon being governed by
+   `RAYON_NUM_THREADS`.
+6. **Codified by the runtime test + mutation test, not a `RULES` code.** The linter
+   baseline is unchanged/CLEAN. When the docs-tooling branch lands, add the
+   corresponding `invariants.md` §4 blind-spot entry pointing at this test.
+
+## Consequences
+
+- The rare low-pids host degrades gracefully (capped pools) instead of crashing
+  downloads/inference — for base services and every derivative/external alike.
+- Every healthy host is a **no-op**: no throughput change, xet unaffected. Blast
+  radius is confined to the pathological placement.
+- **Complementary action (not in this repo):** report the crashed machine to Vast —
+  `pids.max=1024` on a 46-core instance violates their own `256 × cores` default,
+  likely an old cgroup-v1 host or an operator `--pids-limit`. Fixing it removes that
+  host from the pool; the safety valve remains for the next unpredictable one.
+- **Not covered** (documented): torch `set_num_interop_threads` (not env-driven), Go
+  tooling (`GOMAXPROCS`), libraries reading `sched_getaffinity` directly, and a
+  possible `cgroupns=host` layout where the standard cgroup paths could read the host
+  root (fail-safe: a nonsensical read ⇒ no-op). If a genuine multi-service pids-sum
+  failure ever appears on a *healthy*-budget host, per-service caps are the escalation.
+- The real bad host could not be re-rented (it was gone within days, and cgroup
+  version/pids budget aren't selectable), so end-to-end validation on a live
+  pathological host is opportunistic. The crash-fix itself was already demonstrated on
+  that box during triage; the trigger/arithmetic/write logic is validated host-independently
+  by the unit + mutation tests.
+
+## What would reverse this
+
+- **The durable cure is platform-side.** If Vast aligns the cpuset to the quota (so
+  `nproc` reports the entitlement and runtimes self-size) and/or guarantees
+  `pids.max` scales with allocated cores, the valve stops tripping and can be retired.
+- `hf_xet` respecting a quota/explicit cap upstream — then the conditional
+  `HF_HUB_DISABLE_XET` drops.
+- Evidence the ceiling (16) or trigger (×16) is wrong on real workloads — retune the
+  env override, or move to per-service caps.

--- a/docs/adr/0014-container-aware-cpu-thread-caps.md
+++ b/docs/adr/0014-container-aware-cpu-thread-caps.md
@@ -134,13 +134,22 @@ Every boot it:
    readable quota ⇒ the ceiling), and for `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`,
    `MKL_NUM_THREADS`, `NUMEXPR_NUM_THREADS`, `NUMEXPR_MAX_THREADS`,
    `VECLIB_MAXIMUM_THREADS`, `RAYON_NUM_THREADS` writes the cap, plus
-   `HF_HUB_DISABLE_XET=1` — **only for vars the user/template has not set**.
+   `HF_HUB_DISABLE_XET=1` — **only for vars the user/template has not set**, judged
+   from `/etc/environment` (outside the block) **and** `${WORKSPACE}/.env`.
 4. Writes them into a **delimited managed block** in `/etc/environment`, **stripping
    its own prior block first** and recomputing every boot (migration-safe), and
    `export`s them so supervisord (started later in the same boot) inherits them.
+5. **No-op reconciliation** (formerly-capped instance now on a healthy host, e.g. its
+   `pids.max` was corrected): removes the stale block, `unset`s **only the vars that
+   block actually set** (parsed from the block, not a static list — so a user value
+   is never touched and a var dropped from a future managed-set can't leak), then
+   re-sources `/etc/environment` + `${WORKSPACE}/.env` to restore any real user value
+   — because `10-prep-env.sh` (`export_env=true`) has already exported the stale block
+   into the boot shell that later launches supervisord, so stripping the file alone
+   would leave the caps live in-process.
 
 Codified by `ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh` (unit +
-live + mutation-tested), not a linter rule.
+live + wiring + mutation-tested), not a linter rule.
 
 ## Binding conditions
 
@@ -148,12 +157,16 @@ Non-negotiable; if any is refused the decision is void.
 
 1. **Safety valve, not a fleet tuner.** No-op unless `pids.max < nproc × 16`. Healthy
    hosts are untouched — no thread caps, xet stays enabled.
-2. **Recompute every boot via the managed block.** `/etc/environment` persists across
-   stop/start (overlayfs) and instances migrate hosts; strip-own-block-then-recompute
-   is mandatory so a cap from a prior host never lingers.
-3. **Respect explicit overrides.** A value set by the user/template/launch env (it
-   lands in `/etc/environment` via `10-prep-env.sh`) always wins; the hook fills only
-   unset vars.
+2. **Recompute every boot, and shed on a healthy boot.** `/etc/environment` persists
+   across stop/start (overlayfs) and a host's `pids.max` can be corrected; the managed
+   block is stripped-and-recomputed every boot, and on a no-op boot the vars the stale
+   block set are also cleared from the boot shell (not just the file) so supervisord
+   does not inherit them. A cap from a prior boot never lingers, in the file or the
+   process.
+3. **Respect explicit overrides.** A value the user set via `/etc/environment` (incl.
+   launch `-e`, dumped there by `10-prep-env.sh`) **or `${WORKSPACE}/.env`** always
+   wins — the hook fills only unset vars, and the no-op path restores such values
+   rather than clearing them.
 4. **Fail-safe.** Unreadable/ambiguous cgroup state ⇒ no-op; never fall back to
    `nproc` as the cap basis.
 5. **Xet disabled only on the tripped path**, and never relied upon being governed by
@@ -177,6 +190,14 @@ Non-negotiable; if any is refused the decision is void.
   possible `cgroupns=host` layout where the standard cgroup paths could read the host
   root (fail-safe: a nonsensical read ⇒ no-op). If a genuine multi-service pids-sum
   failure ever appears on a *healthy*-budget host, per-service caps are the escalation.
+- **Known limitation of the no-op path.** It can restore a user value that lives in
+  `/etc/environment` or `${WORKSPACE}/.env`, but not one that exists *only* in the
+  process env — e.g. a `-e OMP_NUM_THREADS=…` added via edit-instance *after* first
+  boot, which `10-prep-env.sh` (write-once, identity-gated) never records in the file.
+  On a healthy reboot that var is unset back to the library default rather than the
+  user's number. This is a downstream symptom of `10-prep-env.sh`'s write-once design,
+  not fixable in this hook; the safe direction (default, not a stale cap) is the lesser
+  harm. Setting the override in `.env` avoids it entirely.
 - The real bad host could not be re-rented (it was gone within days, and cgroup
   version/pids budget aren't selectable), so end-to-end validation on a live
   pathological host is opportunistic. The crash-fix itself was already demonstrated on


### PR DESCRIPTION
## Problem

Native/ML runtimes (OpenMP/`libgomp`, OpenBLAS, MKL, torch, Rust `rayon`/`hf_xet`) size their thread pools to the **visible** CPU count. A Vast container sees the whole physical host (`nproc` = 384) but is entitled only to a rented slice (~46-core quota) and has a hard container-wide `pids.max`. When `pids.max` is also low, a couple of pools exhaust it and `pthread_create` fails with `EAGAIN`.

Surfaced as the **ACE-Step image failing every generation** on one host:
- download crashed in `hf_xet`: `failed to spawn thread: WouldBlock`
- inference crashed in `libgomp`: `Thread creation failed`

Confirmed on the box: `OMP_NUM_THREADS=8` took the server **363 → 20 threads** and generation recovered.

## Why a *safety valve*, not a fleet-wide cap

Sampling four hosts showed the crash is a **rare bad-host condition**, not the norm:

| host | cgroup | `nproc` | quota-cores | `pids.max` | pids ÷ visible-core |
|------|--------|---------|-------------|------------|---------------------|
| ACE-Step (crashed) | v1 | 384 | 46 | **1024** | **2.7** |
| B | v2 | 384 | 46 | 11776 | 30.7 |
| C | v2 | 128 | 61 | 15616 | 122 |
| D | v2 | 128 | 41 | 10240 | 80 |

Healthy hosts follow `pids.max ≈ 256 × allocated-cores` (B/C/D fit exactly). The crashed host got `1024 = 256 × 4` — a budget sized as if it had 4 cores, not the 46 it rented. It's a misconfigured/rogue host (the only cgroup-v1 sample). But you **can't select against it** — cgroup version and `pids.max` aren't in the rental offer — so the only protection is a boot-time on-box adaptation. (The bad machine is being reported to Vast separately; that fixes one host, not the next random placement.)

## The change

`ROOT/etc/vast_boot.d/12-cpu-thread-limits.sh` — a low-pids safety valve, inherited by every derivative/external via the base `ROOT/` overlay. Every boot it:

- **No-op unless `pids.max < nproc × 16`** (the bad host is 2.7; every healthy host 30–120). Healthy hosts are completely untouched — no caps, `hf_xet` stays enabled.
- Otherwise caps `OMP/OPENBLAS/MKL/NUMEXPR/VECLIB/RAYON` to `clamp(round(quota), 2, ${VAST_CPU_THREAD_CEILING:-16})` and sets `HF_HUB_DISABLE_XET=1` (xet's Rust pool ignores the thread vars; its only cost — slower dedup transfer — applies only where it would otherwise crash).
- Writes them to a **managed block** in `/etc/environment` (sourced by every service, re-read on restart — the actual failure vector), **stripped and recomputed every boot** so a cap from a prior host never lingers after a stop/start onto different hardware, and **never overrides** a user/template value.

## Testing

`ROOT/opt/instance-tools/tests/base/56-cpu-thread-limits.sh`:
- **Unit** — the pure decision against synthetic `(pids.max, nproc, quota)` tuples, including the now-unrentable pathological host (→ caps to 16) and all three healthy boxes (→ no-op).
- **Write path** — managed-block content, idempotency across re-runs, user-override preservation.
- **Live** — recomputes the decision from the running host's cgroup values and asserts `/etc/environment` matches (correct on healthy or pathological hosts).
- **Mutation-tested** — dropping the ceiling clamp, the trigger, the idempotent strip, or the override guard each makes the test fail.

Not a linter rule: "effective cores, not visible cores, size the pools" is a runtime cgroup fact a static analyzer can't see (`invariants.md` §4 blind spot); the honest gate is the on-box test. Rationale and rejected alternatives are in **ADR 0014**.

## Note on ADR cross-refs

The ADR/docs framework (`invariants.md`, ADRs 0009–0013) currently lives on the unmerged tooling branch (#206), not `main`. ADR 0014 here is self-contained; its cross-references resolve once that lands, and the matching `invariants.md` §4 entry will be added on the docs branch.