### PR TITLE
feat(oobabooga): ADR-0004 accel/torch reconciliation + CI

### DIFF
--- a/.github/workflows/build-oobabooga.yml
+++ b/.github/workflows/build-oobabooga.yml
@@ -1,18 +1,32 @@
-# STUB (default-branch enabler) — NOT the real build.
+# Build Oobabooga (Text Generation WebUI) image - works on main repo (scheduled +
+# manual) and forks (manual).
+# Required repository secrets:
+#   DOCKERHUB_USERNAME
+#   DOCKERHUB_TOKEN
+#   DOCKERHUB_NAMESPACE          - production namespace (final multi-arch index lives here)
+#   DOCKERHUB_NAMESPACE_STAGING  - staging namespace (per-arch build artifacts live here)
+# Optional: SLACK_WEBHOOK_URL
 #
-# A `workflow_dispatch` workflow is only triggerable once it exists on the default
-# branch. This stub registers the trigger so the real Build Oobabooga workflow can be
-# manually dispatched FROM the feature branch (feature/oobabooga-adr0004-ci), where the
-# full workflow + the oobabooga image live. When dispatched against that branch, GitHub
-# runs THAT branch's version of this file (the real build), not this stub.
+# Release detection: resolves HEAD of the upstream main branch (like the sibling
+# derivative workflows). The Dockerfile derives its accelerator-wheel handling from
+# the resolved ref's requirements at build time, so CI always tracks latest. A
+# scheduled run skips if the latest upstream commit is older than COMMIT_AGE_THRESHOLD;
+# a manual OOBABOOGA_REF input overrides. There is an accepted risk a new ref breaks
+# the build (a missing cp312 accel wheel, a new torch minor) — it fails LOUDLY and
+# the planned live-GPU QA gate (ADR 0005, not yet built) is the intended runtime
+# net (ADR 0004).
 #
-# Intentionally NO `schedule:` here — main must not auto-run a build it cannot satisfy
-# (the oobabooga image files are not on main yet). Running this stub from main is a no-op.
-# This file is replaced by the real workflow when the feature PR (#207) merges.
+# Currently amd64-only: oobabooga's accelerator wheels (exllamav3, flash_attn,
+# xformers, llama_cpp_binaries) publish x86_64-only wheels. Re-enable arm64 when
+# those gain aarch64 CUDA wheels (and update merge-manifests `arches` below).
 
 name: Build Oobabooga Image
 
 on:
+  schedule:
+    # Run every 12 hours (staggered from sibling derivatives)
+    - cron: '50 5,17 * * *'
+
   workflow_dispatch:
     inputs:
       OOBABOOGA_REF:
@@ -26,14 +40,263 @@ on:
         description: "Custom tag (Auto default)"
         required: false
 
+env:
+  DEFAULT_DOCKERHUB_REPO: "oobabooga"
+  OOBABOOGA_GITHUB_REPO: "oobabooga/text-generation-webui"
+  OOBABOOGA_BRANCH: "main"
+  # 12 hours (matches the schedule cron) — scheduled runs skip if the latest
+  # upstream commit is older than this.
+  COMMIT_AGE_THRESHOLD: 43200
+
 jobs:
-  stub:
+  preflight:
     runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.decision.outputs.should-run }}
+      oobabooga-ref: ${{ steps.resolve-ref.outputs.ref }}
     steps:
-      - name: Explain
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for required secrets
+        id: secrets
         run: |
