### PR TITLE
Fix CivitAI token validation and authenticated downloads

### DIFF
--- a/ROOT/opt/instance-tools/lib/provisioner/README.md
+++ b/ROOT/opt/instance-tools/lib/provisioner/README.md
@@ -456,8 +456,14 @@ Downloads run in two independent parallel pools:
 | URL Pattern | Handler | Auth | Pool |
 |-------------|---------|------|------|
 | `huggingface.co` | `hf download` | `$HF_TOKEN` (automatic) | `hf_downloads` |
-| `civitai.com` | `wget` with `Authorization` header | `$CIVITAI_TOKEN` | `wget_downloads` |
+| `civitai.com` (https, host-matched) | `curl` with `Authorization` header | `$CIVITAI_TOKEN` | `wget_downloads` |
 | Everything else | `wget` | None | `wget_downloads` |
+
+Authenticated CivitAI downloads use `curl` rather than `wget`: CivitAI's download
+endpoint 307s to a presigned CDN host, and `wget --header` re-sends the header across
+that host change (leaking the token, and the CDN 400s on it), while `curl` drops it.
+The CivitAI match is on the parsed **host** over https — not a substring — so a URL
+merely containing `civitai.com` in its path or query never receives the token.
 
 **HuggingFace URL formats:**
 

--- a/ROOT/opt/instance-tools/lib/provisioner/auth.py
+++ b/ROOT/opt/instance-tools/lib/provisioner/auth.py
@@ -55,6 +55,10 @@ def validate_civitai_token(token_env: str = "CIVITAI_TOKEN") -> bool:
             headers={
                 "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",
+                # urllib's default User-Agent ("Python-urllib/x.y") is blocked
+                # by CivitAI's Cloudflare WAF (403, before the Authorization
+                # header is evaluated), making every token look invalid.
+                "User-Agent": "Mozilla/5.0 (compatible; vast-ai-provisioner)",
             },
         )
         with urlopen(req, timeout=15) as resp:

--- a/ROOT/opt/instance-tools/lib/provisioner/downloaders/wget.py
+++ b/ROOT/opt/instance-tools/lib/provisioner/downloaders/wget.py
@@ -20,7 +20,13 @@ log = logging.getLogger("provisioner")
 
 def _get_content_disposition_filename(url: str, auth_header: str | None = None) -> str:
     """Fetch the filename from Content-Disposition headers."""
-    cmd = ["curl", "-sI", "-L", "--max-time", "30", url]
+    # CivitAI's download endpoint mishandles auth on HEAD requests, 401ing
+    # even with a token that downloads the same file fine via GET. Use a
+    # ranged GET (-r 0-0, 1 byte) instead, for CivitAI only.
+    if _is_civitai(url):
+        cmd = ["curl", "-sD", "-", "-o", "/dev/null", "-L", "-r", "0-0", "--max-time", "30", url]
+    else:
+        cmd = ["curl", "-sI", "-L", "--max-time", "30", url]
     if auth_header:
         cmd.extend(["-H", auth_header])
 
