### PR TITLE
ci(portal): automate the release cut on VERSION change (ADR 0015)

### DIFF
--- a/.github/workflows/release-portal.yml
+++ b/.github/workflows/release-portal.yml
@@ -1,0 +1,94 @@
+# Release Instance Portal when portal-aio/VERSION changes on main.
+#
+# Mechanism (see ADR 0015 + ROOT/opt/instance-tools/bin/update-portal):
+#   portal-aio/ ships to the fleet as a GitHub *release*, not via the image build.
+#   Instances read /opt/portal-aio/VERSION on first boot, compare it to this repo's
+#   *latest* release tag, and on mismatch download the release's
+#   instance-portal.tar.gz. So publishing a release here is what ships portal
+#   changes to running instances.
+#
+# This workflow builds instance-portal.tar.gz = `git archive` of the portal-aio/
+# tree (tracked files only) and publishes a release tagged with the VERSION
+# contents, marked --latest. Bumping portal-aio/VERSION on main and publishing the
+# matching release in one CI run keeps main and the release from diverging (which
+# would otherwise downgrade freshly-built images — ADR 0015).
+#
+# Idempotent: if a release for the version already exists, it is a no-op.
+# Auth: default GITHUB_TOKEN with contents: write. No repository secrets required.
+
+name: Release Portal
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'portal-aio/VERSION'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Ref or commit to release from"
+        required: false
+        default: main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-portal
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.sha }}
+
+      - name: Read portal version
+        id: ver
+        run: |
+          VER="$(tr -d '[:space:]' < portal-aio/VERSION)"
+          [[ "$VER" == v* ]] || VER="v$VER"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "Portal version: $VER"
+
+      - name: Check whether the release already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release ${{ steps.ver.outputs.version }} already exists — nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build instance-portal.tar.gz
+        if: steps.exists.outputs.exists == 'false'
+        run: |
+          git archive --format=tar.gz --prefix=portal-aio/ HEAD:portal-aio \
+            -o instance-portal.tar.gz
+          echo "--- archive top level ---"
+          tar -tzf instance-portal.tar.gz | awk -F/ 'NF>1{print $2}' | sort -u
+          # Sanity: the tarball's own VERSION must match the tag we are cutting.
+          INTERNAL="$(tar -xzOf instance-portal.tar.gz portal-aio/VERSION | tr -d '[:space:]')"
+          [[ "$INTERNAL" == v* ]] || INTERNAL="v$INTERNAL"
+          if [[ "$INTERNAL" != "${{ steps.ver.outputs.version }}" ]]; then
+            echo "::error::internal VERSION ($INTERNAL) != release tag (${{ steps.ver.outputs.version }})"
+            exit 1
+          fi
+
+      - name: Create tag and publish release
+        if: steps.exists.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.ver.outputs.version }}" instance-portal.tar.gz \
+            --target "${{ github.sha }}" \
+            --title "Instance Portal ${{ steps.ver.outputs.version }}" \
+            --latest \
+            --generate-notes
+          echo "Published ${{ steps.ver.outputs.version }} as latest."

--- a/.github/workflows/release-portal.yml
+++ b/.github/workflows/release-portal.yml
@@ -3,17 +3,22 @@
 # Mechanism (see ADR 0015 + ROOT/opt/instance-tools/bin/update-portal):
 #   portal-aio/ ships to the fleet as a GitHub *release*, not via the image build.
 #   Instances read /opt/portal-aio/VERSION on first boot, compare it to this repo's
-#   *latest* release tag, and on mismatch download the release's
-#   instance-portal.tar.gz. So publishing a release here is what ships portal
-#   changes to running instances.
+#   *latest* release tag, and on ANY mismatch (upgrade OR downgrade) download the
+#   latest release's instance-portal.tar.gz. So publishing a release here is what
+#   ships portal changes to running instances.
 #