-          echo "This is the main-branch STUB for 'Build Oobabooga Image'."
-          echo "It exists only to enable workflow_dispatch."
-          echo "To run the real build, dispatch this workflow against the branch"
-          echo "feature/oobabooga-adr0004-ci (Run workflow -> Use workflow from -> that branch)."
-          echo "That branch carries the full build + the oobabooga image."
+          missing=()
+          [[ -z "${{ secrets.DOCKERHUB_USERNAME }}" ]] && missing+=("DOCKERHUB_USERNAME")
+          [[ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]] && missing+=("DOCKERHUB_TOKEN")
+          [[ -z "${{ secrets.DOCKERHUB_NAMESPACE }}" ]] && missing+=("DOCKERHUB_NAMESPACE")
+          [[ -z "${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}" ]] && missing+=("DOCKERHUB_NAMESPACE_STAGING")
+          if [[ ${#missing[@]} -eq 0 ]]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+            echo "Required secrets configured"
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - missing secrets: ${missing[*]}"
+          fi
+
+      - name: Resolve Oobabooga git ref
+        id: resolve-ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MANUAL_REF="${{ inputs.OOBABOOGA_REF }}"
+
+          if [[ -n "$MANUAL_REF" ]]; then
+            echo "Using manual ref: $MANUAL_REF"
+            echo "ref=$MANUAL_REF" >> $GITHUB_OUTPUT
+            echo "commit-age=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Resolving HEAD of ${{ env.OOBABOOGA_BRANCH }} branch via GitHub API..."
+          # -L: the upstream repo path 301-redirects; follow it.
+          RESPONSE=$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ env.OOBABOOGA_GITHUB_REPO }}/commits/${{ env.OOBABOOGA_BRANCH }}")
+          COMMIT_SHA=$(echo "$RESPONSE" | jq -r '.sha' | cut -c1-7)
+          COMMIT_DATE=$(echo "$RESPONSE" | jq -r '.commit.committer.date')
+
+          if [[ "$COMMIT_SHA" == "null" || -z "$COMMIT_SHA" ]]; then
+            echo "::error::Could not resolve HEAD of ${{ env.OOBABOOGA_BRANCH }} branch"
+            exit 1
+          fi
+
+          COMMIT_EPOCH=$(date -d "$COMMIT_DATE" +%s)
+          NOW_EPOCH=$(date +%s)
+          AGE=$((NOW_EPOCH - COMMIT_EPOCH))
+
+          echo "Resolved ${{ env.OOBABOOGA_BRANCH }} -> $COMMIT_SHA (${AGE}s old)"
+          echo "ref=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "commit-age=$AGE" >> $GITHUB_OUTPUT
+
+      - name: Determine if build should run
+        id: decision
+        run: |
+          SECRETS="${{ steps.secrets.outputs.available }}"
+          TRIGGER="${{ github.event_name }}"
+          RESOLVED_REF="${{ steps.resolve-ref.outputs.ref }}"
+          COMMIT_AGE="${{ steps.resolve-ref.outputs.commit-age }}"
+
+          if [[ "$SECRETS" != "true" ]]; then
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - Required secrets not configured"
+          elif [[ "$TRIGGER" == "workflow_dispatch" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "Manual build for ref: $RESOLVED_REF"
+          elif [[ "$COMMIT_AGE" -le "${{ env.COMMIT_AGE_THRESHOLD }}" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "Scheduled build for ref: $RESOLVED_REF (${COMMIT_AGE}s old <= ${{ env.COMMIT_AGE_THRESHOLD }}s threshold)"
+          else
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping scheduled build - latest upstream commit is ${COMMIT_AGE}s old (threshold ${{ env.COMMIT_AGE_THRESHOLD }}s)"
+          fi
+
+  build:
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: ${{ matrix.arch.runs_on }}
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image:
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+        # arm64 is intentionally absent: oobabooga's accelerator wheels
+        # (exllamav3, flash_attn, xformers, llama_cpp_binaries) are x86_64-only.
+        # Re-add the arm64 entry once those gain aarch64 CUDA wheels (and update
+        # merge-manifests `arches` below).
+        arch:
+          - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: ./.github/actions/maximize-build-space
+
+      - name: Derive staging tag
+        run: |
+          PYTORCH_BASE="${{ matrix.base_image }}"
+          TAG="${PYTORCH_BASE##*:}"
+
+          CUDA_VERSION=$(echo "$TAG" | sed -n 's/.*cuda-\([0-9.]*\).*/\1/p')
+
+          if [[ -z "$CUDA_VERSION" ]]; then
+            echo "::error::Failed to parse base image: $PYTORCH_BASE"
+            exit 1
+          fi
+
+          OOBABOOGA_REF="${{ needs.preflight.outputs.oobabooga-ref }}"
+          BUILD_DATE=$(date -u +%Y-%m-%d)
+
+          IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
+          if [[ -z "$IMAGE_TAG_BASE" ]]; then
+            IMAGE_TAG_BASE="${OOBABOOGA_REF}-${BUILD_DATE}-cuda-${CUDA_VERSION}"
+          fi
+
+          DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
+          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+
+          echo "STAGING_TAG_BASE=$STAGING_TAG_BASE" >> $GITHUB_ENV
+
+          echo "Derived staging tag base: $STAGING_TAG_BASE (arch=${{ matrix.arch.suffix }})"
+
+      - name: Build and push arch image to staging
+        uses: ./.github/actions/build-arch-image
+        with:
+          context: derivatives/pytorch/derivatives/oobabooga
+          arch: ${{ matrix.arch.platform }}
+          tag-base: ${{ env.STAGING_TAG_BASE }}
+          build-args: |
+            PYTORCH_BASE=${{ matrix.base_image }}
+            OOBABOOGA_REF=${{ needs.preflight.outputs.oobabooga-ref }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  merge-manifests:
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image:
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Derive image tags
+        run: |
+          PYTORCH_BASE="${{ matrix.base_image }}"
+          TAG="${PYTORCH_BASE##*:}"
+
+          CUDA_VERSION=$(echo "$TAG" | sed -n 's/.*cuda-\([0-9.]*\).*/\1/p')
+
+          OOBABOOGA_REF="${{ needs.preflight.outputs.oobabooga-ref }}"
+          BUILD_DATE=$(date -u +%Y-%m-%d)
+
+          IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
+          if [[ -z "$IMAGE_TAG_BASE" ]]; then
+            IMAGE_TAG_BASE="${OOBABOOGA_REF}-${BUILD_DATE}-cuda-${CUDA_VERSION}"
+          fi
+
+          DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
+          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+          PROD_TAG="${{ secrets.DOCKERHUB_NAMESPACE }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+
+          echo "STAGING_TAG_BASE=$STAGING_TAG_BASE" >> $GITHUB_ENV
+          echo "PROD_TAG=$PROD_TAG" >> $GITHUB_ENV
+
+          MATRIX_ID=$(echo "$PYTORCH_BASE" | md5sum | cut -c1-8)
+          echo "MATRIX_ID=$MATRIX_ID" >> $GITHUB_ENV
+
+      - name: Assemble multi-arch index in production
+        uses: ./.github/actions/merge-arch-manifests
+        with:
+          target-tag: ${{ env.PROD_TAG }}
+          source-tag-base: ${{ env.STAGING_TAG_BASE }}
+          # amd64-only until the accelerator wheels gain aarch64 CUDA wheels
+          # (see build matrix comment above). Add `arm64` back here when the
+          # build matrix gains arm64.
+          arches: amd64
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Record merged manifest tag
+        run: |
+          mkdir -p built-tags
+          echo "${{ env.PROD_TAG }}" > built-tags/tag-${{ env.MATRIX_ID }}.txt
+
+      - name: Upload manifest tag
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-tag-${{ env.MATRIX_ID }}
+          path: built-tags/
+          retention-days: 1
+
+  collect-tags:
+    needs: [preflight, build, merge-manifests]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      all-tags: ${{ steps.collect.outputs.tags }}
+    steps:
+      - name: Download all tag artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: built-tag-*
+          path: all-tags/
+          merge-multiple: true
+
+      - name: Aggregate tags
+        id: collect
+        run: |
+          if [ -d all-tags ] && [ "$(ls -A all-tags 2>/dev/null)" ]; then
+            TAGS=$(cat all-tags/*.txt | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "Found tags: $TAGS"
+          else
+            echo "::warning::No tags found - build may have failed"
+            TAGS="[]"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+  notify:
+    needs: [preflight, build, merge-manifests, collect-tags]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    uses: ./.github/workflows/notify-slack.yml
+    with:
+      build-result: ${{ needs.merge-manifests.result }}
+      image-name: "Oobabooga"
+      image-ref: ${{ needs.preflight.outputs.oobabooga-ref }}
+      image-tags: ${{ needs.collect-tags.outputs.all-tags }}
+      trigger: ${{ github.event_name }}
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/derivatives/pytorch/derivatives/oobabooga/Dockerfile
+++ b/derivatives/pytorch/derivatives/oobabooga/Dockerfile
@@ -86,13 +86,5 @@ RUN \
     torch_versions_post="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
     { [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem version drift:"; diff <(echo "$torch_versions_pre") <(echo "$torch_versions_post"); exit 1; }; }
 
-# EXPOSE the Caddy-front (external) ports this image's baked PORTAL_CONFIG
-# declares: Instance Portal (1111), Jupyter (8080), Text Generation WebUI (7860),
-# Oobabooga API (5000). EXPOSE drives Vast's port auto-map so Caddy proxies them;
-# the base overlays via a COPY (not FROM), so its ports are NOT inherited and a
-# derivative that bakes a default must declare the full front set itself
-# (ADR 0002). Never EXPOSE the loopback internals (11111 / 18080 / 17860 / 15000).
-EXPOSE 1111 8080 7860 5000
-
 # Defend against environment clashes when syncing to volume
 RUN env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/oobabooga/Dockerfile
+++ b/derivatives/pytorch/derivatives/oobabooga/Dockerfile
@@ -17,39 +17,82 @@ RUN \
     set -euo pipefail && \
     [[ -n "${OOBABOOGA_REF}" ]] || { echo "Must specify OOBABOOGA_REF" && exit 1; } && \
     . /venv/main/bin/activate && \
-    # We have PyTorch pre-installed so we will check at the end of the install that it has not been clobbered
-    # Snapshot the base's full torch ecosystem (torch + torchvision + torchaudio + torchcodec).
+    # Snapshot the base's full torch ecosystem; the drift-guard at the end asserts
+    # it is byte-identical post-install (the base stays the single source of truth).
     torch_versions_pre="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
-    # xformers publishes amd64-only CUDA wheels; skip on other arches
-    # (e.g. aarch64/sbsa for Grace Blackwell) so dependency resolution does
-    # not fail the build. dpkg --print-architecture reflects the actual
-    # container arch — unlike ${TARGETARCH:-amd64}, it doesn't silently
-    # mis-select amd64 when buildx hasn't injected TARGETARCH.
-    EXTRA_ACCEL_PKGS="" && \
-    if [[ "$(dpkg --print-architecture)" == "amd64" ]]; then \
-        EXTRA_ACCEL_PKGS="xformers"; \
-    fi && \
-    # Pin to the inherited torch version. Fail build on dependency resolution if matching version is unavailable
-    uv pip install --no-cache-dir ${EXTRA_ACCEL_PKGS} torch=="${PYTORCH_VERSION}" --torch-backend "${PYTORCH_BACKEND}" && \
-    # Get Oobabooga and install dependencies
+    # Declarative "the torch ecosystem must not move" floor, applied to the upstream
+    # requirements install below — the base owns torch. xformers is NOT pinned here:
+    # it arrives via the ref's own accel URL (installed --no-deps), internally
+    # consistent with the exllamav3 wheel from the same ref.
+    printf 'torch==%s\ntorchvision\ntorchaudio\ntorchcodec\n' "${PYTORCH_VERSION}" > /tmp/torch-constraints.txt && \
+    ARCH="$(dpkg --print-architecture)" && \
+    # Get Oobabooga at the CI-resolved ref (latest upstream HEAD, or a manual ref).
     cd /opt/workspace-internal && \
     git clone https://github.com/oobabooga/text-generation-webui && \
     cd /opt/workspace-internal/text-generation-webui && \
     git checkout "${OOBABOOGA_REF}" && \
-    # Upstream requirements pin CUDA wheels to cp313 — rewrite for cp312
-    sed -i 's/cp313-cp313/cp312-cp312/g; s/python_version == "3.13"/python_version == "3.12"/g' \
-        requirements/full/requirements.txt && \
-    # Strip base-provided torch ecosystem pins from upstream requirements so
-    # the pytorch base remains the single source of truth.
-    sed -i -E '/^(torch|torchvision|torchaudio|torchcodec)([[:space:]]|[<>=!])/d' requirements/full/requirements.txt && \
-    uv pip install --no-cache-dir \
-        -r requirements/full/requirements.txt && \
+    REQ=requirements/full/requirements.txt && \
+    # The accel handling is derived from THIS ref's requirements at build time
+    # (REF-agnostic) so CI always tracks the latest upstream. There is a real risk
+    # a future ref breaks here (a missing cp312 wheel, a new torch minor); that is
+    # accepted — every check below fails the build LOUDLY rather than degrade
+    # silently, and the planned live-GPU QA gate (ADR 0005) is the intended runtime
+    # net. See ADR 0004.
+    # The base is py312; upstream pins its prebuilt CUDA accel wheels to cp313 —
+    # rewrite the ABI tag + the python_version marker so they select on py312.
+    sed -i 's/cp313-cp313/cp312-cp312/g; s/python_version == "3.13"/python_version == "3.12"/g' "$REQ" && \
+    # Base pytorch is the single source of truth for the torch ecosystem.
+    sed -i -E '/^(torch|torchvision|torchaudio|torchcodec)([[:space:]]|[<>=!])/d' "$REQ" && \
+    # Split the externally-hosted accelerator wheels out by STABLE host/org token
+    # (REF-agnostic — survives version bumps, unlike a pinned filename). They carry
+    # foreign torch/xformers METADATA pins (e.g. exllamav3 -> torch==2.9.0);
+    # installing them --no-deps keeps the base torch 2.9.1 (patch-ABI compatible)
+    # and avoids a downgrade that would trip the drift-guard.
+    ACCEL_RE='github\.com/(turboderp-org/exllamav3|mjun0812/flash-attention-prebuild-wheels|oobabooga/llama-cpp-binaries)|download\.pytorch\.org/whl/[^ ]*xformers-' && \
+    grep -E "$ACCEL_RE" "$REQ" > /tmp/ooba-accel.txt || true && \
+    grep -vE "$ACCEL_RE" "$REQ" > /tmp/ooba-rest.txt && \
+    # Fail LOUD if a COMPILED wheel URL leaked into the rest install: that means
+    # ACCEL_RE missed an externally-hosted accel host, so the wheel would install
+    # WITH deps and could carry a foreign torch/xformers pin nothing catches. Only
+    # compiled wheels qualify — a py3-none-* wheel (e.g. upstream's own custom
+    # gradio fork) is pure-python and legitimately belongs in the rest install; a
+    # torch metadata pin in such a wheel is already caught by the constraints floor.
+    LEAKED_WHEELS="$(grep -E 'https?://[^ ]+\.whl' /tmp/ooba-rest.txt | grep -vE 'py3-none-' || true)" && \
+    if [ -n "$LEAKED_WHEELS" ]; then \
+        echo "::error:: a compiled wheel URL leaked into the rest install — ACCEL_RE missed an accel host:"; \
+        echo "$LEAKED_WHEELS"; exit 1; \
+    fi && \
+    # Install the rest FIRST under the torch constraints, then the ref's accel
+    # wheels --no-deps LAST so they are authoritative: a rest dependency (e.g. one
+    # that pulls xformers from PyPI) cannot silently clobber the ref's accel build.
+    uv pip install --no-cache-dir -c /tmp/torch-constraints.txt -r /tmp/ooba-rest.txt && \
+    if [[ "$ARCH" == "amd64" ]]; then \
+        uv pip install --no-cache-dir --no-deps -r /tmp/ooba-accel.txt; \
+    fi && \
     # Download custom models into the build if you want them - None included in default build
     # wget -O ${DATA_DIRECTORY}text-generation-webui/models/model https://url.to.files/model2 && \
-    # wget -O ${DATA_DIRECTORY}text-generation-webui/models/Stable-diffusion/model2.safetensors https://url.to.files/model2 && \
-    # Verify torch ecosystem unchanged.
+    # HARD build-time ABI gate. Import torch FIRST (puts torch/lib on the loader
+    # path), then the bare compiled extensions built against torch 2.9.x, resolved
+    # against the installed torch. A symbol/ABI mismatch fails the build RED — no
+    # silent degrade. The expected module set is DERIVED from the wheels we actually
+    # extracted (adaptive: if upstream drops a loader it is not checked; but an empty
+    # extraction or a wheel that did not install/import fails loud). Symbol
+    # resolution only (no CUDA device), so it runs on a CPU-only CI runner. torchao
+    # is an additional torch-ABI consumer not import-gated here — a QA-gate residual.
+    if [[ "$ARCH" == "amd64" ]]; then \
+        python -c "import torch, importlib, sys, pathlib; a = pathlib.Path('/tmp/ooba-accel.txt').read_text(); checks = [c for c in [('exllamav3_ext', 'exllamav3_ext') if 'turboderp-org/exllamav3' in a else None, ('flash_attn.flash_attn_interface', 'flash_attn_2_cuda') if 'mjun0812/flash-attention' in a else None] if c]; assert checks, 'ABI gate: ACCEL_RE extracted no exllamav3/flash_attn wheel'; [importlib.import_module(m) for m, _ in checks]; assert all(x in sys.modules for _, x in checks), 'accel ABI gate: a compiled module did not load'; print('ABI gate OK:', [x for _, x in checks], 'against torch', torch.__version__)"; \
+    fi && \
+    # (4) Verify the torch ecosystem is unchanged.
     torch_versions_post="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
-    [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem version drift:"; diff <(echo "$torch_versions_pre") <(echo "$torch_versions_post"); exit 1; }
+    { [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem version drift:"; diff <(echo "$torch_versions_pre") <(echo "$torch_versions_post"); exit 1; }; }
+
+# EXPOSE the Caddy-front (external) ports this image's baked PORTAL_CONFIG
+# declares: Instance Portal (1111), Jupyter (8080), Text Generation WebUI (7860),
+# Oobabooga API (5000). EXPOSE drives Vast's port auto-map so Caddy proxies them;
+# the base overlays via a COPY (not FROM), so its ports are NOT inherited and a
+# derivative that bakes a default must declare the full front set itself
+# (ADR 0002). Never EXPOSE the loopback internals (11111 / 18080 / 17860 / 15000).
+EXPOSE 1111 8080 7860 5000
 
 # Defend against environment clashes when syncing to volume
 RUN env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/oobabooga/README.build.md
+++ b/derivatives/pytorch/derivatives/oobabooga/README.build.md
@@ -4,10 +4,19 @@ This Dockerfile relies on the structure provided by [Vast.Ai Base images](https:
 
 See the example below for building instructions.
 
+amd64-only: oobabooga's accelerator wheels (exllamav3, flash_attn, xformers,
+llama_cpp_binaries) publish x86_64-only wheels. The torch 2.9.x/cu128 base is
+required — the wheels are built `+cu128.torch2.9` and the build proves they import
+against it (see the ABI gate in the Dockerfile and
+[ADR 0004](../../../../docs/adr/0004-oobabooga-accel-reconciliation-and-ci.md)).
+The accel-wheel handling is derived from the chosen `OOBABOOGA_REF`'s requirements
+at build time, so CI tracks the latest upstream (CI resolves HEAD of `main`). The
+example below pins a tag for a reproducible local build; pass any commit/branch/tag.
+
 ```bash
 docker buildx build \
     --platform linux/amd64 \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.5.1-cuda-12.1.1-py311 \
-    --build-arg OOBABOOGA_REF=v2.4 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15 \
+    --build-arg OOBABOOGA_REF=v4.9 \
     . -t repo/image:tag --push
 ```

--- a/derivatives/pytorch/derivatives/oobabooga/ROOT/etc/vast_agents/oobabooga.md
+++ b/derivatives/pytorch/derivatives/oobabooga/ROOT/etc/vast_agents/oobabooga.md
@@ -1,7 +1,33 @@
 ## Text Generation WebUI — oobabooga (this image)
 
-Runs the oobabooga Text Generation WebUI for LLMs (supervisor service
-`oobabooga`). It launches with `--api`, which exposes an **OpenAI-compatible**
-API in addition to the chat UI. Both appear in `/capabilities/services`; if the
-API port is exposed it will also show in `/capabilities/endpoints`. Reach either
-via its `direct_url` + token.
+The base image plus a preinstalled **oobabooga Text Generation WebUI**; base.md applies. A
+chat UI and an **OpenAI-compatible API** are served by one `server.py --api` process — get
+their `base_url`s + auth from `/capabilities/endpoints` (don't assume ports). Unlike the
+vLLM/SGLang images there is **no Model-UI and no Ray service**, and the model is chosen
+interactively rather than fixed at boot.
+
+### Models
+
+The image bakes **no model**, but a tiny placeholder (`facebook_galactica-125m`) loads so the
+API answers out of the box. Models live in
+`${DATA_DIRECTORY}text-generation-webui/user_data/models` (persists on a volume). Manage the
+loaded model via oobabooga's **internal API** — *not* in the capability manifest, so call it
+directly on the API's loopback port (e.g. `:15000`):
+```
+curl -s  http://127.0.0.1:15000/v1/internal/model/info               # currently loaded
+curl -s  http://127.0.0.1:15000/v1/internal/model/list               # available on disk
+curl -sX POST http://127.0.0.1:15000/v1/internal/model/load -d '{"model_name":"<name>"}'
+```
+…or use the WebUI **Models** tab. Download by Hugging Face repo id from the WebUI (or
+`download-model.py`). Pass `--model <name>` via `OOBABOOGA_ARGS` to load one at boot.
+
+### Loaders
+
+The accelerator stack is preinstalled, so a model is served by the loader matching its
+**format**: **Transformers** (HF checkpoints), **GGUF** (llama.cpp), or **EXL3** (ExLlamaV3).
+
+### Gotcha
+
+`OOBABOOGA_ARGS` is **additive** (appended after the baked `--api`/port flags). **Do not add a
+bare `--listen`** — it binds the UI/API on `0.0.0.0`, bypassing the Caddy auth edge, so the
+launcher refuses to start (the loopback-behind-Caddy invariant).

--- a/derivatives/pytorch/derivatives/oobabooga/ROOT/etc/vast_boot.d/05-oobabooga-env.sh
+++ b/derivatives/pytorch/derivatives/oobabooga/ROOT/etc/vast_boot.d/05-oobabooga-env.sh
@@ -7,7 +7,7 @@
 # parsed by portal-aio/caddy_manager/caddy_config_manager.py). Caddy stands up
 # an authed proxy site only when external != internal, so each app binds its
 # INTERNAL port on loopback (server.py without --listen; see oobabooga.sh) and
-# users reach it via the EXTERNAL port (which the Dockerfile EXPOSEs).
+# users reach it via the EXTERNAL port (opened by the Vast template's `ports:` config).
 #   Text Generation WebUI: external 7860  -> internal 17860
 #   Oobabooga API (OpenAI-compatible): external 5000 -> internal 15000
 if [[ -z $PORTAL_CONFIG ]]; then

--- a/derivatives/pytorch/derivatives/oobabooga/ROOT/etc/vast_boot.d/05-oobabooga-env.sh
+++ b/derivatives/pytorch/derivatives/oobabooga/ROOT/etc/vast_boot.d/05-oobabooga-env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Default portal configuration (ADR 0002). The launch template overrides
+# PORTAL_CONFIG; this baked default lets the image self-describe its ports.
+#
+# Format: localhost:<external>:<internal>:<path>:<Label>  (pipe-separated;
+# parsed by portal-aio/caddy_manager/caddy_config_manager.py). Caddy stands up
+# an authed proxy site only when external != internal, so each app binds its
+# INTERNAL port on loopback (server.py without --listen; see oobabooga.sh) and
+# users reach it via the EXTERNAL port (which the Dockerfile EXPOSEs).
+#   Text Generation WebUI: external 7860  -> internal 17860
+#   Oobabooga API (OpenAI-compatible): external 5000 -> internal 15000
+if [[ -z $PORTAL_CONFIG ]]; then
+    export PORTAL_CONFIG="localhost:1111:11111:/:Instance Portal|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal|localhost:7860:17860:/:Text Generation WebUI|localhost:5000:15000:/:Oobabooga API"
+fi

--- a/derivatives/pytorch/derivatives/oobabooga/ROOT/opt/instance-tools/tests/oobabooga.d/10-oobabooga-serving.sh
+++ b/derivatives/pytorch/derivatives/oobabooga/ROOT/opt/instance-tools/tests/oobabooga.d/10-oobabooga-serving.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Test: oobabooga (Text Generation WebUI) serving + generation.
+#
+# oobabooga.sh launches server.py with --listen-port 17860 (WebUI) and
+# --api --api-port 15000 (OpenAI-compatible API), both bound to 127.0.0.1
+# (no --listen; the 30-networking base test covers the no-0.0.0.0 bind).
+#
+# Health (WebUI 200 + API model list) is a hard prerequisite. Generation is
+# ENFORCED — a real /v1/completions must produce completion tokens — matching
+# how the vLLM and ComfyUI tests verify actual functionality, not just health.
+# Like vLLM (which skips when VLLM_MODEL is unset), this skips ONLY when no
+# model is loaded to exercise; the model is template/provisioning-supplied (the
+# image bakes none, but a model loads by default). We assert that inference
+# RAN (completion_tokens > 0), not that the content is "right".
+# TEST_TIMEOUT=3600
+source "$(dirname "$0")/../lib.sh"
+
+UI_PORT="${OOBABOOGA_UI_PORT:-17860}"
+API_PORT="${OOBABOOGA_API_PORT:-15000}"
+HEALTH_TIMEOUT="${OOBABOOGA_HEALTH_TIMEOUT:-1800}"
+GEN_TIMEOUT="${OOBABOOGA_GEN_TIMEOUT:-180}"
+UI="http://127.0.0.1:${UI_PORT}"
+API="http://127.0.0.1:${API_PORT}"
+
+service_running oobabooga || test_skip "oobabooga service not running"
+
+# ── WebUI on its loopback port (hard prerequisite) ───────────────────
+echo "  -- waiting for the WebUI on ${UI} --"
+wait_for_port "$UI_PORT" "$HEALTH_TIMEOUT" \
+    || test_fail "WebUI not listening on ${UI_PORT} within ${HEALTH_TIMEOUT}s"
+code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${UI}/" 2>/dev/null)
+[[ "$code" == "200" ]] || test_fail "WebUI not served at ${UI}/ (HTTP ${code})"
+echo "  WebUI served at ${UI}/ (HTTP 200)"
+
+# ── OpenAI-compatible API on its loopback port (hard prerequisite) ───
+echo "  -- waiting for the API on ${API} --"
+wait_for_port "$API_PORT" "$HEALTH_TIMEOUT" \
+    || test_fail "API not listening on ${API_PORT} within ${HEALTH_TIMEOUT}s"
+echo "$(curl -s --max-time 15 "${API}/v1/models" 2>/dev/null)" \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); assert d.get('object')=='list', 'not an OpenAI-style model list'" 2>/dev/null \
+    || test_fail "API ${API}/v1/models did not return a valid OpenAI model list"
+echo "  API model list served at ${API}/v1/models"
+
+# ── Loaded model (the thing to exercise) ─────────────────────────────
+# /v1/internal/model/info reports the CURRENTLY-LOADED model. Skip — don't
+# pass — when none is loaded: there is no functionality to verify (vLLM skips
+# the same way when VLLM_MODEL is unset). A normal launch loads a default.
+loaded=$(curl -s --max-time 15 "${API}/v1/internal/model/info" 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(''); raise SystemExit
+n = d.get('model_name') or ''
+print('' if n in ('', 'None') else n)" 2>/dev/null)
+
+[[ -n "$loaded" ]] \
+    || test_skip "no model loaded — set a model (e.g. OOBABOOGA_ARGS=\"--model <name>\") to exercise generation"
+echo "  loaded model: ${loaded}"
+
+# ── ENFORCED generation ──────────────────────────────────────────────
+echo "  -- generation (/v1/completions) --"
+body=$(mktemp)
+http_code=$(curl -s --max-time "$GEN_TIMEOUT" -o "$body" -w '%{http_code}' \
+    "${API}/v1/completions" \
+    -H 'Content-Type: application/json' \
+    -d '{"prompt":"The Vast.ai platform provides","max_tokens":16,"temperature":0.1}' 2>/dev/null)
+
+if [[ "$http_code" != "200" ]]; then
+    echo "  response: $(head -c 300 "$body")"
+    rm -f "$body"
+    test_fail "generation failed: HTTP ${http_code} from ${API}/v1/completions (model ${loaded})"
+fi
+
+# Inference RAN if it produced completion tokens — content is not judged
+# (a tiny default model emits gibberish but is still serving), matching vLLM.
+toks=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+ch = (d.get('choices') or [{}])[0]
+assert ch.get('text') is not None, 'no completion text in response'
+print(d.get('usage', {}).get('completion_tokens', 0) or 0)" "$body" 2>/dev/null)
+rm -f "$body"
+
+[[ "${toks:-0}" =~ ^[0-9]+$ ]] && (( toks > 0 )) \
+    || test_fail "generation produced 0 completion tokens (model ${loaded}) — inference did not run"
+echo "  generation OK: ${toks} completion token(s) from ${loaded}"
+
+test_pass "oobabooga serving + generation verified (WebUI ${UI_PORT} + OpenAI API ${API_PORT} on loopback; ${toks} tokens on ${loaded})"

--- a/derivatives/pytorch/derivatives/oobabooga/ROOT/opt/supervisor-scripts/oobabooga.sh
+++ b/derivatives/pytorch/derivatives/oobabooga/ROOT/opt/supervisor-scripts/oobabooga.sh
@@ -15,8 +15,19 @@ done
 export GIT_CONFIG_GLOBAL=/tmp/temporary-git-config
 git config --file $GIT_CONFIG_GLOBAL --add safe.directory '*'
 
+# Bind the loopback ports UNCONDITIONALLY (additive, not a replaceable default) so
+# a launch template cannot drop them and re-expose the service. server.py / the
+# API bind 127.0.0.1 unless --listen is passed; we deliberately never pass it.
+# OOBABOOGA_ARGS may ADD extra args (incl. overriding the ports, which argparse
+# resolves last-wins), but injecting a bare `--listen` would flip both
+# Caddy-fronted ports to 0.0.0.0 — refuse to start in that case (ADR 0004).
+if [[ " ${OOBABOOGA_ARGS:-} " =~ (^|[[:space:]])--listen([[:space:]]|$) ]]; then
+    echo "$PROC_NAME refusing to start: a bare --listen in OOBABOOGA_ARGS would bind 0.0.0.0 on the Caddy-fronted ports (ADR 0004). Remove it; the app already binds loopback behind Caddy."
+    exit 1
+fi
+
 # Launch Oobabooga
 cd ${DATA_DIRECTORY}text-generation-webui
 LD_PRELOAD=libtcmalloc_minimal.so.4 \
         pty python server.py \
-        ${OOBABOOGA_ARGS:---listen-port 17860 --api --api-port 15000} 2>&1
+        --listen-port 17860 --api --api-port 15000 ${OOBABOOGA_ARGS:-} 2>&1

--- a/docs/adr/0004-oobabooga-accel-reconciliation-and-ci.md
+++ b/docs/adr/0004-oobabooga-accel-reconciliation-and-ci.md
@@ -1,4 +1,4 @@
-# ADR 0004 — oobabooga: accel-wheel/torch reconciliation, ADR-0002 convention backfill, and CI
+# ADR 0004 — oobabooga: accel-wheel/torch reconciliation and CI
 
 - **Status:** Accepted (conditional — see Binding conditions). **Amended 2026-06-25
   — see Amendment below.**
@@ -69,12 +69,12 @@ Verified reality that shaped the decision:
   `--listen`**, and upstream binds `127.0.0.1` for both the UI (`server.py`) and the
   API (`modules/api/script.py` binds `0.0.0.0` only when `--listen` is set). The
   baked default is therefore safe.
-- [ADR 0002](0002-portal-config-and-expose-conventions.md) governs the convention
-  half: bake a default `PORTAL_CONFIG` + `EXPOSE` the Caddy-front ports. oobabooga is
-  one of "the 24" awaiting backfill (ADR 0002 migration step 3). **Binding
-  condition 1 of ADR 0002 requires a runtime `ss -ltnp` 0.0.0.0-bind smoke gate for
-  any EXPOSE-ing image** and states that deferring it "voids the decision." This ADR
-  addresses that head-on (see Binding conditions / partial amendment of ADR 0002).
+- oobabooga bakes a default `PORTAL_CONFIG` (the established `05-<name>-env.sh`
+  fallback), but does **not** `EXPOSE` its Caddy-front ports: ports are opened by the
+  Vast template's `ports:` config, and the EXPOSE-from-images convention (ADR 0002) is
+  **deferred pending a platform decision** — the portal-EXPOSE lint work is out of scope
+  here. What this ADR keeps is the runtime bind-safety principle (apps bind loopback
+  behind Caddy, never `0.0.0.0`), which holds regardless of how ports are opened.
 
 The owner's two product/governance calls: **install exllamav3 anyway** (2.9.0 vs
 2.9.1 is a patch diff and PyTorch keeps patch ABI compat — the base family's own
@@ -162,15 +162,15 @@ HARD gate (fail RED, no degrade).**
      This invariant is itself linted: **L053** (ERROR) fires if an image ships
      `ROOT/opt/accel-wheels.txt` without both the `--no-deps` install and this import
      gate, with mutation tests proving it bites.
-2. **Convention (ADR 0002 backfill):** new guarded
+2. **Baked portal default:** new guarded
    `ROOT/etc/vast_boot.d/05-oobabooga-env.sh` baking `PORTAL_CONFIG` with entries
    Instance Portal `1111:11111`, Jupyter `8080:18080`, Jupyter Terminal `8080:8080`
-   (equal-port tab), **Text Generation WebUI `<UI_EXT>:17860`**, **Oobabooga API
-   `<API_EXT>:15000`**; Dockerfile `EXPOSE 1111 8080 <UI_EXT> <API_EXT>`.
-   `<UI_EXT>`/`<API_EXT>` are set to the **live published Vast template's external
-   port values** (pending from the owner) — must be real distinct integers before
-   merge (`portal.py:74` `int()` rejects placeholders and breaks `lint --all`).
-   Satisfies L050/L051/L052 by the ADR 0002 set-model.
+   (equal-port tab), Text Generation WebUI `7860:17860`, Oobabooga API `5000:15000`
+   — the established `05-<name>-env.sh` fallback (the launch template's `PORTAL_CONFIG`
+   still wins). NOTE: the image does **not** `EXPOSE` these ports — they are opened by
+   the Vast template's `ports:` config. The EXPOSE-from-images convention (ADR 0002)
+   is deferred pending a platform decision, so the portal-EXPOSE lint work is not part
+   of this change.
 3. **CI:** new `.github/workflows/build-oobabooga.yml`, **amd64-only single arch**
    (`ubuntu-latest`), single base
    `vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15`, `OOBABOOGA_REF`
@@ -209,10 +209,8 @@ is void.
    regression," two compensating controls are required now: (a) **make
    `oobabooga.sh`'s default additive-safe** so a launch template cannot *drop* the
    loopback `--listen-port/--api-port` default (closing the
-   `${OOBABOOGA_ARGS:-…}` full-replacement → `--listen` → `0.0.0.0` escape hatch on
-   the EXPOSEd ports); (b) the QA-gate checklist explicitly includes the in-container
-   `ss -ltnp` bind check for ports 17860/15000 before publish. Static `L051` +
-   the verified loopback default remain the fast layer.
+   `${OOBABOOGA_ARGS:-…}` full-replacement → `--listen` → `0.0.0.0` escape hatch); (b) the QA-gate checklist explicitly includes the in-container
+   `ss -ltnp` bind check for ports 17860/15000 before publish. The verified loopback default remains the fast layer.
 5. **Pre-decided fail-RED runbook.** When upstream and the base torch fall out of ABI
    lockstep (a *when*, given the exact-patch wheel pin), the gate fails the whole
    build. The reviewed escape is the **manifest**: drop the offending wheel line to
@@ -242,5 +240,5 @@ is void.
   "install anyway" premise is void → invoke the condition-5 runbook.
 - If GPU-class runners arrive, condition 4's deferral ends: wire ADR 0002's bind
   gate into `build-oobabooga.yml` and drop the QA-gate ownership.
-- If Vast's EXPOSE auto-map behaviour changes, revisit the convention half per
-  ADR 0002.
+- If the EXPOSE-from-images convention (ADR 0002) is adopted later, revisit whether
+  oobabooga should EXPOSE its Caddy-front ports instead of relying on template `ports:`.

--- a/docs/adr/0004-oobabooga-accel-reconciliation-and-ci.md
+++ b/docs/adr/0004-oobabooga-accel-reconciliation-and-ci.md
@@ -1,0 +1,246 @@
+# ADR 0004 — oobabooga: accel-wheel/torch reconciliation, ADR-0002 convention backfill, and CI
+
+- **Status:** Accepted (conditional — see Binding conditions). **Amended 2026-06-25
+  — see Amendment below.**
+- **Date:** 2026-06-25
+- **Decision owner:** Rob Ballantyne
+- **Process:** idea brief → critical review → competing designs → multi-dimension review
+  (feasibility / maintainability / risk) → synthesis → final review gate on the
+  plan (which empirically tested the load-bearing assumption).
+
+## Amendment (2026-06-25) — track latest upstream, do not pin
+
+The original synthesis pinned `OOBABOOGA_REF` to a release tag (`v4.9`) and shipped a
+static, owned `ROOT/opt/accel-wheels.txt` manifest validated against that tag (original
+condition 5: "REF and manifest move together"). **This was reversed**: pinning broke the
+house automation — every other derivative's CI resolves the latest upstream HEAD and
+rebuilds, and a pinned ref silently stops tracking upstream. Per the decision owner, the
+correct posture is: **CI resolves the latest upstream ref (HEAD of `main`, like the
+sibling workflows) and builds from it, accepting the risk that a future ref breaks the
+build** — the **planned** live-GPU QA gate ([ADR 0005], not yet built) is the intended
+runtime net for exactly this. Until it exists, the only gates are the static linter,
+the `docker build` itself (incl. the hard ABI import gate), and a human acting on a red
+scheduled run; the build-time checks are deliberately fail-loud (no silent degrade).
+
+Concretely, superseding the affected parts below:
+- **Install:** the static `accel-wheels.txt` manifest is **removed**. The Dockerfile now
+  derives the accel wheels from the *resolved ref's* `requirements/full/requirements.txt`
+  at build time (REF-agnostic): rewrite the cp313→cp312 ABI tag + marker, strip the base
+  torch ecosystem, split the externally-hosted accel wheels out **by stable host/org
+  token** (`turboderp-org/exllamav3`, `mjun0812/flash-attention-prebuild-wheels`,
+  `oobabooga/llama-cpp-binaries`, `download.pytorch.org/...xformers-`) and install them
+  `--no-deps`, then install the rest under a torch-ecosystem constraints floor. `--no-deps`
+  + the drift-guard + the hard ABI import gate are retained unchanged.
+- **CI (was condition-5 pinning):** `OOBABOOGA_REF` resolves to **HEAD of upstream `main`**
+  via the GitHub API with a commit-age threshold (scheduled runs skip stale upstreams) and
+  a manual override — matching `build-a1111.yml` / `build-fluxgym.yml`.
+- **Linter:** the manifest-coupled **`L053`** rule is **removed** (it keyed on the now-gone
+  `accel-wheels.txt`). The pre-existing **`L020`** drift-guard remains the codified
+  invariant that the base torch cannot be silently downgraded.
+
+Below, references to "the owned manifest" / "pinned tag" / "condition 5" / "L053" are
+retained as the historical record but are superseded by this amendment.
+
+## Context
+
+Bring the `oobabooga` (text-generation-webui) derivative
+(`derivatives/pytorch/derivatives/oobabooga/`) up to current conventions and give
+it a dedicated build pipeline. Three coupled needs, surfaced as two `imagegen lint`
+WARNs (`L052` no baked `PORTAL_CONFIG`; `L030` no `build-oobabooga.yml`) plus a
+"verify the base is appropriate" ask.
+
+Verified reality that shaped the decision:
+
+- **The build is latently RED and has been for some time** — there is no CI, so it
+  was never caught. oobabooga upstream `requirements/full/requirements.txt`
+  (release `v4.9`) selects, on Linux x86_64, accel wheels whose **wheel METADATA
+  hard-pins `torch==2.9.0` and `xformers==0.0.33`** (exllamav3 0.0.34; flash_attn
+  2.8.3 is `+cu128torch2.9`). The pytorch base family ships **torch 2.9.1 only** —
+  2.9.0 was *deliberately superseded* (`build-pytorch.yml:93` "patch versions
+  maintain ABI compat — 2.9.0 superseded"); **no 2.9.0 `-mini` base exists**, and a
+  py313 base is also 2.9.1. The Dockerfile hard-pins torch to the inherited 2.9.1
+  with a pre/post drift-guard that fails the build on any torch change. So
+  exllamav3's `torch==2.9.0` collides with 2.9.1 → resolver error or torch
+  downgrade → drift-guard trips.
+- The accel wheels (exllamav3, flash_attn, xformers, llama_cpp_binaries) are
+  **x86_64-only** → the image is **amd64-only**; arm64 has no backend wheels.
+- The app binds **loopback** by default: `oobabooga.sh` launches
+  `python server.py --listen-port 17860 --api --api-port 15000` **without
+  `--listen`**, and upstream binds `127.0.0.1` for both the UI (`server.py`) and the
+  API (`modules/api/script.py` binds `0.0.0.0` only when `--listen` is set). The
+  baked default is therefore safe.
+- [ADR 0002](0002-portal-config-and-expose-conventions.md) governs the convention
+  half: bake a default `PORTAL_CONFIG` + `EXPOSE` the Caddy-front ports. oobabooga is
+  one of "the 24" awaiting backfill (ADR 0002 migration step 3). **Binding
+  condition 1 of ADR 0002 requires a runtime `ss -ltnp` 0.0.0.0-bind smoke gate for
+  any EXPOSE-ing image** and states that deferring it "voids the decision." This ADR
+  addresses that head-on (see Binding conditions / partial amendment of ADR 0002).
+
+The owner's two product/governance calls: **install exllamav3 anyway** (2.9.0 vs
+2.9.1 is a patch diff and PyTorch keeps patch ABI compat — the base family's own
+"superseded" comment asserts this); and, because **no GPU-class CI runners exist
+yet**, **defer the runtime bind gate to a downstream QA gate** rather than wire it
+into CI now. The UI **and** the API both get authed Caddy fronts.
+
+## Options considered
+
+The install-strategy fork drew three candidate designs, evaluated across three
+dimensions. Scores (1–10): feasibility / maintainability / risk.
+
+- **Option A — minimal `sed` repair (Alpha; 7 / 3 / 5).** Keep the existing
+  `cp313→cp312` sed; drop the index-xformers; pull the exllamav3 line out and
+  install it `--no-deps`; one-line `import exllamav3` check. **Rejected:** the
+  maintainability lens showed the sed "works today *only by coincidence* of
+  upstream's wheel-naming" and the live `audioop-lts ... python_version >= "3.13"`
+  line (uses `>=`, not `==`) already proves the pattern-match silently rots; the
+  risk lens showed its one-line `import exllamav3` may not catch the ABI break at
+  all (exllamav3 lazy/JIT-loads its CUDA ext — oobabooga #4554), and even when it
+  fires it drags in the pure-Python closure and fails RED for non-ABI reasons.
+- **Option C — owned manifest + uv constraints (Beta; 9 / 8 / 2).** Stop
+  transforming upstream's file: a derivative-owned `accel-wheels.txt` of explicit
+  cp312 URLs installed `--no-deps`, a uv `-c constraints.txt` pinning
+  `torch==${PYTORCH_VERSION}` + `xformers==0.0.33`, requirements stripped by stable
+  token, **cp313 sed dropped entirely**. Won feasibility (the constraints file makes
+  the torch downgrade *structurally impossible*, not merely line-removed) and
+  maintainability (deletes the whole silent-rot class). **Risk lens scored it 2 and
+  said "block":** it never tests that the compiled extension actually *loads*
+  against 2.9.1 — a confident green over an untested ABI assumption that fails on a
+  paying user's GPU.
+- **Option G — import-proof gate + safe-degrade (Gamma; 4 / 4 / 7).** `--no-deps`
+  install + a build-time import of the *compiled submodule* (the only real ABI
+  proof), but on failure it **uninstalls the package and ships GREEN-but-degraded**
+  with a `/.abi_degraded` marker and a CI `::warning::`. Won the risk lens (real
+  ABI proof) but **feasibility called the degrade a "correctness bug"** (ships green
+  while masking the exact failure the task exists to fix) and maintainability called
+  green-but-degraded "silent capability loss behind an ignorable warning."
+
+The review was complementary, not contradictory: Option C's install mechanism and
+Option G's *verification* each fix the other's sole weakness. Both other judges were
+unanimous against G's **degrade** path specifically.
+
+Also rejected: a torch-2.9.0 base (none exists; fights the family's superseded
+decision); dropping exllamav3 outright (gives up a headline loader without testing
+the — empirically valid — compatibility; retained only as the explicit fail-RED
+runbook escape, below).
+
+## Decision
+
+**Adopt Option C's install mechanism, grafted with Option G's verification as a
+HARD gate (fail RED, no degrade).**
+
+1. **Install (Dockerfile):**
+   - Derivative-owned `ROOT/opt/accel-wheels.txt` naming the exact validated
+     Linux/x86_64 **cp312** wheel URLs (exllamav3 0.0.34, flash_attn 2.8.3,
+     llama_cpp_binaries + ik_llama_cpp_binaries 0.136.0, xformers 0.0.33), installed
+     **`uv pip install --no-deps`** (amd64-gated). `--no-deps` is the load-bearing
+     mechanism: it severs exllamav3's `torch==2.9.0` / `xformers==0.0.33` METADATA
+     pins so the base's torch 2.9.1 is never downgraded.
+   - A uv **`-c constraints.txt`** pinning `torch==${PYTORCH_VERSION}`,
+     torch{vision,audio,codec}, and `xformers==0.0.33`, applied to the remaining
+     upstream requirements install — a declarative "torch must not move" floor.
+   - **Drop the `cp313→cp312` sed and the `python_version` marker rewrite**; the URLs
+     are named directly in the manifest and upstream markers evaluate on the real
+     py312 interpreter. This deletes the silent-rot class (incl. the `>=` blind
+     spot). The stable-token strip of owned lines is retained as belt-and-braces; on
+     the current `v4.9` file it is largely inert (no bare torch lines; accel lines
+     are `python_version=="3.13"`-gated), so it is defensive, not load-bearing.
+   - Keep the existing torch drift-guard as a post-assertion.
+   - **HARD build-time ABI gate** (CPU-runner-safe — empirically verified on a
+     GPU-less host: the compiled `.so`s resolve against torch 2.9.1 needing only the
+     torch-wheel-bundled CUDA libs, not `libcuda.so.1`). Exact incantation, torch
+     first, bare compiled modules, plus a `sys.modules` assertion:
+     ```
+     python -c "import torch; import exllamav3_ext; import flash_attn.flash_attn_interface; import sys; \
+       assert 'exllamav3_ext' in sys.modules and 'flash_attn_2_cuda' in sys.modules"
+     ```
+     On `ImportError`/`OSError` the **build fails RED**. There is no degrade path, no
+     `/.abi_degraded`, no uninstall. `torchao` (a third torch-ABI consumer) is
+     installed normally under the torch constraints (pip resolves a build compatible
+     with 2.9.1) but is **not** in the hard gate — its CPU-runner import behaviour is
+     unverified, and a spurious failure there would manufacture the permanently-red
+     workflow condition 1 warns against; it is a documented QA-gate residual instead.
+     This invariant is itself linted: **L053** (ERROR) fires if an image ships
+     `ROOT/opt/accel-wheels.txt` without both the `--no-deps` install and this import
+     gate, with mutation tests proving it bites.
+2. **Convention (ADR 0002 backfill):** new guarded
+   `ROOT/etc/vast_boot.d/05-oobabooga-env.sh` baking `PORTAL_CONFIG` with entries
+   Instance Portal `1111:11111`, Jupyter `8080:18080`, Jupyter Terminal `8080:8080`
+   (equal-port tab), **Text Generation WebUI `<UI_EXT>:17860`**, **Oobabooga API
+   `<API_EXT>:15000`**; Dockerfile `EXPOSE 1111 8080 <UI_EXT> <API_EXT>`.
+   `<UI_EXT>`/`<API_EXT>` are set to the **live published Vast template's external
+   port values** (pending from the owner) — must be real distinct integers before
+   merge (`portal.py:74` `int()` rejects placeholders and breaks `lint --all`).
+   Satisfies L050/L051/L052 by the ADR 0002 set-model.
+3. **CI:** new `.github/workflows/build-oobabooga.yml`, **amd64-only single arch**
+   (`ubuntu-latest`), single base
+   `vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15`, `OOBABOOGA_REF`
+   **pinned to the manifest-matched release tag** (`DEFAULT_OOBABOOGA_REF=v4.9` in
+   the workflow env; manual override allowed). The pin is deliberate: the
+   `accel-wheels.txt` manifest is validated against that exact tag's requirements,
+   so REF and manifest move together under review (condition 5) rather than an
+   unattended auto-latest that would outrun the manifest. Scheduled runs rebuild the
+   pinned tag against the latest base (picks up base bumps). Clones the amd64-only
+   single-app workflow + the shared `build-arch-image` / `merge-arch-manifests` /
+   `notify-slack` composite actions.
+4. **Runtime bind gate:** **deferred to the QA gate** (no GPU-class runners exist);
+   recorded explicitly here, not silently skipped. See Binding conditions — this is
+   a scoped, time-boxed **partial amendment of ADR 0002 binding condition 1**.
+
+## Binding conditions
+
+Surviving conditions from the final review gate. If any is refused, the decision
+is void.
+
+1. **The ABI gate uses the exact incantation above** (`import torch` first; bare
+   `exllamav3_ext` / `flash_attn.flash_attn_interface`, never top-level
+   `import exllamav3`; `sys.modules` assertion). A casually
+   written gate ships a permanently-red workflow (false-negative on
+   pydantic/rich/formatron skew) or a silent no-op. Empirically verified
+   CPU-runner-safe.
+2. **`--no-deps` on the accel manifest is mandatory** and is the mechanism that
+   prevents the torch downgrade; the uv `-c constraints.txt` is the structural floor
+   behind it. Neither may be dropped "to simplify."
+3. **Placeholder ports are replaced with the live template's real integers before
+   merge**, and `imagegen lint --all` must report the baseline CLEAN.
+4. **Partial amendment of ADR 0002 binding condition 1 (bind smoke gate).** Because
+   no GPU-class CI runner exists, the runtime `ss -ltnp` 0.0.0.0-bind gate is
+   **owned by the QA gate** until GPU runners land, at which point it is wired into
+   `build-oobabooga.yml`. To keep this honest rather than a "green check shipping the
+   regression," two compensating controls are required now: (a) **make
+   `oobabooga.sh`'s default additive-safe** so a launch template cannot *drop* the
+   loopback `--listen-port/--api-port` default (closing the
+   `${OOBABOOGA_ARGS:-…}` full-replacement → `--listen` → `0.0.0.0` escape hatch on
+   the EXPOSEd ports); (b) the QA-gate checklist explicitly includes the in-container
+   `ss -ltnp` bind check for ports 17860/15000 before publish. Static `L051` +
+   the verified loopback default remain the fast layer.
+5. **Pre-decided fail-RED runbook.** When upstream and the base torch fall out of ABI
+   lockstep (a *when*, given the exact-patch wheel pin), the gate fails the whole
+   build. The reviewed escape is the **manifest**: drop the offending wheel line to
+   ship WebUI-only (the UI + llama.cpp backend do not need exllamav3), or pin
+   `OOBABOOGA_REF` back, rather than relax the gate or block a base/security bump.
+
+## Consequences
+
+- **Positive:** the build becomes green *and proven* (real compiled-ABI check, not
+  an assertion); the silent-`sed`-rot class is deleted; the accel matrix is an
+  explicit, reviewed, greppable manifest pinned to a release tag; the image
+  self-describes its ports (L050/L051/L052 clean); oobabooga gains CI (L030);
+  amd64-only matches wheel reality.
+- **Accepted-negative:** the owned manifest must be reconciled on each deliberate
+  `OOBABOOGA_REF` bump (visible, reviewed work). The ABI gate covers exllamav3 /
+  flash_attn / torchao but cannot prove kernel *execution* on a CPU runner — that
+  residual, and the network-bind residual, are owned by the QA gate until GPU
+  runners exist. fail-RED-always couples "broken accel ABI" to "broken image" by
+  design (mitigated by the runbook, condition 5).
+
+## What would reverse this
+
+- If `import exllamav3_ext` / `flash_attn_2_cuda` ever require a GPU/driver at import
+  on `ubuntu-latest` (a future wheel linking `libcuda.so.1` directly), the hard CI
+  gate must move to a GPU/QA step — the empirical CPU-safety premise collapses.
+- If a future base torch bump breaks 2.9.x patch-ABI compat for these wheels, the
+  "install anyway" premise is void → invoke the condition-5 runbook.
+- If GPU-class runners arrive, condition 4's deferral ends: wire ADR 0002's bind
+  gate into `build-oobabooga.yml` and drop the QA-gate ownership.
+- If Vast's EXPOSE auto-map behaviour changes, revisit the convention half per
+  ADR 0002.


### PR DESCRIPTION
Reconciled image half of #207 onto `main` after #206 (the imagegen linter/generator) landed.

#207 branched pre-rebase, so its copy of the imagegen tooling was stale. That tooling now comes entirely from `main` (206); this PR carries only oobabooga's genuine ADR-0004 work:

- Dockerfile accel/torch reconciliation, supervisor, agent guide, README.build
- a boot-env script and a live-GPU serving test
- ADR 0004

Applied 3-way onto `main` so #212's GPL/AGPL `LICENSES.md` compliance is preserved (LICENSES.md untouched).

**Validated on main's now-active invariant linter:** oobabooga lints 0 errors; whole-repo baseline CLEAN (27 images); imagegen suite 131 pass.

**Not included (deliberately):**
- stabledaw — not proceeding currently.
- the portal-config lint subsystem (ADR 0002/0003) — its rule codes collide with 206's L05x numbering and it belongs with the portal/exposure cluster (PRs #205/#208, ADR 0006); moving to its own PR.

Supersedes #207 (which is being closed).