@@ -85,16 +91,28 @@ def download_wget(
         os.makedirs(os.path.dirname(dest), exist_ok=True)
 
         def _do_download() -> bool:
-            cmd = [
-                "wget", "-q", "--show-progress",
-                "--max-redirect=10",
-                "-O", dest,
-                url,
-            ]
-            if auth_header:
-                cmd.extend(["--header", auth_header])
+            if auth_header and _is_civitai(url):
+                # wget forwards --header to every redirect hop, including
+                # cross-host ones. CivitAI's download endpoint 307-redirects
+                # to a presigned CDN URL that 400s on any Authorization
+                # header; curl drops it automatically once the host changes.
+                cmd = [
+                    "curl", "-fSL", "--max-redirs", "10",
+                    "-H", auth_header,
+                    "-o", dest,
+                    url,
+                ]
+                label = "curl"
+            else:
+                cmd = [
+                    "wget", "-q", "--show-progress",
+                    "--max-redirect=10",
+                    "-O", dest,
+                    url,
+                ]
+                label = "wget"
 
-            result = run_cmd(cmd, label="wget", check=False)
+            result = run_cmd(cmd, label=label, check=False)
             if result.returncode != 0:
                 # Clean up partial downloads
                 try:

--- a/ROOT/opt/instance-tools/lib/provisioner/downloaders/wget.py
+++ b/ROOT/opt/instance-tools/lib/provisioner/downloaders/wget.py
@@ -1,6 +1,8 @@
-"""Generic wget download handler.
+"""Generic download handler.
 
-Handles CivitAI (with token) and plain HTTP downloads.
+Handles plain HTTP downloads with wget, and authenticated CivitAI downloads with
+curl — CivitAI 307s to a presigned CDN host, and wget re-sends --header across that
+host change (leaking the token) while curl drops it.
 Supports content-disposition filename extraction when dest ends with '/'.
 """
 
@@ -9,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+from urllib.parse import urlparse
 
 from ..concurrency import FileLock
 from ..subprocess_runner import run_cmd
@@ -43,7 +46,20 @@ def _get_content_disposition_filename(url: str, auth_header: str | None = None) 
 
 
 def _is_civitai(url: str) -> bool:
-    return "civitai.com" in url
+    """True only for real CivitAI hosts over HTTPS.
+
+    This decides whether the user's CivitAI token is attached, so a substring
+    test is not good enough: manifests are third-party data (PROVISIONING_SCRIPT
+    fetches one by URL, PROVISIONING_DOWNLOADS accepts url|path pairs), and
+    "civitai.com" appears in a path, a subdomain suffix or a query string of a
+    URL an attacker controls — e.g. https://evil.example/civitai.com/x or
+    https://civitai.com.evil.example/x — each of which would hand over the token.
+    Matching on the parsed host also rules out http://, which would put the
+    bearer token on the wire in cleartext.
+    """
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    return parsed.scheme == "https" and (host == "civitai.com" or host.endswith(".civitai.com"))
 
 
 def download_wget(

--- a/ROOT/opt/instance-tools/lib/provisioner/tests/test_auth.py
+++ b/ROOT/opt/instance-tools/lib/provisioner/tests/test_auth.py
@@ -62,6 +62,23 @@ class TestValidateHfToken:
         with patch("provisioner.auth.urlopen", return_value=mock_resp):
             assert validate_hf_token("HF_TOKEN") is False
 
+    def test_no_custom_user_agent(self, monkeypatch):
+        """The User-Agent fix is CivitAI-specific; HF's request is untouched."""
+        monkeypatch.setenv("HF_TOKEN", "tok")
+        captured = {}
+
+        def fake_urlopen(req, timeout=15):
+            captured["req"] = req
+            resp = MagicMock()
+            resp.status = 200
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("provisioner.auth.urlopen", side_effect=fake_urlopen):
+            assert validate_hf_token("HF_TOKEN") is True
+        assert "User-agent" not in captured["req"].headers
+
 
 class TestValidateCivitaiToken:
     def test_no_token_returns_false(self):
@@ -93,3 +110,20 @@ class TestValidateCivitaiToken:
         monkeypatch.setenv("CIVITAI_TOKEN", "tok")
         with patch("provisioner.auth.urlopen", side_effect=OSError("network")):
             assert validate_civitai_token("CIVITAI_TOKEN") is False
+
+    def test_sets_user_agent(self, monkeypatch):
+        """CivitAI's WAF blocks urllib's default User-Agent, made tokens look invalid."""
+        monkeypatch.setenv("CIVITAI_TOKEN", "tok")
+        captured = {}
+
+        def fake_urlopen(req, timeout=15):
+            captured["req"] = req
+            resp = MagicMock()
+            resp.status = 200
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("provisioner.auth.urlopen", side_effect=fake_urlopen):
+            assert validate_civitai_token("CIVITAI_TOKEN") is True
+        assert captured["req"].headers.get("User-agent")  # urllib normalizes the header key case

--- a/ROOT/opt/instance-tools/lib/provisioner/tests/test_downloaders.py
+++ b/ROOT/opt/instance-tools/lib/provisioner/tests/test_downloaders.py
@@ -347,3 +347,118 @@ class TestDownloadWget:
             dest="/tmp/models/",
         )
         download_wget(entry, retry=RetrySettings(), civitai_token="tok", dry_run=True)
