### PR TITLE
fix(portal-aio): bump aiohttp/idna/click(+typer) to clear remaining CVEs

### DIFF
--- a/portal-aio/requirements.txt
+++ b/portal-aio/requirements.txt
@@ -10,7 +10,7 @@ attrs==24.2.0
 cachetools==5.5.0
 certifi==2024.8.30
 charset-normalizer==3.4.0
-click==8.3.3
+click==8.1.7
 dnspython==2.7.0
 email_validator==2.2.0
 exceptiongroup==1.2.2

--- a/portal-aio/requirements.txt
+++ b/portal-aio/requirements.txt
@@ -10,7 +10,7 @@ attrs==24.2.0
 cachetools==5.5.0
 certifi==2024.8.30
 charset-normalizer==3.4.0
-click==8.1.7
+click==8.3.3
 dnspython==2.7.0
 email_validator==2.2.0
 exceptiongroup==1.2.2
@@ -42,7 +42,7 @@ shellingham==1.5.4
 shortuuid==1.0.13
 sniffio==1.3.1
 starlette==1.3.1
-typer==0.12.5
+typer==0.26.8
 typing_extensions==4.12.2
 typing-inspection==0.4.2
 urllib3==2.7.0

--- a/portal-aio/requirements.txt
+++ b/portal-aio/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==24.1.0
 aiohappyeyeballs==2.5.0
-aiohttp==3.13.4
+aiohttp==3.14.1
 aiosignal==1.4.0
 annotated-doc==0.0.3
 annotated-types==0.7.0
@@ -10,7 +10,7 @@ attrs==24.2.0
 cachetools==5.5.0
 certifi==2024.8.30
 charset-normalizer==3.4.0
-click==8.1.7
+click==8.3.3
 dnspython==2.7.0
 email_validator==2.2.0
 exceptiongroup==1.2.2
@@ -22,7 +22,7 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.6.4
 httpx==0.27.2
-idna==3.10
+idna==3.15
 Jinja2==3.1.6
 markdown-it-py==3.0.0
 MarkupSafe==3.0.1


### PR DESCRIPTION
## Summary

Follow-up to #216. Clears **all remaining advisories** on `portal-aio/requirements.txt` — the **12 remaining Dependabot alerts** (11 `aiohttp` + 1 `idna`) plus the OSV-only `click` advisory — taking portal-aio to **0 Dependabot alerts** and **0 pip-audit findings**.

| Package | Old → New | Clears |
|---|---|---|
| aiohttp | 3.13.4 → **3.14.1** | 11 Dependabot alerts (#41,42,48–56) |
| idna | 3.10 → **3.15** | 1 Dependabot alert (#40) |
| click | 8.1.7 → **8.3.3** | OSV PYSEC-2026-2132 / CVE-2026-7246 |
| typer | 0.12.5 → **0.26.8** | enabling bump — click ≥8.2 requires it (see below) |

## Why typer moves

click 8.2 made secondary-flag validation a hard error; `typer 0.12.5` still emits such flags via `fastapi-cli`, so click 8.3.3 crashes the portal launcher at startup (`TypeError: Secondary flag is not valid for non-boolean flag`). `typer 0.26.8` fixes it. `fastapi-cli 0.0.5` only requires `typer>=0.12.3` (no upper cap), and **portal-aio does not import typer directly** — the only surface is `fastapi run`, so the blast radius is the launcher, which is dogfooded below.

## Runtime risk

`aiohttp` is the one bump with app code (`tunnel_manager.py`: `ClientSession`, `session.get(url, timeout=10).json()`, `ClientError`/`ClientConnectorError`). `idna` is transitive (via `requests`). `click`/`typer` are the CLI launcher path.

## Verification

- **Resolution:** `uv pip check` → all 54 packages compatible; only the 4 lines above change.
- **Audit:** `pip-audit` (OSV) on the full set → **No known vulnerabilities found**.
- **Live dogfood** (fresh instance, real portal venv, CPython 3.11): applied post-#216+#217 stack + portal.py migration → `instance_portal` + `tunnel_manager` **RUNNING**, portal `GET /` → **200**, quick tunnels recreated (`@app.on_event` fires, aiohttp path exercised), no secondary-flag crash. The click bump was caught crashing the launcher under the old typer and re-added only after the typer bump was dogfooded clean.

## Fleet rollout

As with #216, merging clears the **alerts**; running instances get the fix only when a portal release is cut (`portal-aio/VERSION` bump).