-# This workflow builds instance-portal.tar.gz = `git archive` of the portal-aio/
-# tree (tracked files only) and publishes a release tagged with the VERSION
-# contents, marked --latest. Bumping portal-aio/VERSION on main and publishing the
-# matching release in one CI run keeps main and the release from diverging (which
-# would otherwise downgrade freshly-built images — ADR 0015).
+# Safety guards (each maps to a red-team finding — do not remove without re-review):
+#   - Strict vX.Y.Z: a malformed/empty VERSION must never publish a garbage tag.
+#   - Monotonic gate: never publish a version <= the current published latest, so a
+#     revert-to-lower VERSION or a back-fill of an older version cannot mark an older
+#     release --latest and downgrade the fleet.
+#   - Published-state idempotency: skip only when a *published* release already
+#     exists; a leftover DRAFT of the same version is deleted and re-published (a
+#     draft is invisible to releases/latest, so treating it as "done" would strand
+#     the release and downgrade fresh images).
+#   - Single resolved SHA: archive, tag, and --target all use one commit; abort if a
+#     pre-existing tag points elsewhere.
 #
-# Idempotent: if a release for the version already exists, it is a no-op.
 # Auth: default GITHUB_TOKEN with contents: write. No repository secrets required.
 
 name: Release Portal
@@ -46,49 +51,105 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref || github.sha }}
 
-      - name: Read portal version
+      - name: Resolve version + commit, validate format
         id: ver
         run: |
-          VER="$(tr -d '[:space:]' < portal-aio/VERSION)"
-          [[ "$VER" == v* ]] || VER="v$VER"
+          set -euo pipefail
+          SHA="$(git rev-parse HEAD)"
+          RAW="$(tr -d '[:space:]' < portal-aio/VERSION)"
+          if [[ ! "$RAW" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::portal-aio/VERSION is not a vX.Y.Z version: '$RAW'"
+            exit 1
+          fi
+          VER="$RAW"; [[ "$VER" == v* ]] || VER="v$VER"
           echo "version=$VER" >> "$GITHUB_OUTPUT"
-          echo "Portal version: $VER"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Portal version: $VER @ $SHA"
 
-      - name: Check whether the release already exists
-        id: exists
+      - name: Decide action (published / draft / monotonic guards)
+        id: plan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Release ${{ steps.ver.outputs.version }} already exists — nothing to do."
+          set -euo pipefail
+          V="${{ steps.ver.outputs.version }}"
+          SHA="${{ steps.ver.outputs.sha }}"
+
+          # Current published latest (excludes drafts/prereleases); empty if none.
+          LATEST="$(gh release view --json tagName -q '.tagName' 2>/dev/null || true)"
+          echo "current published latest: ${LATEST:-<none>}"
+
+          # State of a release for THIS version, if any.
+          STATE="none"
+          if gh release view "$V" >/dev/null 2>&1; then
+            if [[ "$(gh release view "$V" --json isDraft -q '.isDraft')" == "true" ]]; then
+              STATE="draft"; else STATE="published"; fi
+          fi
+          echo "release state for $V: $STATE"
+
+          # Already shipped -> idempotent no-op.
+          if [[ "$STATE" == "published" ]]; then
+            echo "action=skip" >> "$GITHUB_OUTPUT"
+            echo "$V is already published — nothing to do."
+            exit 0
+          fi
+
+          # Monotonic gate: never (re)publish a version <= the current published latest.
+          if [[ -n "$LATEST" ]]; then
+            HIGHEST="$(printf '%s\n%s\n' "$LATEST" "$V" | sort -V | tail -1)"
+            if [[ "$V" == "$LATEST" || "$HIGHEST" != "$V" ]]; then
+              echo "::error::refusing to publish $V — not greater than current latest $LATEST (downgrade/back-fill guard)"
+              exit 1
+            fi
+          fi
+
+          # A pre-existing tag must point at the commit we are releasing.
+          if git rev-parse -q --verify "refs/tags/$V" >/dev/null; then
+            TAGSHA="$(git rev-parse "refs/tags/$V^{commit}")"
+            if [[ "$TAGSHA" != "$SHA" ]]; then
+              echo "::error::tag $V exists at $TAGSHA, not the release commit $SHA"
+              exit 1
+            fi
+          fi
+
+          echo "action=publish" >> "$GITHUB_OUTPUT"
+          if [[ "$STATE" == "draft" ]]; then
+            echo "draft_to_replace=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "draft_to_replace=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build instance-portal.tar.gz
-        if: steps.exists.outputs.exists == 'false'
+        if: steps.plan.outputs.action == 'publish'
         run: |
+          set -euo pipefail
           git archive --format=tar.gz --prefix=portal-aio/ HEAD:portal-aio \
             -o instance-portal.tar.gz
-          echo "--- archive top level ---"
-          tar -tzf instance-portal.tar.gz | awk -F/ 'NF>1{print $2}' | sort -u
-          # Sanity: the tarball's own VERSION must match the tag we are cutting.
           INTERNAL="$(tar -xzOf instance-portal.tar.gz portal-aio/VERSION | tr -d '[:space:]')"
           [[ "$INTERNAL" == v* ]] || INTERNAL="v$INTERNAL"
           if [[ "$INTERNAL" != "${{ steps.ver.outputs.version }}" ]]; then
             echo "::error::internal VERSION ($INTERNAL) != release tag (${{ steps.ver.outputs.version }})"
             exit 1
           fi
+          echo "--- archive top level ---"
+          tar -tzf instance-portal.tar.gz | awk -F/ 'NF>1{print $2}' | sort -u
 
-      - name: Create tag and publish release
-        if: steps.exists.outputs.exists == 'false'
+      - name: Delete stale draft for this version (keeps the tag)
+        if: steps.plan.outputs.action == 'publish' && steps.plan.outputs.draft_to_replace == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete "${{ steps.ver.outputs.version }}" --yes
+          echo "Deleted stale draft ${{ steps.ver.outputs.version }}."
+
+      - name: Create tag and publish release as latest
+        if: steps.plan.outputs.action == 'publish'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.ver.outputs.version }}" instance-portal.tar.gz \
-            --target "${{ github.sha }}" \
+            --target "${{ steps.ver.outputs.sha }}" \
             --title "Instance Portal ${{ steps.ver.outputs.version }}" \
             --latest \
             --generate-notes
