### PR TITLE
ci: harden upstream ref resolution against transient GitHub API blips

### DIFF
--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -85,13 +85,29 @@ jobs:
           fi
 
           echo "Resolving HEAD of ${{ env.A1111_BRANCH }} branch via GitHub API..."
-          RESPONSE=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ env.A1111_GITHUB_REPO }}/commits/${{ env.A1111_BRANCH }}")
+          # Retry on any non-200 (transient rate-limit / 5xx) so a single API blip
+          # does not fail the scheduled build. See run 29711096409.
+          RESPONSE=""
+          HTTP_CODE="000"
+          for attempt in 1 2 3 4 5; do
+            HTTP_CODE=$(curl -sS -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ env.A1111_GITHUB_REPO }}/commits/${{ env.A1111_BRANCH }}") || HTTP_CODE="000"
+            if [[ "$HTTP_CODE" == "200" ]]; then
+              RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
+              break
+            fi
+            echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
+            sleep 5
+          done
           COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
           COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
 
           if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
-            echo "::error::Could not resolve HEAD of ${{ env.A1111_BRANCH }} branch"
+            echo "::error::Could not resolve HEAD of ${{ env.A1111_BRANCH }} branch after 5 attempts (last HTTP $HTTP_CODE)"
+            echo "Last API response (truncated):"
+            echo "$RESPONSE" | head -c 2000
             exit 1
           fi
 

--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -85,12 +85,15 @@ jobs:
           fi
 
           echo "Resolving HEAD of ${{ env.A1111_BRANCH }} branch via GitHub API..."
-          # Retry on any non-200 (transient rate-limit / 5xx) so a single API blip
-          # does not fail the scheduled build. See run 29711096409.
+          # Retry a few times so a brief 5xx / connection blip on this one API call
+          # does not fail the scheduled build (see run 29711096409). Each attempt is
+          # time-bounded so a stalled endpoint cannot hang the job, and the jq
+          # extraction is written to not depend on `set -o pipefail` being off.
           RESPONSE=""
           HTTP_CODE="000"
           for attempt in 1 2 3 4 5; do
-            HTTP_CODE=$(curl -sS -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
+            HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 30 \
+              -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ env.A1111_GITHUB_REPO }}/commits/${{ env.A1111_BRANCH }}") || HTTP_CODE="000"
@@ -98,13 +101,16 @@ jobs:
               RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
               break
             fi
-            echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
-            sleep 5
+            if (( attempt < 5 )); then
+              echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
+              sleep 5
+            fi
           done
-          COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
-          COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
+          COMMIT_SHA_FULL=$(jq -r '.sha // empty' <<< "$RESPONSE" 2>/dev/null || true)
+          COMMIT_SHA="${COMMIT_SHA_FULL:0:7}"
+          COMMIT_DATE=$(jq -r '.commit.committer.date // empty' <<< "$RESPONSE" 2>/dev/null || true)
 
-          if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
+          if [[ -z "$COMMIT_SHA" ]]; then
             echo "::error::Could not resolve HEAD of ${{ env.A1111_BRANCH }} branch after 5 attempts (last HTTP $HTTP_CODE)"
             echo "Last API response (truncated):"
             echo "$RESPONSE" | head -c 2000

--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -97,8 +97,10 @@ jobs:
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ env.A1111_GITHUB_REPO }}/commits/${{ env.A1111_BRANCH }}") || HTTP_CODE="000"
+            # Capture the body every attempt so the failure diagnostic below shows
+            # the last error payload rather than an empty string.
+            RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json" 2>/dev/null || true)
             if [[ "$HTTP_CODE" == "200" ]]; then
-              RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
               break
             fi
             if (( attempt < 5 )); then

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -95,8 +95,10 @@ jobs:
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ env.FLUXGYM_GITHUB_REPO }}/commits/${{ env.FLUXGYM_BRANCH }}") || HTTP_CODE="000"
+            # Capture the body every attempt so the failure diagnostic below shows
+            # the last error payload rather than an empty string.
+            RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json" 2>/dev/null || true)
             if [[ "$HTTP_CODE" == "200" ]]; then
-              RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
               break
             fi
             if (( attempt < 5 )); then

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -83,13 +83,29 @@ jobs:
           fi
 
           echo "Resolving HEAD of ${{ env.FLUXGYM_BRANCH }} branch via GitHub API..."
