### PR TITLE
ci: harden upstream-release checks against transient network blips

### DIFF
--- a/.github/actions/check-dockerhub-release/action.yml
+++ b/.github/actions/check-dockerhub-release/action.yml
@@ -46,7 +46,8 @@ runs:
       run: |
         echo "Fetching tags from DockerHub for ${{ inputs.repository }}..."
         
-        RESPONSE=$(curl -sfS "https://hub.docker.com/v2/repositories/${{ inputs.repository }}/tags?page_size=100&ordering=last_updated" || echo "")
+        RESPONSE=$(curl -sfS --retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30 \
+          "https://hub.docker.com/v2/repositories/${{ inputs.repository }}/tags?page_size=100&ordering=last_updated" || echo "")
         
         if [[ -z "$RESPONSE" ]]; then
           echo "::warning::Failed to fetch tags from DockerHub"

--- a/.github/actions/check-ghcr-release/action.yml
+++ b/.github/actions/check-ghcr-release/action.yml
@@ -75,12 +75,12 @@ runs:
           fi
 
           if [[ -n "$AUTH_HEADER" ]]; then
-            RESPONSE=$(curl -sfS \
+            RESPONSE=$(curl -sfS --retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30 \
               -H "Accept: application/vnd.github+json" \
               -H "$AUTH_HEADER" \
               "https://api.github.com/orgs/${{ inputs.owner }}/packages/container/${{ inputs.package }}/versions?per_page=100&page=${page}" 2>/dev/null || echo "")
           else
-            RESPONSE=$(curl -sfS \
+            RESPONSE=$(curl -sfS --retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30 \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/orgs/${{ inputs.owner }}/packages/container/${{ inputs.package }}/versions?per_page=100&page=${page}" 2>/dev/null || echo "")
           fi

--- a/.github/actions/check-github-release/action.yml
+++ b/.github/actions/check-github-release/action.yml
@@ -80,6 +80,7 @@ runs:
         
         if [[ "$HTTP_CODE" != "200" ]]; then
           echo "::warning::GitHub API returned $HTTP_CODE"
+          echo "Response (truncated): $(echo "$BODY" | head -c 500)"
           echo "new-release=${{ inputs.trigger != 'schedule' }}" >> $GITHUB_OUTPUT
           exit 0
         fi

--- a/.github/actions/check-github-release/action.yml
+++ b/.github/actions/check-github-release/action.yml
@@ -67,7 +67,10 @@ runs:
           AUTH_HEADER="Authorization: Bearer $GH_TOKEN"
         fi
         
-        HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+        # --retry rides out transient 5xx/connection blips; the timeouts bound
+        # each attempt so a stalled endpoint cannot hang the job.
+        HTTP_RESPONSE=$(curl -sS --retry 5 --retry-max-time 60 \
+          --connect-timeout 10 --max-time 30 -w "\n%{http_code}" \
           -H "Accept: application/vnd.github+json" \
           ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
           "https://api.github.com/repos/${{ inputs.repository }}/releases?per_page=10")
@@ -139,13 +142,23 @@ runs:
         # Optionally resolve master/main to commit hash
         if [[ "${{ inputs.resolve-master-to-commit }}" == "true" && ("$REF" == "master" || "$REF" == "main") ]]; then
           echo "Resolving $REF → HEAD commit"
-          COMMIT=$(git ls-remote "https://github.com/${{ inputs.repository }}.git" "refs/heads/$REF" | cut -f1 | cut -c1-7)
+          COMMIT=""
+          for attempt in 1 2 3; do
+            COMMIT=$(git ls-remote "https://github.com/${{ inputs.repository }}.git" "refs/heads/$REF" 2>/dev/null | cut -f1 | cut -c1-7) || COMMIT=""
+            [[ -n "$COMMIT" ]] && break
+            if (( attempt < 3 )); then
+              echo "Attempt $attempt/3: could not resolve $REF via ls-remote, retrying in 3s..."
+              sleep 3
+            fi
+          done
           if [[ -n "$COMMIT" ]]; then
             REF="$COMMIT"
             echo "Resolved to: $REF"
           else
-            echo "::warning::Could not resolve HEAD, using fallback"
-            REF="$(date -u +%Y%m%d-%H%M)"
+            # Never fall back to a synthetic value: a timestamp is not a valid git
+            # ref and only defers the failure to a confusing checkout error later.
+            echo "::error::Could not resolve HEAD of $REF for ${{ inputs.repository }} after 3 attempts"
+            exit 1
           fi
         fi
         

--- a/.github/actions/check-github-release/action.yml
+++ b/.github/actions/check-github-release/action.yml
@@ -73,7 +73,10 @@ runs:
           --connect-timeout 10 --max-time 30 -w "\n%{http_code}" \
           -H "Accept: application/vnd.github+json" \
           ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
-          "https://api.github.com/repos/${{ inputs.repository }}/releases?per_page=10")
+          "https://api.github.com/repos/${{ inputs.repository }}/releases?per_page=10") || HTTP_RESPONSE=$'\n000'
+        # A connection-level failure (curl non-zero, no HTTP response) is caught
+        # above so bash -e does not kill the step: HTTP_CODE parses as 000 and we
+        # fall through to the non-200 warning + graceful-skip path below.
         
         HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n1)
         BODY=$(echo "$HTTP_RESPONSE" | sed '$d')