+
+
+class TestDownloadWgetCommand:
+    """curl (not wget) is used for authenticated CivitAI downloads, since wget
+    forwards --header across cross-host redirects and CivitAI's download
+    endpoint 307s to a presigned CDN URL that 400s on any Authorization
+    header. Every other case keeps using wget."""
+
+    @patch("provisioner.downloaders.wget.run_cmd")
+    @patch("provisioner.downloaders.wget.FileLock")
+    @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
+    @patch("provisioner.downloaders.wget.os.makedirs")
+    def test_civitai_download_uses_curl_not_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+        mock_lock.return_value.__enter__ = MagicMock()
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+        mock_run_cmd.return_value = MagicMock(returncode=1)
+
+        entry = DownloadEntry(url="https://civitai.com/api/download/models/123", dest="/tmp/model.bin")
+        with pytest.raises(RuntimeError):
+            download_wget(entry, retry=RetrySettings(max_attempts=1), civitai_token="tok")
+
+        cmd = mock_run_cmd.call_args[0][0]
+        assert cmd[0] == "curl"
+        assert "wget" not in cmd
+        assert "-H" in cmd
+        assert "Authorization: Bearer tok" in cmd
+
+    @patch("provisioner.downloaders.wget.run_cmd")
+    @patch("provisioner.downloaders.wget.FileLock")
+    @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
+    @patch("provisioner.downloaders.wget.os.makedirs")
+    def test_non_civitai_download_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+        mock_lock.return_value.__enter__ = MagicMock()
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+        mock_run_cmd.return_value = MagicMock(returncode=1)
+
+        entry = DownloadEntry(url="https://example.com/file.bin", dest="/tmp/file.bin")
+        with pytest.raises(RuntimeError):
+            download_wget(entry, retry=RetrySettings(max_attempts=1))
+
+        cmd = mock_run_cmd.call_args[0][0]
+        assert cmd[0] == "wget"
+
+    @patch("provisioner.downloaders.wget.run_cmd")
+    @patch("provisioner.downloaders.wget.FileLock")
+    @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
+    @patch("provisioner.downloaders.wget.os.makedirs")
+    def test_civitai_without_token_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+        """No token means no header to leak, so plain wget is fine."""
+        mock_lock.return_value.__enter__ = MagicMock()
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+        mock_run_cmd.return_value = MagicMock(returncode=1)
+
+        entry = DownloadEntry(url="https://civitai.com/api/download/models/123", dest="/tmp/model.bin")
+        with pytest.raises(RuntimeError):
+            download_wget(entry, retry=RetrySettings(max_attempts=1))
+
+        cmd = mock_run_cmd.call_args[0][0]
+        assert cmd[0] == "wget"
+
+    @patch("provisioner.downloaders.wget.run_cmd")
+    @patch("provisioner.downloaders.wget.FileLock")
+    @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
+    @patch("provisioner.downloaders.wget.os.makedirs")
+    def test_non_civitai_with_auth_header_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+        """_is_civitai(url) is checked explicitly, not just auth_header."""
+        mock_lock.return_value.__enter__ = MagicMock()
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+        mock_run_cmd.return_value = MagicMock(returncode=1)
+
+        entry = DownloadEntry(url="https://example.com/file.bin", dest="/tmp/file.bin")
+        with pytest.raises(RuntimeError):
+            download_wget(entry, retry=RetrySettings(max_attempts=1), civitai_token="tok")
+
+        cmd = mock_run_cmd.call_args[0][0]
+        assert cmd[0] == "wget"
+
+
+class TestContentDispositionUsesGetNotHead:
+    """CivitAI mishandles auth on HEAD requests, so it always uses a ranged
+    GET (-r 0-0) instead, auth header or not; every other host keeps HEAD."""
+
+    @patch("provisioner.downloaders.wget.subprocess.run")
+    def test_civitai_with_auth_header_uses_ranged_get_not_head(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="")
+        _get_content_disposition_filename("https://civitai.com/api/download/models/123", "Authorization: Bearer tok")
+        cmd = mock_run.call_args[0][0]
+        assert "-I" not in cmd
+        assert "-r" in cmd
+        assert "0-0" in cmd
+
+    @patch("provisioner.downloaders.wget.subprocess.run")
+    def test_non_civitai_with_auth_header_still_uses_head(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="")
+        _get_content_disposition_filename("https://example.com/dl", "Authorization: Bearer tok")
+        cmd = mock_run.call_args[0][0]
+        assert "-sI" in cmd
+        assert "-r" not in cmd
+
+    @patch("provisioner.downloaders.wget.subprocess.run")
+    def test_non_civitai_without_auth_header_uses_head(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="")
+        _get_content_disposition_filename("https://example.com/dl")
+        cmd = mock_run.call_args[0][0]
+        assert "-sI" in cmd
+        assert "-r" not in cmd
+
+    @patch("provisioner.downloaders.wget.subprocess.run")
+    def test_civitai_without_auth_header_still_uses_ranged_get(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="")
+        _get_content_disposition_filename("https://civitai.com/api/download/models/123")
+        cmd = mock_run.call_args[0][0]
+        assert "-I" not in cmd
+        assert "-r" in cmd
+        assert "0-0" in cmd