-          RESPONSE=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ env.FLUXGYM_GITHUB_REPO }}/commits/${{ env.FLUXGYM_BRANCH }}")
+          # Retry on any non-200 (transient rate-limit / 5xx) so a single API blip
+          # does not fail the scheduled build. See run 29711096409.
+          RESPONSE=""
+          HTTP_CODE="000"
+          for attempt in 1 2 3 4 5; do
+            HTTP_CODE=$(curl -sS -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ env.FLUXGYM_GITHUB_REPO }}/commits/${{ env.FLUXGYM_BRANCH }}") || HTTP_CODE="000"
+            if [[ "$HTTP_CODE" == "200" ]]; then
+              RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
+              break
+            fi
+            echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
+            sleep 5
+          done
           COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
           COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
 
           if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
-            echo "::error::Could not resolve HEAD of ${{ env.FLUXGYM_BRANCH }} branch"
+            echo "::error::Could not resolve HEAD of ${{ env.FLUXGYM_BRANCH }} branch after 5 attempts (last HTTP $HTTP_CODE)"
+            echo "Last API response (truncated):"
+            echo "$RESPONSE" | head -c 2000
             exit 1
           fi
 

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -83,12 +83,15 @@ jobs:
           fi
 
           echo "Resolving HEAD of ${{ env.FLUXGYM_BRANCH }} branch via GitHub API..."
-          # Retry on any non-200 (transient rate-limit / 5xx) so a single API blip
-          # does not fail the scheduled build. See run 29711096409.
+          # Retry a few times so a brief 5xx / connection blip on this one API call
+          # does not fail the scheduled build (see run 29711096409). Each attempt is
+          # time-bounded so a stalled endpoint cannot hang the job, and the jq
+          # extraction is written to not depend on `set -o pipefail` being off.
           RESPONSE=""
           HTTP_CODE="000"
           for attempt in 1 2 3 4 5; do
-            HTTP_CODE=$(curl -sS -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
+            HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 30 \
+              -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ env.FLUXGYM_GITHUB_REPO }}/commits/${{ env.FLUXGYM_BRANCH }}") || HTTP_CODE="000"
@@ -96,13 +99,16 @@ jobs:
               RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
               break
             fi
-            echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
-            sleep 5
+            if (( attempt < 5 )); then
+              echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
+              sleep 5
+            fi
           done
-          COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
-          COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
+          COMMIT_SHA_FULL=$(jq -r '.sha // empty' <<< "$RESPONSE" 2>/dev/null || true)
+          COMMIT_SHA="${COMMIT_SHA_FULL:0:7}"
+          COMMIT_DATE=$(jq -r '.commit.committer.date // empty' <<< "$RESPONSE" 2>/dev/null || true)
 
-          if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
+          if [[ -z "$COMMIT_SHA" ]]; then
             echo "::error::Could not resolve HEAD of ${{ env.FLUXGYM_BRANCH }} branch after 5 attempts (last HTTP $HTTP_CODE)"
             echo "Last API response (truncated):"
             echo "$RESPONSE" | head -c 2000

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -92,12 +92,15 @@ jobs:
           fi
 
           echo "Resolving HEAD of ${{ env.WAN2GP_BRANCH }} branch via GitHub API..."
-          # Retry on any non-200 (transient rate-limit / 5xx) so a single API blip
-          # does not fail the scheduled build. See run 29711096409.
+          # Retry a few times so a brief 5xx / connection blip on this one API call
+          # does not fail the scheduled build (see run 29711096409). Each attempt is
+          # time-bounded so a stalled endpoint cannot hang the job, and the jq
+          # extraction is written to not depend on `set -o pipefail` being off.
           RESPONSE=""
           HTTP_CODE="000"
           for attempt in 1 2 3 4 5; do
-            HTTP_CODE=$(curl -sS -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
+            HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 30 \
+              -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ env.WAN2GP_GITHUB_REPO }}/commits/${{ env.WAN2GP_BRANCH }}") || HTTP_CODE="000"
@@ -105,13 +108,16 @@ jobs:
               RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
               break
             fi
-            echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
-            sleep 5
+            if (( attempt < 5 )); then
+              echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
+              sleep 5
+            fi
           done
-          COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
-          COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
+          COMMIT_SHA_FULL=$(jq -r '.sha // empty' <<< "$RESPONSE" 2>/dev/null || true)
+          COMMIT_SHA="${COMMIT_SHA_FULL:0:7}"
+          COMMIT_DATE=$(jq -r '.commit.committer.date // empty' <<< "$RESPONSE" 2>/dev/null || true)
 