-          echo "Published ${{ steps.ver.outputs.version }} as latest."
+          echo "Published ${{ steps.ver.outputs.version }} as latest at ${{ steps.ver.outputs.sha }}."

--- a/docs/adr/0015-portal-release-automation.md
+++ b/docs/adr/0015-portal-release-automation.md
@@ -51,19 +51,33 @@ never diverge for long — a constraint a human-timed cut cannot guarantee.
 
 Add `.github/workflows/release-portal.yml`. Triggers: push to `main` on path
 `portal-aio/VERSION`, plus `workflow_dispatch` (ref input) for back-fill. It reads
-`portal-aio/VERSION`, and if a release for that tag does not already exist, builds
-`instance-portal.tar.gz` = `git archive` of the `portal-aio/` tree (tracked files
-only — matches the historical asset layout, excludes `.claude`/`.pytest_cache`/
-`venv`), asserts the tarball's internal `VERSION` matches, then `gh release create
-<version> --latest` at the triggering commit. Idempotent: an existing release for
-that version is a no-op.
+`portal-aio/VERSION`, validates it, and — unless a **published** release for that
+version already exists — builds `instance-portal.tar.gz` = `git archive` of the
+`portal-aio/` tree (tracked files only — matches the historical asset layout,
+excludes `.claude`/`.pytest_cache`/`venv`), asserts the tarball's internal `VERSION`
+matches, then `gh release create <version> --latest` at the resolved commit.
 
 ## Binding conditions
 
+These guards are non-negotiable — each closes a fleet-downgrade or wrong-ship failure
+mode found in adversarial review; removing one requires a fresh review.
+
 - The asset is a `git archive` of `portal-aio/` with `--prefix=portal-aio/`, so it
   extracts to `/opt/portal-aio/…` exactly as `update-portal` expects.
-- The workflow is **idempotent** — re-running for an existing release must not fail
-  or replace a published asset.
+- **Strict version format** — `portal-aio/VERSION` must match `^v?\d+\.\d+\.\d+$` or
+  the run fails; an empty/malformed VERSION must never publish a tag.
+- **Monotonic gate** — the workflow refuses to publish a version that is not strictly
+  greater than the current *published* latest release. This is what makes `--latest`
+  safe: a revert-to-lower VERSION or a `workflow_dispatch` back-fill of an older
+  version cannot mark an older release latest and downgrade the fleet.
+- **Idempotency keys on _published_ state, not existence** — a matching **draft**
+  release (invisible to `releases/latest`) is treated as *not shipped*: it is deleted
+  and re-published. Only an already-**published** release for the version is a no-op.
+  (Checking mere existence would let a leftover draft strand the release and downgrade
+  freshly-built images — the exact trap this ADR closes.)
+- **Single resolved commit** — archive, tag, and `--target` all use one SHA
+  (`git rev-parse HEAD` after checkout); if a tag for the version already exists at a
+  different commit, the run aborts rather than mis-tag.
 - Only `portal-aio/VERSION` triggers it; editing portal code without bumping
   VERSION does **not** cut a release (matches the source-of-truth model).
 - `contents: write` is the only elevated permission; auth via the default

--- a/docs/adr/0015-portal-release-automation.md
+++ b/docs/adr/0015-portal-release-automation.md
@@ -1,0 +1,90 @@
+# ADR 0015 — Automate the Instance Portal release cut on VERSION change
+
+- **Status:** Proposed
+- **Date:** 2026-07-15
+- **Decision owner:** Rob Ballantyne
+
+## Context
+
+`portal-aio/` (the Instance Portal + tunnel manager) ships to the fleet through a
+GitHub **release**, not the base-image build. On first boot,
+`ROOT/etc/vast_boot.d/first_boot/10-update-instance-portal.sh` reads the installed
+version from `/opt/portal-aio/VERSION`, fetches the repo's **latest release**
+`tag_name`, and — on any mismatch, upgrade **or downgrade** — calls
+`ROOT/opt/instance-tools/bin/update-portal`, which downloads that release's
+`instance-portal.tar.gz`, extracts it to `/opt`, and reinstalls
+`requirements.txt`. `portal-aio/VERSION` is the source of truth for the installed
+version; the release tag is the source of truth for the target.
+
+Until now the release was cut **by hand**: bump `VERSION`, `git tag`, build a
+tarball of `portal-aio/`, upload it as the release asset. There was no packaging
+workflow. This surfaced during the #216/#217 CVE remediation: the fix reached
+`main` but could not reach the fleet without a manual, error-prone cut.
+
+The manual path also has a **correctness trap**. Because `main` bakes
+`portal-aio/VERSION` into freshly-built images, and first boot downgrades on *any*
+mismatch, if `main`'s VERSION is ahead of the latest **published** release, a new
+image boots with `installed > latest` and **downgrades itself**, silently undoing
+whatever the VERSION bump shipped. So `main`'s VERSION and the latest release must
+never diverge for long — a constraint a human-timed cut cannot guarantee.
+
+## Options considered
+
+- **A — Publish on `VERSION` change on `main` (chosen).** A workflow triggers on a
+  push to `main` that touches `portal-aio/VERSION`, reads the version, builds the
+  tarball via `git archive`, and creates + publishes the release as `latest`.
+  *Trade-off:* no separate publish button — the fleet push fires on merge. Accepted
+  because the VERSION-bump PR review **is** the decision to ship, and this makes
+  `main`↔release divergence structurally impossible (they move in one CI run),
+  closing the downgrade window.
+
+- **B — Publish on tag push (`v*`).** Rejected: a human pushing a tag is a
+  deliberate act, but it leaves a downgrade window open between merging the VERSION
+  bump and pushing the tag, and lets the tag drift from the `VERSION` file.
+
+- **C — Manual `workflow_dispatch` only.** Rejected as the primary trigger: keeps a
+  human finger on publish but leaves the downgrade window open until someone
+  remembers to run it — the exact failure mode this ADR exists to remove. Retained
+  as a **secondary** trigger for back-fill / re-runs.
+
+## Decision
+
+Add `.github/workflows/release-portal.yml`. Triggers: push to `main` on path
+`portal-aio/VERSION`, plus `workflow_dispatch` (ref input) for back-fill. It reads
+`portal-aio/VERSION`, and if a release for that tag does not already exist, builds
+`instance-portal.tar.gz` = `git archive` of the `portal-aio/` tree (tracked files
+only — matches the historical asset layout, excludes `.claude`/`.pytest_cache`/
+`venv`), asserts the tarball's internal `VERSION` matches, then `gh release create
+<version> --latest` at the triggering commit. Idempotent: an existing release for
+that version is a no-op.
+
+## Binding conditions
+
+- The asset is a `git archive` of `portal-aio/` with `--prefix=portal-aio/`, so it
+  extracts to `/opt/portal-aio/…` exactly as `update-portal` expects.
+- The workflow is **idempotent** — re-running for an existing release must not fail
+  or replace a published asset.
+- Only `portal-aio/VERSION` triggers it; editing portal code without bumping
+  VERSION does **not** cut a release (matches the source-of-truth model).
+- `contents: write` is the only elevated permission; auth via the default
+  `GITHUB_TOKEN`.
+
+## Consequences
+
+- Bumping `portal-aio/VERSION` on `main` ships the portal to the fleet automatically
+  and atomically — the downgrade window is eliminated.
+- The release cut is reproducible (no hand-built tarballs) and auditable (one CI run
+  per version).
+- **Accepted negative:** a merge that bumps VERSION is a fleet-wide push with no
+  post-merge pause. Mitigation: the gate is the VERSION-bump PR; rollback remains
+  "cut a higher VERSION" (unchanged from the manual path), and `--no-update-portal`
+  / pinned `PORTAL_VERSION` remain the per-instance escape hatches.
+
+## What would reverse this
+
+- If the portal delivery mechanism stops keying off the GitHub "latest" release
+  (e.g. moves to a pinned manifest or is baked into the image build), this workflow
+  is obsolete.
+- If auto-publish-on-merge proves too eager in practice (accidental fleet pushes),
+  fall back to Option C (dispatch-gated) — the job body is unchanged, only the
+  trigger flips.


### PR DESCRIPTION
Makes the Instance Portal release a CI step instead of a hand-cut tarball. Design approved as **Option A** (VERSION-change auto-publish); ADR 0015 records it with the rejected alternatives.

## What it does
`.github/workflows/release-portal.yml` — on a push to `main` touching `portal-aio/VERSION` (or manual `workflow_dispatch`):
1. reads `portal-aio/VERSION`,
2. no-op if a release for that tag already exists (idempotent),
3. builds `instance-portal.tar.gz` = `git archive` of `portal-aio/` (tracked files only — matches the historical asset layout),
4. asserts the tarball's internal VERSION matches the tag,
5. `gh release create <version> --latest` at the triggering commit.

Auth is the default `GITHUB_TOKEN` with `contents: write`; no repository secrets.

## Why auto-publish on VERSION change
`main` bakes `portal-aio/VERSION` into images, and first boot updates on **any** mismatch including **downgrade**. If `main`'s VERSION runs ahead of the latest *published* release, a fresh image downgrades itself on boot, undoing the bump. Publishing in the same CI run as the VERSION merge makes that divergence structurally impossible. The ship gate is the VERSION-bump PR review.

## Validation
YAML parses; the version-read + `git archive` + internal-VERSION-match steps were dry-run locally against `main` (asset structure matches the v3.1.1 release).

## Follow-up in this PR's wake
Once merged, I'll cut **v3.1.2** through this workflow (delete the hand-made tag/draft, dispatch the workflow) so #216/#217 ship to the fleet via CI — pending your go-ahead on the publish.