--- a/ROOT/opt/instance-tools/lib/provisioner/tests/test_downloaders.py
+++ b/ROOT/opt/instance-tools/lib/provisioner/tests/test_downloaders.py
@@ -146,8 +146,25 @@ class TestIsCivitai:
     def test_non_civitai_url(self):
         assert _is_civitai("https://example.com/file.bin") is False
 
-    def test_civitai_in_path(self):
+    def test_civitai_subdomain(self):
         assert _is_civitai("https://mirror.civitai.com/models/123") is True
+
+    # _is_civitai decides whether the user's CivitAI token is attached, and
+    # manifests are third-party data (PROVISIONING_SCRIPT is fetched by URL,
+    # PROVISIONING_DOWNLOADS takes url|path pairs). A substring test would hand
+    # the token to any host that can get "civitai.com" into its URL.
+    @pytest.mark.parametrize("url", [
+        "https://attacker.example/civitai.com/model.safetensors",  # in the path
+        "https://civitai.com.attacker.example/x",                  # as a prefix
+        "https://evil.example/x?ref=civitai.com",                  # in the query
+        "https://notcivitai.com/x",                                # unrelated host
+    ])
+    def test_lookalike_hosts_do_not_get_the_token(self, url):
+        assert _is_civitai(url) is False
+
+    def test_plaintext_civitai_is_rejected(self):
+        """http:// would put the bearer token on the wire in cleartext."""
+        assert _is_civitai("http://civitai.com/api/download/models/123") is False
 
 
 # ---------- _get_content_disposition_filename ----------
@@ -359,12 +376,12 @@ class TestDownloadWgetCommand:
     @patch("provisioner.downloaders.wget.FileLock")
     @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
     @patch("provisioner.downloaders.wget.os.makedirs")
-    def test_civitai_download_uses_curl_not_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+    def test_civitai_download_uses_curl_not_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd, tmp_path):
         mock_lock.return_value.__enter__ = MagicMock()
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
         mock_run_cmd.return_value = MagicMock(returncode=1)
 
-        entry = DownloadEntry(url="https://civitai.com/api/download/models/123", dest="/tmp/model.bin")
+        entry = DownloadEntry(url="https://civitai.com/api/download/models/123", dest=str(tmp_path / "model.bin"))
         with pytest.raises(RuntimeError):
             download_wget(entry, retry=RetrySettings(max_attempts=1), civitai_token="tok")
 