-          if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
+          if [[ -z "$COMMIT_SHA" ]]; then
             echo "::error::Could not resolve HEAD of ${{ env.WAN2GP_BRANCH }} branch after 5 attempts (last HTTP $HTTP_CODE)"
             echo "Last API response (truncated):"
             echo "$RESPONSE" | head -c 2000

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -92,13 +92,29 @@ jobs:
           fi
 
           echo "Resolving HEAD of ${{ env.WAN2GP_BRANCH }} branch via GitHub API..."
-          RESPONSE=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ env.WAN2GP_GITHUB_REPO }}/commits/${{ env.WAN2GP_BRANCH }}")
+          # Retry on any non-200 (transient rate-limit / 5xx) so a single API blip
+          # does not fail the scheduled build. See run 29711096409.
+          RESPONSE=""
+          HTTP_CODE="000"
+          for attempt in 1 2 3 4 5; do
+            HTTP_CODE=$(curl -sS -w '%{http_code}' -o "$RUNNER_TEMP/upstream-commit.json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ env.WAN2GP_GITHUB_REPO }}/commits/${{ env.WAN2GP_BRANCH }}") || HTTP_CODE="000"
+            if [[ "$HTTP_CODE" == "200" ]]; then
+              RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
+              break
+            fi
+            echo "Attempt $attempt/5: GitHub API returned HTTP $HTTP_CODE, retrying in 5s..."
+            sleep 5
+          done
           COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
           COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
 
           if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
-            echo "::error::Could not resolve HEAD of ${{ env.WAN2GP_BRANCH }} branch"
+            echo "::error::Could not resolve HEAD of ${{ env.WAN2GP_BRANCH }} branch after 5 attempts (last HTTP $HTTP_CODE)"
+            echo "Last API response (truncated):"
+            echo "$RESPONSE" | head -c 2000
             exit 1
           fi
 

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -104,8 +104,10 @@ jobs:
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ env.WAN2GP_GITHUB_REPO }}/commits/${{ env.WAN2GP_BRANCH }}") || HTTP_CODE="000"
+            # Capture the body every attempt so the failure diagnostic below shows
+            # the last error payload rather than an empty string.
+            RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json" 2>/dev/null || true)
             if [[ "$HTTP_CODE" == "200" ]]; then
-              RESPONSE=$(cat "$RUNNER_TEMP/upstream-commit.json")
               break
             fi
             if (( attempt < 5 )); then


### PR DESCRIPTION
## What

The scheduled image builds resolve the upstream repo's HEAD via a single unguarded `curl` to `api.github.com/repos/<repo>/commits/<branch>`. With no HTTP-status check and no retry, any non-200 response (rate limit, brief 5xx) yields an empty `.sha`, trips the guard, and turns a transient blip into a **red build** — while logging nothing, so the next flake is undiagnosable.

Run [29711096409](https://github.com/vast-ai/base-image/actions/runs/29711096409/job/88255002510) (*Build Wan2GP Image*, 2026-07-20 01:33 UTC) failed exactly this way with `Could not resolve HEAD of main branch`. The `main` branch was fine — the very next scheduled run (13:32 UTC) passed with no change.

## Change

Wrap the API call in a 5-attempt loop that:
- checks the HTTP status and retries any non-200 (rate-limit / 5xx),
- resolves on the first 200,
- on final failure surfaces the last HTTP code and a truncated response body for diagnosis.

Applied to the three workflows that hard-`exit 1` on this path:
- `build-wan2gp.yml`
- `build-a1111.yml`
- `build-fluxgym.yml`

**Left as-is** (already resilient):
- `build-ace-step.yml`, `build-sd-forge.yml` — degrade gracefully (`::warning::` + continue/`exit 0`, never a red build).
- `build-ostris-ai-toolkit.yml` — resolves via `git ls-remote` (not rate-limited).

## Verification

- `yaml.safe_load` passes on all three files; `bash -n` on the new block passes.
- Ran the loop against the live API: happy path resolves `deepbeepmeep/Wan2GP@main` = `6af9481` on the first 200; a nonexistent branch retries and then hits the error path with the real HTTP code (422) surfaced.

---
Tracked in [CON-1618](https://vastai.atlassian.net/browse/CON-1618).