--- a/.github/actions/check-pypi-release/action.yml
+++ b/.github/actions/check-pypi-release/action.yml
@@ -84,10 +84,13 @@ runs:
         fi
 
         RESPONSE_FILE=$(mktemp)
+        # Guard the `|| HTTP_CODE=000` OUTSIDE the substitution: on a connection
+        # failure curl still prints `000` via -w, so a `|| echo "000"` inside the
+        # $() would append a second `000` and yield HTTP_CODE=000000.
         HTTP_CODE=$(curl -sS --retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30 \
           -o "$RESPONSE_FILE" -w "%{http_code}" \
           -H "Accept: application/json" \
-          "https://pypi.org/pypi/${PKG}/json" || echo "000")
+          "https://pypi.org/pypi/${PKG}/json") || HTTP_CODE="000"
 
         if [[ "$HTTP_CODE" != "200" ]]; then
           echo "::warning::PyPI API returned $HTTP_CODE for ${PKG}"

--- a/.github/actions/check-pypi-release/action.yml
+++ b/.github/actions/check-pypi-release/action.yml
@@ -84,7 +84,8 @@ runs:
         fi
 
         RESPONSE_FILE=$(mktemp)
-        HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" \
+        HTTP_CODE=$(curl -sS --retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30 \
+          -o "$RESPONSE_FILE" -w "%{http_code}" \
           -H "Accept: application/json" \
           "https://pypi.org/pypi/${PKG}/json" || echo "000")
 

--- a/.github/actions/check-pypi-release/action.yml
+++ b/.github/actions/check-pypi-release/action.yml
@@ -91,6 +91,7 @@ runs:
 
         if [[ "$HTTP_CODE" != "200" ]]; then
           echo "::warning::PyPI API returned $HTTP_CODE for ${PKG}"
+          echo "Response (truncated): $(head -c 500 "$RESPONSE_FILE" 2>/dev/null)"
           if [[ "$TRIGGER" != "schedule" ]]; then
             # Manual trigger: proceed with whatever fallback the caller gave us.
             # No fallback means the caller asked for "latest" but we can't

--- a/.github/workflows/build-aio-studio.yml
+++ b/.github/workflows/build-aio-studio.yml
@@ -137,7 +137,16 @@ jobs:
           if [[ -n "${{ inputs.FORGE_REF }}" ]]; then
             echo "ref=${{ inputs.FORGE_REF }}" >> $GITHUB_OUTPUT
           else