@@ -378,12 +395,12 @@ class TestDownloadWgetCommand:
     @patch("provisioner.downloaders.wget.FileLock")
     @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
     @patch("provisioner.downloaders.wget.os.makedirs")
-    def test_non_civitai_download_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+    def test_non_civitai_download_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd, tmp_path):
         mock_lock.return_value.__enter__ = MagicMock()
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
         mock_run_cmd.return_value = MagicMock(returncode=1)
 
-        entry = DownloadEntry(url="https://example.com/file.bin", dest="/tmp/file.bin")
+        entry = DownloadEntry(url="https://example.com/file.bin", dest=str(tmp_path / "file.bin"))
         with pytest.raises(RuntimeError):
             download_wget(entry, retry=RetrySettings(max_attempts=1))
 
@@ -394,13 +411,13 @@ class TestDownloadWgetCommand:
     @patch("provisioner.downloaders.wget.FileLock")
     @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
     @patch("provisioner.downloaders.wget.os.makedirs")
-    def test_civitai_without_token_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+    def test_civitai_without_token_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd, tmp_path):
         """No token means no header to leak, so plain wget is fine."""
         mock_lock.return_value.__enter__ = MagicMock()
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
         mock_run_cmd.return_value = MagicMock(returncode=1)
 
-        entry = DownloadEntry(url="https://civitai.com/api/download/models/123", dest="/tmp/model.bin")
+        entry = DownloadEntry(url="https://civitai.com/api/download/models/123", dest=str(tmp_path / "model.bin"))
         with pytest.raises(RuntimeError):
             download_wget(entry, retry=RetrySettings(max_attempts=1))
 
@@ -411,13 +428,13 @@ class TestDownloadWgetCommand:
     @patch("provisioner.downloaders.wget.FileLock")
     @patch("provisioner.downloaders.wget.os.path.isfile", return_value=False)
     @patch("provisioner.downloaders.wget.os.makedirs")
-    def test_non_civitai_with_auth_header_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd):
+    def test_non_civitai_with_auth_header_still_uses_wget(self, mock_makedirs, mock_isfile, mock_lock, mock_run_cmd, tmp_path):
         """_is_civitai(url) is checked explicitly, not just auth_header."""
         mock_lock.return_value.__enter__ = MagicMock()
         mock_lock.return_value.__exit__ = MagicMock(return_value=False)
         mock_run_cmd.return_value = MagicMock(returncode=1)
 
-        entry = DownloadEntry(url="https://example.com/file.bin", dest="/tmp/file.bin")
+        entry = DownloadEntry(url="https://example.com/file.bin", dest=str(tmp_path / "file.bin"))
         with pytest.raises(RuntimeError):
             download_wget(entry, retry=RetrySettings(max_attempts=1), civitai_token="tok")
 


### PR DESCRIPTION
- auth.py: CivitAI's Cloudflare WAF blocks urllib's default User-Agent with a 403 before evaluating the Authorization header, so token validation always reported "invalid". Added a real User-Agent, scoped to CivitAI only.

- downloaders/wget.py: CivitAI's download endpoint 307-redirects to a presigned CDN URL (R2/B2) that 400s on any Authorization header. wget forwards --header across cross-host redirects; curl drops it automatically once the host changes. Switched to curl for CivitAI downloads that carry a token; every other case still uses wget.

- Same file: _get_content_disposition_filename used a HEAD request, which CivitAI mishandles auth on (401s even with a valid token). Switched to a ranged GET (-r 0-0) for CivitAI, HEAD elsewhere.

Both changes explicitly check _is_civitai(url) so they can't affect HuggingFace or any other host. Added regression tests.

---

I confirmed the provisioner can download CivitAI models with my patch

https://github.com/mtsmfm/base-image/pkgs/container/comfyui