-            REF=$(git ls-remote https://github.com/Haoming02/sd-webui-forge-classic.git HEAD | cut -f1 | cut -c1-7)
+            REF=""
+            for attempt in 1 2 3; do
+              REF=$(git ls-remote https://github.com/Haoming02/sd-webui-forge-classic.git HEAD 2>/dev/null | cut -f1 | cut -c1-7) || REF=""
+              if [[ -n "$REF" ]]; then break; fi
+              if (( attempt < 3 )); then echo "Attempt $attempt/3: ls-remote failed, retrying in 3s..."; sleep 3; fi
+            done
+            if [[ -z "$REF" ]]; then
+              echo "::error::Could not resolve HEAD of Haoming02/sd-webui-forge-classic after 3 attempts"
+              exit 1
+            fi
             echo "ref=${REF}" >> $GITHUB_OUTPUT
           fi
 
@@ -148,7 +157,16 @@ jobs:
           if [[ -n "${{ inputs.AI_TOOLKIT_REF }}" ]]; then
             echo "ref=${{ inputs.AI_TOOLKIT_REF }}" >> $GITHUB_OUTPUT
           else
-            REF=$(git ls-remote https://github.com/ostris/ai-toolkit.git HEAD | cut -f1 | cut -c1-7)
+            REF=""
+            for attempt in 1 2 3; do
+              REF=$(git ls-remote https://github.com/ostris/ai-toolkit.git HEAD 2>/dev/null | cut -f1 | cut -c1-7) || REF=""
+              if [[ -n "$REF" ]]; then break; fi
+              if (( attempt < 3 )); then echo "Attempt $attempt/3: ls-remote failed, retrying in 3s..."; sleep 3; fi
+            done
+            if [[ -z "$REF" ]]; then
+              echo "::error::Could not resolve HEAD of ostris/ai-toolkit after 3 attempts"
+              exit 1
+            fi
             echo "ref=${REF}" >> $GITHUB_OUTPUT
           fi
 
@@ -159,7 +177,16 @@ jobs:
           if [[ -n "${{ inputs.WAN2GP_REF }}" ]]; then
             echo "ref=${{ inputs.WAN2GP_REF }}" >> $GITHUB_OUTPUT
           else
-            REF=$(git ls-remote https://github.com/deepbeepmeep/Wan2GP.git HEAD | cut -f1 | cut -c1-7)
+            REF=""
+            for attempt in 1 2 3; do
+              REF=$(git ls-remote https://github.com/deepbeepmeep/Wan2GP.git HEAD 2>/dev/null | cut -f1 | cut -c1-7) || REF=""
+              if [[ -n "$REF" ]]; then break; fi
+              if (( attempt < 3 )); then echo "Attempt $attempt/3: ls-remote failed, retrying in 3s..."; sleep 3; fi
+            done
+            if [[ -z "$REF" ]]; then
+              echo "::error::Could not resolve HEAD of deepbeepmeep/Wan2GP after 3 attempts"
+              exit 1
+            fi
             echo "ref=${REF}" >> $GITHUB_OUTPUT
           fi
 
@@ -167,7 +194,16 @@ jobs:
         id: ace-step-ui
         shell: bash
         run: |
-          REF=$(git ls-remote https://github.com/fspecii/ace-step-ui.git HEAD | cut -f1 | cut -c1-7)
+          REF=""
+          for attempt in 1 2 3; do
+            REF=$(git ls-remote https://github.com/fspecii/ace-step-ui.git HEAD 2>/dev/null | cut -f1 | cut -c1-7) || REF=""
+            if [[ -n "$REF" ]]; then break; fi
+            if (( attempt < 3 )); then echo "Attempt $attempt/3: ls-remote failed, retrying in 3s..."; sleep 3; fi
+          done
+          if [[ -z "$REF" ]]; then
+            echo "::error::Could not resolve HEAD of fspecii/ace-step-ui after 3 attempts"
+            exit 1
+          fi
           echo "ref=${REF}" >> $GITHUB_OUTPUT
 
       - name: Generate image tag

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -108,9 +108,12 @@ jobs:
 
             # Query GitHub API for latest commit SHA and date. --retry rides out
             # transient 5xx/connection blips; timeouts bound each attempt.
+            # `|| RESPONSE='{}'` catches a connection-level curl failure (after
+            # retries) so bash -e doesn't kill the job: an empty JSON object makes
+            # COMMIT_SHA resolve to "null" and hit the warn + continue guard below.
             RESPONSE=$(curl -sS --retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30 \
               -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/${repo}/commits/${branch}")
+              "https://api.github.com/repos/${repo}/commits/${branch}") || RESPONSE='{}'
 
             COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
             COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -106,8 +106,10 @@ jobs:
               continue
             fi
 
-            # Query GitHub API for latest commit SHA and date
-            RESPONSE=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+            # Query GitHub API for latest commit SHA and date. --retry rides out
+            # transient 5xx/connection blips; timeouts bound each attempt.
+            RESPONSE=$(curl -sS --retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30 \
+              -H "Authorization: Bearer $GH_TOKEN" \
               "https://api.github.com/repos/${repo}/commits/${branch}")
 
             COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)


### PR DESCRIPTION
Follow-up to #221. That PR hardened the three workflows that *inline* the upstream ref lookup; this one hardens the shared **`check-*-release` composite actions** and two remaining workflows that resolve upstream state with single, unguarded network calls.

## Why
A brief 5xx / connection blip on one of these calls currently surfaces as a missed release-detection cycle (silent) or, on manual dispatch, a red build — the same class of failure as the [run 29711096409](https://github.com/vast-ai/base-image/actions/runs/29711096409) that motivated #221. These actions back ~13 workflows, so they're higher leverage than the three leaf files.

## Changes
- **`check-github-release`** (7 consumers: comfyui, invokeai, llama-cpp, openwebui, voicebox, whisper, aio-studio), **`check-dockerhub-release`** (5: ollama, ostris, sglang, vllm, vllm-omni), **`check-ghcr-release`**, **`check-pypi-release`**: add `--retry 5 --retry-max-time 60 --connect-timeout 10 --max-time 30` to the API calls. `--retry` rides out transient 5xx/connection errors (honoring `Retry-After`, bounded to 60s total); the timeouts bound each attempt so a stalled endpoint can't hang the job.
- **`check-github-release`** — the master/main `ls-remote` fallback used to set `REF="$(date …)"`, a timestamp that is not a valid git ref and just defers the failure to a confusing checkout error later. Now retries the `ls-remote` and **fails with a clear error** instead.
- **`build-aio-studio`** — the four bare `git ls-remote … HEAD` resolves had no retry and no empty guard (a transient blip hard-failed the step via errexit; an empty result produced a blank ref). Added a 3-attempt retry + explicit empty guard to each.
- **`build-sd-forge`** — `curl -s` (silent, single attempt) → `-sS` with the same retry/timeout flags.

## Not changed (deliberately)
The `::warning::` + skip-on-schedule behavior in the release checks is left intact — a transient blip on a scheduled run correctly means "no new release this cycle," and the next run picks it up. This PR only makes that path more resilient and stops it from hard-failing manual builds on a recoverable blip.

## Verification
- YAML parses on all six files.
- Composite `shell: bash` runs with `-eo pipefail`; every added bash block was checked to be errexit/pipefail-safe (ls-remote retry loops, `&& break` short-circuit, empty-body handling) under `bash -eo pipefail`.
- curl flag combinations and the combined body+code parsing exercised against the live GitHub and DockerHub APIs (HTTP 200, correct parse; bogus repo → clean error path, no crash).

Depends on nothing in #221 — independent branch off `main`; the two can merge in either order.

---
Tracked in [CON-1618](https://vastai.atlassian.net/browse/CON-1618).