### PR TITLE
feat(imagegen): portal-config lint rules + bind-address smoke gate (ADR 0002/0003)

### DIFF
--- a/.github/workflows/portal-aio-tests.yml
+++ b/.github/workflows/portal-aio-tests.yml
@@ -1,0 +1,33 @@
+# Unit-test gate for the portal-aio stack (the Instance Portal / Caddy config
+# manager). Runs against portal-aio/requirements.txt — the same deps the image
+# installs (Dockerfile: `uv pip install -r /opt/portal-aio/requirements.txt`) —
+# so the test environment matches production. See ADR 0002.
+name: portal-aio tests
+
+on:
+  pull_request:
+    paths:
+      - "portal-aio/**"
+      - ".github/workflows/portal-aio-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "portal-aio/**"
+      - ".github/workflows/portal-aio-tests.yml"
+
+jobs:
+  portal-aio-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps (the same set the image installs)
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r portal-aio/requirements.txt
+      - name: Run portal-aio tests
+        working-directory: portal-aio
+        run: python -m pytest tests -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -419,18 +419,26 @@ The Instance Portal provides tabbed browser access to services. It is configured
 ### Format
 
 ```
-PORTAL_CONFIG="localhost:internal:external:path:Label|localhost:internal:external:path:Label|..."
+PORTAL_CONFIG="localhost:external:internal:path:Label|localhost:external:internal:path:Label|..."
 ```
 
-Fields are colon-separated, entries are pipe-separated:
+Fields are colon-separated, entries are pipe-separated. Field order matches the
+runtime parser (`portal-aio/caddy_manager/caddy_config_manager.py`):
 
 | Field | Example | Description |
 |-------|---------|-------------|
 | Host | `localhost` | Always `localhost` |
-| Internal port | `7860` | Port the app listens on inside the container |
-| External port | `17860` | Port exposed to the user (convention: internal + 10000) |
+| External port | `7860` | The Caddy-front port — what the user reaches; Caddy terminates TLS + auth here |
+| Internal port | `17860` | The port the app listens on inside the container (bind loopback) |
 | Path | `/` | URL path for the tab link |
 | Label | `My App` | Tab label shown in the portal |
+
+External and internal ports are **arbitrary per image** — there is no
+`internal + 10000` rule (see [docs/invariants.md](docs/invariants.md) §3). When
+`external == internal`, Caddy **skips proxying** and the port is served directly
+and **unauthenticated** — used deliberately for tab-only entries (e.g. the Jupyter
+Terminal `8080:8080`); never point an equal-port entry at a service that must be
+authenticated.
 
 ### Example
 

--- a/docs/adr/0002-portal-config-and-expose-conventions.md
+++ b/docs/adr/0002-portal-config-and-expose-conventions.md
@@ -96,23 +96,23 @@ scaffold.
     one entry stays EXPOSE-safe even if it is equal-port in another entry (the
     multi-URL convention).
 - **Linter checks** (codes in RULES so `docs/lint-rules.md` regenerates):
-  - **L050 (ERROR):** `set(EXPOSE) == required`.
-  - **L051 (ERROR, security, advisory-over-the-real-gate):** `set(EXPOSE) ∩ forbidden == ∅`
+  - **L056 (ERROR):** `set(EXPOSE) == required`.
+  - **L057 (ERROR, security, advisory-over-the-real-gate):** `set(EXPOSE) ∩ forbidden == ∅`
     — "never EXPOSE a port that no entry proxies." Per Binding condition 1, this static
     pass is explicitly *advisory*; the bind smoke-check is the gate.
-  - **L052 (WARN→ERROR after migration):** image bakes no default.
+  - **L058 (WARN→ERROR after migration):** image bakes no default.
   - Mutant tests: proxied+equal-port-tab on the same external must PASS EXPOSE of that
     port; equal-port-only must FAIL; pure internal must FAIL; plus the aio-studio
     selkies-strip mutation case.
 - **Generator:** scaffolds a matched `EXPOSE` + `PORTAL_CONFIG` pair with `CHANGEPORT`
   markers and a required explicit declaration for any equal-port/direct entry.
 - **Migration (monotonic; per-image/family; never base-inherited-to-all-33-at-once):**
-  (1) land parser + L050/L051 dormant + L052 WARN;
+  (1) land parser + L056/L057 dormant + L058 WARN;
   (2) backfill `EXPOSE` on the 9 baked images, auditing each entry against the app's
   actual launch `--port`/`HOST`;
   (3) backfill default + `EXPOSE` on the 24, batched by build family, each with a
   `docker build` + boot smoke test;
-  (4) flip L052→ERROR once all bake a default; add the regression-net assertion.
+  (4) flip L058→ERROR once all bake a default; add the regression-net assertion.
 
 ## Binding conditions
 
@@ -123,7 +123,7 @@ it claims to prevent):
 1. **The `0.0.0.0` bind check is a MANDATORY smoke gate, not "static-where-visible."**
    For every image the boot smoke test runs an in-container `ss -ltnp` and FAILS if any
    `EXPOSE`d port — *including equal-port siblings sharing that external* — has a
-   `0.0.0.0`/`::` listener. L051's static pass is downgraded to advisory; this is the
+   `0.0.0.0`/`::` listener. L057's static pass is downgraded to advisory; this is the
    real gate. (Binds are routinely not statically visible: `npm run start`,
    `acestep-api --port 8001`, `${WAN2GP_PORT}`.)
 2. **`portal.py` extracts `PORTAL_CONFIG` including the env script's post-assignment
@@ -141,8 +141,8 @@ it claims to prevent):
    the platform guarantees those maps. Otherwise a host that does not auto-open 1111
    leaves the Instance Portal unreachable while EXPOSE of 1111 is forbidden.
 
-Additionally documented (not gates, but must be stated so a green L051 is not
-misread): **L051 proves "proxied," not "authenticated"** — a runtime `AUTH_EXCLUDE`
+Additionally documented (not gates, but must be stated so a green L057 is not
+misread): **L057 proves "proxied," not "authenticated"** — a runtime `AUTH_EXCLUDE`
 can mark a proxied port no-auth, outside the linter's view; and the linter validates
 the baked default, not the post-`10-prep-env.sh`-mutation runtime string. The smoke
 test must `rm /etc/portal.yaml` first (the runtime prefers that cache over
@@ -155,7 +155,7 @@ test must `rm /etc/portal.yaml` first (the runtime prefers that cache over
   is a regression net over all images; fits the existing linter discipline with minimal
   new machinery; both encodings stay greppable.
 - **Negative / accepted:** two encodings persist, so drift is *detected* not impossible
-  (mitigated by L050 in CI); a second `PORTAL_CONFIG` parser must track the runtime one
+  (mitigated by L056 in CI); a second `PORTAL_CONFIG` parser must track the runtime one
   (mitigated by a pinned test); the real safety gate is a per-image GPU-class smoke test
   asserting loopback binds, which is heavier than a static check; `AUTH_EXCLUDE` and the
   64-port ceiling remain unmodeled (documented, not gated).
@@ -165,7 +165,7 @@ test must `rm /etc/portal.yaml` first (the runtime prefers that cache over
 - If `portal.py` cannot reliably extract the effective `PORTAL_CONFIG` (condition 2
   infeasible) AND dumping a rendered runtime config in smoke proves impractical → the
   static cross-check is unsound; ship only the bind smoke-gate (condition 1) and drop
-  L050/L051.
+  L056/L057.
 - If the mandatory `0.0.0.0` bind smoke-gate (condition 1) cannot be made to run for
   every family → do not add `EXPOSE`; EXPOSE without that gate is in direct tension with
   the loopback invariant and manufactures false confidence.

--- a/docs/adr/0002-portal-config-and-expose-conventions.md
+++ b/docs/adr/0002-portal-config-and-expose-conventions.md
@@ -1,0 +1,173 @@
+# ADR 0002 — Bake PORTAL_CONFIG defaults + EXPOSE Caddy-front ports across all images
+
+- **Status:** Accepted (conditional — see Binding conditions)
+- **Date:** 2026-06-23
+- **Decision owner:** Rob Ballantyne
+- **Process:** idea brief → critical review → competing designs → multi-dimension review
+  (feasibility / maintainability / risk) → synthesis → final review gate on the plan.
+
+## Context
+
+Creating a Vast.ai marketplace/frontend template currently requires the template
+author to hand-author the published port mappings and the `PORTAL_CONFIG` env var
+per template — manual, duplicated, error-prone. The proposal: make each image
+*self-describing* so template creation derives ports from the image.
+
+Verified reality that shapes the decision:
+
+- **`EXPOSE` is used in 0 of 33 Dockerfiles.** `PORTAL_CONFIG` is baked in only 9
+  images via `ROOT/etc/vast_boot.d/05-<name>-env.sh`, always behind an
+  `if [[ -z $PORTAL_CONFIG ]]` guard (bake a default; the launch template
+  overrides). The other 24 rely entirely on the template.
+- **Vast auto-maps `EXPOSE`d ports.** Per the Vast Docker-execution docs, any
+  `EXPOSE`d port becomes an external port request. This is the friction reduction:
+  EXPOSE-ing the Caddy-front port makes `VAST_TCP_PORT_<ext>` exist, which (per the
+  parser, below) is what makes Caddy actually stand up the proxy site — without the
+  template author adding `-p`. 64-port/instance limit; 8080/22 auto-opened.
+- **Authoritative `PORTAL_CONFIG` format** (`portal-aio/caddy_manager/caddy_config_manager.py:26`,
+  `hostname,ext,int,path,name = s.split(':',4)`): `localhost:<external>:<internal>:<path>:<Label>`,
+  pipe-separated. **`CONTRIBUTING.md` documents this order BACKWARDS** — must be fixed.
+- **Caddy proxy gate** (`caddy_config_manager.py:217`):
+  `if external_port == internal_port or not VAST_TCP_PORT_<external>: continue`.
+  Caddy stands up an auth site on `:external` ONLY when `external≠internal` AND the
+  host mapped it. **Equal-port (`ext==int`) entries are skipped — no site, no auth**;
+  they exist only as portal-tab metadata.
+- **Multi-URL convention:** an app needing multiple tabs uses ONE proxied entry
+  (`ext≠int`) to force Caddy, plus subsequent equal-port (`ext==int`) entries purely
+  for tab/URL building (avoids a duplicate-Caddy-site clash). So one external port
+  value can appear as both a proxied external and an equal-port external.
+- **The loopback-behind-Caddy security invariant is hard** (see
+  [docs/invariants.md](../invariants.md)); the repo has had two prior incidents of
+  services binding `0.0.0.0` and being exposed. `EXPOSE` + Vast auto-map turns a
+  latent `0.0.0.0` bind into a live public exposure.
+- **`external == internal + 10000` is NOT a real invariant** (invariants §3); external
+  ports are arbitrary per image. Known data bugs already exist: aio-studio `7861:7861`
+  (Wan2GP binds `17861`), ACE-Step entry `:3000` while it launches `--port 8001`.
+- Existing tooling [ADR 0001](0001-image-scaffolding-tooling.md): a Python generator +
+  tested static invariant linter (`tools/imagegen`), `L0xx` codes, mutant-per-invariant
+  tests, docs generated from the RULES catalog. Linter = FAST gate; `docker build` +
+  smoke = correctness gate.
+
+## Options considered
+
+- **Option 1 — Enforce, don't deduplicate (CHOSEN).** Keep two hand-authored
+  encodings (`EXPOSE` in the Dockerfile, the `PORTAL_CONFIG` default in
+  `05-<name>-env.sh`) and add cross-artifact linter checks that prove they agree.
+  Drift is *detected* every CI run, not made impossible. Won all three lenses
+  (feasibility 9, maintainability 8, risk 8). Decisive reasons: lowest net-new
+  machinery, perfect fit with the existing linter-as-gate discipline, both encodings
+  stay greppable at rest, per-image migration blast radius, security check is local
+  and fails safe.
+- **Option 2 — Single declarative source → generate everything.** A `services:` block
+  in each image's capability YAML; `imagegen sync` generates `EXPOSE` + the
+  `PORTAL_CONFIG` default into marked regions; round-trip byte-compare in CI. Rejected
+  as the spine: it makes drift *structurally impossible* (its real edge) but imports a
+  new contributor verb, marker-integrity-in-bash, a risky 33-image backfill, and a
+  runtime-behaviour change for the 24 previously-undefaulted images — and "drift
+  impossible" is mis-priced when "drift detected each CI run" is the standard the repo
+  already lives by. **Grafted:** its mandatory *explicit declaration* of equal-port /
+  direct entries (so an unauthenticated port is never an emergent accident), and its
+  matched-pair generator scaffold.
+- **Option 3 — Dockerfile ENV as source, boot-time derivation.** Two coordinated ENV
+  vars per Dockerfile + `EXPOSE ${VAR}` + a shared base boot script assembling
+  `PORTAL_CONFIG`. Rejected (feasibility 5, maintainability 4, risk 3): premise
+  (PORTAL_CONFIG as Dockerfile ENV) is contrary to the repo; relies on undocumented
+  `EXPOSE ${MULTI_PORT_VAR}` expansion; a base `EXPOSE` inherited by all 33 images at
+  once is exactly the broad-blast shape of the two prior incidents; and it forfeits a
+  greppable `PORTAL_CONFIG` literal at rest. Kept only as a warning: do **not**
+  centralise via base inheritance; migrate per-image/family.
+
+## Decision
+
+Adopt **Option 1**, grafting Option 2's explicit equal-port declaration + matched-pair
+scaffold.
+
+- **P0 prerequisite:** fix `CONTRIBUTING.md` field order to the parser's
+  (`hostname:external:internal:path:name`); extend the docs⟷linter agreement test to
+  cover port-field semantics.
+- **A shared `portal.py` parser** mirrors `caddy_config_manager.py:26`, pinned by a
+  test against the real parser, aggregating entries **by external port**.
+- **Set model** (a port is EXPOSE-safe iff *some* entry proxies it):
+  - `proxied_ext = {ext | ∃ entry ext≠int}`
+  - `forbidden = ({all int values} ∪ {ext | ∃ entry ext==int}) − proxied_ext`
+    (= ports no entry proxies)
+  - `required = proxied_ext − base_allowlist`
+  - `required` and `forbidden` are **disjoint by construction**, so a port proxied by
+    one entry stays EXPOSE-safe even if it is equal-port in another entry (the
+    multi-URL convention).
+- **Linter checks** (codes in RULES so `docs/lint-rules.md` regenerates):
+  - **L050 (ERROR):** `set(EXPOSE) == required`.
+  - **L051 (ERROR, security, advisory-over-the-real-gate):** `set(EXPOSE) ∩ forbidden == ∅`
+    — "never EXPOSE a port that no entry proxies." Per Binding condition 1, this static
+    pass is explicitly *advisory*; the bind smoke-check is the gate.
+  - **L052 (WARN→ERROR after migration):** image bakes no default.
+  - Mutant tests: proxied+equal-port-tab on the same external must PASS EXPOSE of that
+    port; equal-port-only must FAIL; pure internal must FAIL; plus the aio-studio
+    selkies-strip mutation case.
+- **Generator:** scaffolds a matched `EXPOSE` + `PORTAL_CONFIG` pair with `CHANGEPORT`
+  markers and a required explicit declaration for any equal-port/direct entry.
+- **Migration (monotonic; per-image/family; never base-inherited-to-all-33-at-once):**
+  (1) land parser + L050/L051 dormant + L052 WARN;
+  (2) backfill `EXPOSE` on the 9 baked images, auditing each entry against the app's
+  actual launch `--port`/`HOST`;
+  (3) backfill default + `EXPOSE` on the 24, batched by build family, each with a
+  `docker build` + boot smoke test;
+  (4) flip L052→ERROR once all bake a default; add the regression-net assertion.
+
+## Binding conditions
+
+Surviving conditions from the final review gate. If any is refused, the decision is
+void (it would manufacture a green check that ships the loopback-exposure regression
+it claims to prevent):
+
+1. **The `0.0.0.0` bind check is a MANDATORY smoke gate, not "static-where-visible."**
+   For every image the boot smoke test runs an in-container `ss -ltnp` and FAILS if any
+   `EXPOSE`d port — *including equal-port siblings sharing that external* — has a
+   `0.0.0.0`/`::` listener. L051's static pass is downgraded to advisory; this is the
+   real gate. (Binds are routinely not statically visible: `npm run start`,
+   `acestep-api --port 8001`, `${WAN2GP_PORT}`.)
+2. **`portal.py` extracts `PORTAL_CONFIG` including the env script's post-assignment
+   mutations** (e.g. aio-studio's selkies `:16100:` strip), pinned by a regression test
+   on that case. If infeasible, re-scope to lint the **rendered runtime config**
+   (a `portal.yaml` dumped during the smoke test), not the at-rest string — and say so.
+   The "validates the at-rest baked default" claim is not safely implementable as first
+   written.
+3. **The entry-audit reconciles each `PORTAL_CONFIG` internal port against the app's
+   actual launch `--port`/`HOST`**, treated as a found-bug fix with its own test (ACE-Step
+   `:3000` vs `--port 8001`; Wan2GP `7861:7861` vs `17861`). Because "fixing" an entry to
+   `ext≠int` is what arms the exposure, condition 1 and condition 3 must land **together**
+   — never the audit first.
+4. **Remove the hardcoded `{1111,8080}` base-allowlist, or justify it with a test** that
+   the platform guarantees those maps. Otherwise a host that does not auto-open 1111
+   leaves the Instance Portal unreachable while EXPOSE of 1111 is forbidden.
+
+Additionally documented (not gates, but must be stated so a green L051 is not
+misread): **L051 proves "proxied," not "authenticated"** — a runtime `AUTH_EXCLUDE`
+can mark a proxied port no-auth, outside the linter's view; and the linter validates
+the baked default, not the post-`10-prep-env.sh`-mutation runtime string. The smoke
+test must `rm /etc/portal.yaml` first (the runtime prefers that cache over
+`PORTAL_CONFIG`).
+
+## Consequences
+
+- **Positive:** template authoring needs less hand-typing (EXPOSE auto-requests the
+  port that makes Caddy proxy it); images self-describe their port map; the cross-check
+  is a regression net over all images; fits the existing linter discipline with minimal
+  new machinery; both encodings stay greppable.
+- **Negative / accepted:** two encodings persist, so drift is *detected* not impossible
+  (mitigated by L050 in CI); a second `PORTAL_CONFIG` parser must track the runtime one
+  (mitigated by a pinned test); the real safety gate is a per-image GPU-class smoke test
+  asserting loopback binds, which is heavier than a static check; `AUTH_EXCLUDE` and the
+  64-port ceiling remain unmodeled (documented, not gated).
+
+## What would reverse this
+
+- If `portal.py` cannot reliably extract the effective `PORTAL_CONFIG` (condition 2
+  infeasible) AND dumping a rendered runtime config in smoke proves impractical → the
+  static cross-check is unsound; ship only the bind smoke-gate (condition 1) and drop
+  L050/L051.
+- If the mandatory `0.0.0.0` bind smoke-gate (condition 1) cannot be made to run for
+  every family → do not add `EXPOSE`; EXPOSE without that gate is in direct tension with
+  the loopback invariant and manufactures false confidence.
+- If Vast's EXPOSE auto-map behaviour changes such that EXPOSE no longer drives
+  `VAST_TCP_PORT_<ext>` → the friction-reduction rationale collapses; revisit.

--- a/docs/adr/0003-portal-hf-space-installer.md
+++ b/docs/adr/0003-portal-hf-space-installer.md
@@ -1,0 +1,218 @@
+# ADR 0003 — Install + run a HuggingFace Space on a live instance (portal feature)
+
+- **Status:** Accepted (conditional — binding conditions from the final review; conditions 1 & 3 remain blocking, **revised 2026-06-24**)
+- **Date:** 2026-06-24
+- **Decision owner:** Rob Ballantyne
+- **Process:** idea brief → critical review (reshaped: dropped nothing, surfaced reachability) →
+  competing designs → multi-dimension review (feasibility / maintainability / risk) →
+  synthesis → final review gate → **revision after two Vast-fact corrections, re-gated.**
+
+## Revision (2026-06-24) — two corrections to the experts' Vast model, re-gated
+
+Two premises the plan was gated on were wrong; both were re-examined on review:
+
+- **Overlay storage persists across stop/start** (lost only on DESTROY). `load_config()`
+  reads `/etc/portal.yaml` when present and regenerates from the `PORTAL_CONFIG` env var
+  only when ABSENT, so Space entries written to it **survive stop/start** (regenerated only
+  on destroy, which correctly has no installed apps). → **Condition 2 downgraded** from
+  "a separate persistent store is mandatory" to "persistent `/etc/portal.yaml` is a viable
+  registry **with** four sub-conditions" (2A–2D below). No longer blocking.
+- **Docker Spaces are handled by Dockerfile-as-RECIPE, not by building/running a
+  container.** The `Dockerfile` is parsed and its instructions translated into provisioner
+  steps replayed on the live instance (no DinD / podman / nested namespaces / host probe).
+  → **Condition 6 (container-runtime feasibility) DROPPED.** Replaced by conditions 7–9.
+  Coverage is partial (~half-to-two-thirds of real Docker Spaces; ~a third honestly
+  refused — multi-stage / `COPY --from` / compiled artifacts / non-apt bases).
+
+**Unchanged by the corrections:** conditions **1 (consent gates the capability, not the
+UI)** and **3 (spare-port raw ingress)** remain **FATAL/blocking** — they are orthogonal to
+persistence and Docker handling, and Dockerfile-as-recipe makes #1 *worse* (the
+unauthenticated boot/`PROVISIONING_URL` path can now replay arbitrary `RUN` as root).
+
+**Latent base bug found while re-gating** (independent of this feature): an empty
+`/etc/portal.yaml` (created by `caddy.sh`'s `touch` when `PORTAL_CONFIG` is unset) makes
+`caddy_config_manager.load_config()` do `yaml.safe_load('')['applications']` → `TypeError`
+→ no Caddyfile → Caddy/portal front fails to start. `portal.py:169` already uses the safe
+`.get('applications', {})`; the Caddy manager (line 18) should too. Fix under the
+Bug→Invariant protocol separately.
+
+## Context
+
+Users find ready-to-run model demos on HuggingFace Spaces but running one on a rented
+GPU today means hand-reverse-engineering its SDK/entrypoint/requirements into a
+provisioning manifest or a Dockerfile. The idea: from the Instance Portal, point at a
+Space (repo id/URL), and have it installed, launched loopback-bound, and surfaced as an
+authenticated portal tab.
+
+Verified reality that shapes the decision:
+
+- **Most of the install machinery already exists.** The provisioner (`lib/provisioner`)
+  clones git repos, installs apt/pip/conda, downloads HF models, and `register_services`
+  writes a supervisor conf+script and `supervisorctl reread/update` — i.e. it already
+  registers a new long-running service on a LIVE instance, idempotently. Its `Service`
+  schema supports isolated venvs + env injection with **no schema change**. So the novel
+  surface is narrow: a **HF-Space → provisioner-manifest adapter**.
+- **Reachability is fixed at instance creation.** Caddy proxies an external port only if
+  `external != internal` AND `VAST_TCP_PORT_<ext>` exists (set at creation; see
+  [ADR 0002](0002-portal-config-and-expose-conventions.md)). There is no runtime
+  "open a port" API. **Resolution: the instance template reserves a POOL of spare mapped
+  external ports; the feature leases one per app.**
+- **`/etc/portal.yaml` is a regenerable boot CACHE of the `PORTAL_CONFIG` env var**, not
+  durable authored state (`caddy_config_manager.load_config`). A stop/start can rewrite
+  it from env. The Caddy manager is one-shot (no live-reload); applying config =
+  `supervisorctl restart caddy` (a ~1–2s bounce of all portal sessions).
+- **No container runtime exists in any image today** (podman/buildah/CDI/slirp4netns are
+  greenfield).
+- The instance is **single-tenant, everything runs as root, no sandboxing**; it holds the
+  user's `HF_TOKEN` and platform creds in env. `venv` is not a security boundary. The
+  hard loopback-behind-Caddy invariant and two prior `0.0.0.0` exposure incidents
+  ([invariants](../invariants.md) §4) are the security backdrop.
+
+## Options considered
+
+- **Option 1 — Thin manifest adapter on the provisioner (CHOSEN as the Phase-1 spine).**
+  Pure functions (`detect`, `reconcile`, `space_to_manifest`, `ports`) emit a provisioner
+  manifest; thin portal routes preview + submit it to the existing provisioner. Won
+  feasibility (8) and maintainability (9): almost no unproven mechanism on the critical
+  path, ~zero net-new toolchain, matches ADR 0002's "reuse + detect drift, don't
+  reinvent" judgment. Risk lens rated it **3/10** (run-as-root RCE next to secrets) — the
+  reason for the binding conditions and the Phase-2 commitment.
+- **Option 2 — First-class portal app-lifecycle subsystem (rejected).** A new
+  `app_lifecycle` package with a persistent `apps.json` store, free-port lease registry,
+  full lifecycle, boot-reconcile. Rejected as the spine: it manufactures the exact
+  persistent-state drift/GC burden ADR 0002 deliberately avoided (maintainability 5).
+  **Grafted:** its **private-internal-port lease idea** (assign the internal bind from an
+  unmapped 14000–14999 range so `ext != int` by construction) and its
+  **validate-before-apply + rollback** for Caddy. But see binding condition 2 — a real
+  (small) state store IS needed; "derive from portal.yaml" is unsound.
+- **Option 3 — Everything-is-a-container (rejected for Phase 1; adopted as Phase 2).**
+  Every Space → image → nested rootless podman container; the container boundary is the
+  only resolution that makes Python Spaces actually safe and disarms the `0.0.0.0` footgun
+  by construction (risk 6/10, the highest). Rejected now because it depends on nested
+  unprivileged user-namespaces + rootless GPU **inside the already-unprivileged Vast
+  container** — a host-gated capability that silently degrades to zero value on some
+  hosts (feasibility 4, maintainability 2) and imports a large greenfield toolchain.
+  **Adopted as the Phase-2 direction** (namespace/container isolation where the host
+  supports it). NOTE (revision): Docker Spaces are NOT built/run as containers in Phase 1
+  — see Dockerfile-as-recipe in the Decision. The container path is purely a Phase-2
+  isolation question now, not a Docker-feasibility one.
+
+## Decision
+
+**Phased.** Ship **Option 1** as Phase 1, evolve toward **Option 3** isolation in Phase 2.
+
+- **Phase 1 (always-works):** the thin manifest adapter. `detect` parses the README YAML
+  and **refuses with reasons** (missing `sdk`/`app_file`, gated model, Docker unavailable)
+  rather than guessing. `reconcile` reconciles the Space's torch pin to the instance CUDA.
+  `space_to_manifest` emits a manifest: `git_repos` + an isolated `/venv/spaces/<name>`
+  pip target + a `services` entry binding loopback. Python Spaces run **as root** (venv
+  isolation only), accepted via explicit consent (see conditions). External port leased
+  from the spare pool; **internal bind from the unmapped 14000–14999 range**. **Docker
+  Spaces: the `Dockerfile` is parsed as a RECIPE** — `RUN apt`→`apt_packages`, `RUN pip`→
+  isolated-venv pip (torch pins stripped per the repo convention), `ENV`/`WORKDIR`/`CMD`→
+  the supervisor service, with a mandatory `0.0.0.0`→`127.0.0.1` launch rewrite — and
+  replayed on the live instance via the provisioner. No container is built or run. Recipes
+  that can't translate faithfully (multi-stage, `COPY --from`, compiled artifacts, non-apt
+  bases) are **refused with reasons** (condition 7), never best-effort. No fake
+  secret-scrub; the Space process simply isn't handed `HF_TOKEN` (the trusted provisioner
+  still uses it for gated downloads).
+- **Phase 2:** namespace/container isolation for all SDK types where the host supports it
+  (closes the run-as-root hole and condition 3 structurally).
+
+## Binding conditions
+
+Surviving findings from the review, **as revised 2026-06-24**. Conditions **1 and 3 are
+blocking** (the decision is void without them); the rest are required before the
+corresponding surface ships.
+
+1. **Gate the capability, not the UI.** [BLOCKING] The provisioner must refuse to
+   auto-install-and-run a Space from the unauthenticated boot / `PROVISIONING_URL` path;
+   running Space code as root requires an authenticated, consented portal action (a consent
+   token set only by the authenticated UI and checked in the provisioner step type). Until
+   this exists, the consent screen is decorative. Made more acute by condition 7 — the boot
+   path would otherwise replay arbitrary Dockerfile `RUN` as root.
+2. **Persistent `/etc/portal.yaml` as the registry — viable with four sub-conditions**
+   [RESHAPEABLE; downgraded from blocking]. The overlay persists across stop/start, so
+   merged-not-clobbered `portal.yaml` is a sound durable registry. But it requires:
+   - **2A.** Harden `caddy_config_manager.load_config` to `.get('applications', {})` (and
+     treat an empty file as absent); always write a well-formed `{'applications': {...}}`.
+     (Also the standalone base bug above.)
+   - **2B.** A **boot-time reconcile** that re-derives base entries (Instance Portal,
+     Jupyter) from the current `PORTAL_CONFIG` env + `10-prep-env.sh` logic and merges the
+     persisted Space entries on top — because once the file exists the env is otherwise
+     ignored forever (a later template change would silently never apply).
+   - **2C.** **Revalidate leased `external` ports against `VAST_TCP_PORT_*` on every boot** —
+     host mappings can move across stop/start, silently dropping a persisted entry from the
+     Caddy proxy gate (installed-but-unreachable with no error).
+   - **2D.** Atomic write-temp-then-rename + a lock (the current `open('w')`+`yaml.dump` is
+     non-atomic; a torn file resurrects 2A's crash).
+3. **Close, or name, the spare-external-port ingress.** [BLOCKING] A root Space can bind a free
+   *mapped* spare port directly → raw, unauthenticated, TLS-less public ingress (an
+   abuse-host harm, not just secret exfil). Either make spare ports mapped **on lease**
+   (so an unleased port has no `VAST_TCP_PORT` to abuse — a platform-side change), or get
+   explicit product-owner sign-off naming "unauthenticated public ingress / abuse host" in
+   the consent text as an accepted Phase-1 harm.
+4. **`reconcile` compatibility = actual install + import in the isolated venv**, not a
+   static pin check (invariants §4: torch success is runtime-only). Runtime failure →
+   blocker, before committing to a multi-GB model download where possible.
+5. **Adopt the existing detached-restart pattern** (`portal.py`'s self-restart) for the
+   Caddy bounce so the triggering request can report commit/rollback; respect
+   `UNSTOPPABLE_PROCESSES`. `caddy validate` before restart; keep the prior Caddyfile for
+   rollback.
+6. ~~Scope honesty: Docker SDK out for Phase 1 (no container runtime).~~ **DROPPED** — the
+   Dockerfile-as-recipe revision removes the container-runtime dependency; Docker SDK is in
+   scope for Phase 1 via recipe translation, subject to conditions 7–9.
+7. **Dockerfile-as-recipe: hard refusal, not best-effort.** Refuse (with the offending
+   instruction + reason) on multi-stage builds, `COPY --from`, compiled-artifact `RUN`s,
+   non-apt bases, and any non-allowlisted instruction. A non-translatable Dockerfile must
+   fail loudly at install, never silently produce a dead app. Pass A (the refusal
+   classifier) is built and tested **first**, against a real corpus of HF Docker-Space
+   Dockerfiles.
+8. **Mandatory post-install bind/serve smoke check before a Space is recorded "installed."**
+   Static translation is explicitly not a correctness gate (CLAUDE.md: static is fast, the
+   real check is runtime). The service must be confirmed serving on its declared loopback
+   port before the portal entry is committed — this is the real gate the recipe path leans
+   on, given lossy translation.
+9. **Replayed `RUN` is untrusted root code on the LIVE filesystem.** Unlike a container
+   build (effects confined to an image layer), recipe `RUN`s mutate the real root FS where
+   the user's secrets live — equal-or-worse containment than the Python-Space path. Treat
+   it under the same consent/isolation regime; feed it into the Phase-2 threat model. Do
+   not let "it's just a recipe" downgrade the threat assessment.
+
+Additionally (not blocking, but recorded): the `ss -ltnp` loopback check is a
+**functional/correctness** gate (did the app bind loopback on its declared port; poll,
+don't snapshot) — it is **explicitly not** an adversarial security control. The
+14000–14999 internal range must be a confirmed cross-team contract that the template
+never maps, or its "not externally reachable" guarantee evaporates. Space names
+(`owner/space`) must be sanitized before reaching `register_services` (regex-guarded).
+
+## Consequences
+
+- **Positive:** delivers the headline value (run a Space on your GPU) on every host in
+  Phase 1; rides the tested provisioner (`register_services`, FileLock, idempotency) with
+  minimal net-new surface; the private-internal-range lease kills the equal-port footgun
+  and keeps a misbinding Space's intended port off the public map; torch reconciliation
+  matches the repo's strip-and-repin convention.
+- **Negative / accepted:** Phase 1 runs untrusted code as root on the user's single-tenant
+  box (consent-gated, not isolated); condition 3's ingress hole persists until Phase 2 (or
+  a lease-time port-mapping platform change); `/etc/portal.yaml` is the durable registry but
+  needs the 2A–2D reconcile/hardening; Docker Spaces are **in scope via recipe** but ~a
+  third are honestly refused; the Caddy restart bounces portal sessions.
+  **The phasing risk is real:** Phase 1 ships the cheap dangerous half and defers the
+  expensive safe half — Phase 2 must not be allowed to become Phase-never (see reversal).
+  **Conditions 1 and 3 remain blocking and were NOT resolved by the 2026-06-24 corrections;
+  the feature does not proceed to build until both have enforced (not UI-level) controls.**
+
+## What would reverse this
+
+- If condition 1 (capability gating) or condition 2 (real state) cannot be met, **stop** —
+  the safety story and the lifecycle/port bookkeeping both collapse on the real codebase.
+- If the platform cannot offer lease-time port mapping AND the product owner will not
+  accept the named ingress harm (condition 3), Phase 1 should not ship run-as-root Spaces;
+  hold for Phase-2 isolation.
+- If Phase-2 isolation proves unbuildable on the host fleet (nested rootless GPU fails on
+  most hosts — the empirical go/no-go Option 3 flagged), then the feature is permanently
+  a run-untrusted-code-as-root tool; reassess whether the official portal should ship it
+  at all versus leaving it a power-user provisioner manifest.
+- If new-Space volume is low enough that a documented "here's the manifest to write"
+  recipe suffices, the adapter may not warrant portal UI at all.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -203,8 +203,10 @@ every Caddy-front (external) port the config declares must actually be exposed (
 `EXPOSE` a port no entry proxies — that port would be mapped publicly with **no auth
 in front**.
 
-- **L056** — the effective exposed set (own + inherited) covers exactly the baked
-  PORTAL_CONFIG Caddy-front ports.
+- **L056** — the effective exposed set (own EXPOSE + inherited via FROM) covers every
+  baked PORTAL_CONFIG Caddy-front port *except* the base-owned ports (1111 Instance
+  Portal, 8080 Jupyter), which the template's `ports:` list opens rather than the image
+  (the `BASE_ALLOWLIST`; ADR 0002 `required = proxied_ext − base_allowlist`).
 - **L057** — `EXPOSE` never includes a port no entry proxies (a loopback/internal
   port, or an equal-port entry Caddy deliberately serves direct) — the security case.
 - **L058** (WARN) — the image bakes a default `PORTAL_CONFIG` at all (else it relies

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -192,6 +192,32 @@ wrappers) for an explicit internal-prefix set — extend `_INTERNAL_TRACKERS` as
 internal projects appear. Precedent: the CON-/HOST-/CLN- references scrubbed from
 docs, workflows, templates, and tooling when this rule landed (ADR 0012).
 
+### EXPOSE matches the baked PORTAL_CONFIG; nothing exposed without a Caddy front — **GATED (L056 / L057; L058 WARN)**
+
+The relationship between a Dockerfile's `EXPOSE` set and the image's baked default
+`PORTAL_CONFIG` is statically checkable (ADR 0002). A `PORTAL_CONFIG` entry is
+`localhost:external:internal:path:Label` — Caddy fronts the *external* port (TLS +
+auth) and proxies to the app's *internal* loopback port. Two obligations follow:
+every Caddy-front (external) port the config declares must actually be exposed (own
+`EXPOSE` or inherited via `FROM`, which is cumulative), and the image must never
+`EXPOSE` a port no entry proxies — that port would be mapped publicly with **no auth
+in front**.
+
+- **L056** — the effective exposed set (own + inherited) covers exactly the baked
+  PORTAL_CONFIG Caddy-front ports.
+- **L057** — `EXPOSE` never includes a port no entry proxies (a loopback/internal
+  port, or an equal-port entry Caddy deliberately serves direct) — the security case.
+- **L058** (WARN) — the image bakes a default `PORTAL_CONFIG` at all (else it relies
+  on the launch template); advisory during the migration.
+
+L056/L057 **ship dormant** — they fire only once an image declares its *own*
+`EXPOSE`, so they gate the ADR-0002 migration as images opt in, rather than failing
+the whole fleet at once. The static checks are the fast advisory layer over the real
+runtime gate, `imagegen bindcheck` (`smoke/bind-check.sh`), which inspects `ss -ltnp`
+on a live box. This is the *constructive* counterpart to §3's finding that
+`external == internal + 10000` is **not** a real convention: the rule is the
+external→internal *proxy* relationship, not an arithmetic offset.
+
 ### Copyleft licence compliance (proposed)
 
 An image that ships GPL-/AGPL-licensed code must (a) convey the licence **text** in

--- a/docs/lint-rules.md
+++ b/docs/lint-rules.md
@@ -25,5 +25,8 @@
 | L053 | ERROR | No baked model weights in a Dockerfile RUN — models arrive at runtime via provisioning / <APP>_MODEL (invariants §6) |
 | L054 | ERROR | A template's VRAM floor, IF set, uses a valid key (gpu_ram / gpu_total_ram, MB) with a numeric value — presence is optional (multi-model hosts omit it; qa supplies it) |
 | L055 | ERROR | External images set ENV TCLLIBPATH=/usr/lib/tcltk/default (they FROM upstream, not our base, so don't inherit it) — else the pty helper's unbuffer/Expect fails and the app launch dies at boot |
+| L056 | ERROR | Effective EXPOSE (own + inherited via FROM) covers exactly the baked PORTAL_CONFIG Caddy-front ports — fires only once an image declares its own EXPOSE (ADR 0002) |
+| L057 | ERROR | EXPOSE never includes a port no PORTAL_CONFIG entry proxies (loopback/internal or equal-port-only) — never expose a port without a Caddy auth front (ADR 0002) |
+| L058 | WARN | Image bakes a default PORTAL_CONFIG (else it relies on the launch template) — advisory during the ADR 0002 migration |
 | L060 | ERROR | No credential-shaped secret committed in docs/adr/** — this repo is public; sensitive specifics live in the internal tracker, not the ADR (ADR 0012) |
 | L061 | ERROR | No internal tracker ticket id (CON-/HOST-/CLN-…) in any public-repo file — it leaks the internal tracker and dangles for external readers; the internal issue links to the ADR/commit, not the reverse (ADR 0012) |

--- a/portal-aio/caddy_manager/caddy_config_manager.py
+++ b/portal-aio/caddy_manager/caddy_config_manager.py
@@ -11,12 +11,17 @@ KEY_PATH = "/etc/instance.key"
 MAX_RETRIES = 5
 
 
-def load_config():
-    yaml_path = '/etc/portal.yaml'
+def load_config(yaml_path='/etc/portal.yaml'):
     if os.path.exists(yaml_path):
         with open(yaml_path, 'r') as file:
-            return yaml.safe_load(file)['applications']
-    
+            data = yaml.safe_load(file)
+        # A present-but-empty/malformed cache (e.g. caddy.sh `touch`es /etc/portal.yaml
+        # before any PORTAL_CONFIG is set) must be treated as ABSENT — fall through and
+        # regenerate from PORTAL_CONFIG, never crash on a missing 'applications' key.
+        # `yaml.safe_load('')` is None; an empty/odd doc has no usable applications map.
+        if isinstance(data, dict) and data.get('applications'):
+            return data['applications']
+
     apps_string = os.environ.get('PORTAL_CONFIG', '')
     if not apps_string:
         raise ValueError("No configuration found in YAML or environment variable")

--- a/portal-aio/tests/test_caddy_config.py
+++ b/portal-aio/tests/test_caddy_config.py
@@ -1,0 +1,82 @@
+"""Regression tests for caddy_manager.load_config — the empty/malformed
+/etc/portal.yaml crash.
+
+Bug: `caddy.sh` `touch`es /etc/portal.yaml when PORTAL_CONFIG is unset, leaving a
+zero-byte file. On the next boot load_config saw the file exists and did
+`yaml.safe_load('')['applications']` → `None['applications']` → TypeError → no
+Caddyfile written → the whole Caddy/portal front failed to start. The invariant:
+**a present-but-empty/malformed cache is treated as ABSENT** (fall through to
+PORTAL_CONFIG), never a crash.
+
+Run from the portal-aio directory (or repo root) with pytest.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from caddy_manager import caddy_config_manager as ccm
+
+
+_CFG = "localhost:1111:11111:/:Instance Portal|localhost:7860:17860:/:App UI"
+
+
+def test_empty_cache_file_falls_through_to_env(tmp_path, monkeypatch):
+    """The reported bug: an empty portal.yaml must NOT crash; with PORTAL_CONFIG set
+    it regenerates from env. (Pre-fix this raised TypeError.)"""
+    p = tmp_path / "portal.yaml"
+    p.write_text("")  # the zero-byte file `caddy.sh` leaves behind
+    monkeypatch.setenv("PORTAL_CONFIG", _CFG)
+    apps = ccm.load_config(str(p))
+    assert set(apps) == {"Instance Portal", "App UI"}
+    assert apps["App UI"]["external_port"] == 7860
+
+
+def test_missing_applications_key_falls_through(tmp_path, monkeypatch):
+    """A valid-YAML cache lacking 'applications' is treated as absent, not a KeyError."""
+    p = tmp_path / "portal.yaml"
+    p.write_text("something_else: true\n")
+    monkeypatch.setenv("PORTAL_CONFIG", _CFG)
+    assert set(ccm.load_config(str(p))) == {"Instance Portal", "App UI"}
+
+
+def test_empty_cache_and_no_env_raises_valueerror_not_typeerror(tmp_path, monkeypatch):
+    """No config anywhere is a graceful ValueError (the pre-existing 'no config' path),
+    never a TypeError crash on the empty file."""
+    p = tmp_path / "portal.yaml"
+    p.write_text("")
+    monkeypatch.delenv("PORTAL_CONFIG", raising=False)
+    with pytest.raises(ValueError):
+        ccm.load_config(str(p))
+
+
+def test_valid_cache_wins_over_env(tmp_path, monkeypatch):
+    """A populated cache is authoritative; the env is ignored (cache-preferred)."""
+    p = tmp_path / "portal.yaml"
+    p.write_text(
+        "applications:\n"
+        "  Cached App:\n"
+        "    hostname: localhost\n"
+        "    external_port: 9000\n"
+        "    internal_port: 19000\n"
+        "    open_path: /\n"
+        "    name: Cached App\n"
+    )
+    monkeypatch.setenv("PORTAL_CONFIG", _CFG)  # must be ignored
+    apps = ccm.load_config(str(p))
+    assert set(apps) == {"Cached App"}
+
+
+def test_regenerated_cache_is_well_formed(tmp_path, monkeypatch):
+    """When regenerating from env, the written file is a valid {'applications': {...}}
+    doc that a subsequent load reads back without falling through."""
+    import yaml
+    p = tmp_path / "portal.yaml"
+    p.write_text("")
+    monkeypatch.setenv("PORTAL_CONFIG", _CFG)
+    ccm.load_config(str(p))  # regenerates + writes
+    doc = yaml.safe_load(p.read_text())
+    assert isinstance(doc, dict) and set(doc["applications"]) == {"Instance Portal", "App UI"}

--- a/tools/imagegen/imagegen/cli.py
+++ b/tools/imagegen/imagegen/cli.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from .discover import discover, find_repo_root, Image
 from .linter import lint_image, lint_repo, ERROR, WARN, EXCEPTIONS, rules_markdown
 from .generate import generate, CLASSES
+from .portal import parse_portal_config
+from . import portal_smoke
 
 
 def _gather(args) -> tuple[Path, list[Image]]:
@@ -117,6 +119,63 @@ def cmd_bump(args) -> int:
     return _bump.bump(args.name, repo=repo)
 
 
+def _read_arg(val: str | None) -> str:
+    """Return the literal value, or the file contents if given as `@path`."""
+    if not val:
+        return ""
+    if val.startswith("@"):
+        return Path(val[1:]).read_text(encoding="utf-8", errors="replace")
+    return val
+
+
+def cmd_bindcheck(args) -> int:
+    """ADR 0002 condition 1: the runtime bind-address smoke gate. Consumes a dumped
+    `ss -ltnp` and the rendered PORTAL_CONFIG string; fails on any public bind that
+    isn't the Caddy auth front. Orchestrated by tools/imagegen/smoke/bind-check.sh."""
+    ss_text = _read_arg(args.ss)
+    if not ss_text:
+        print("error: --ss (the `ss -ltnp` dump, literal or @file) is required", file=sys.stderr)
+        return 2
+
+    pc_text = _read_arg(args.portal_config)
+    try:
+        entries = parse_portal_config(pc_text) if pc_text else []
+    except ValueError as e:
+        print(f"error: bad PORTAL_CONFIG: {e}", file=sys.stderr)
+        return 2
+
+    # exposed ports: explicit override, else from the image/Dockerfile.
+    if args.exposed:
+        exposed = {int(t.split("/")[0]) for t in args.exposed.split() if t.split("/")[0].isdigit()}
+    elif args.dockerfile:
+        exposed = portal_smoke.exposed_ports(Path(args.dockerfile).read_text(encoding="utf-8", errors="replace"))
+    elif args.image:
+        repo = find_repo_root(Path(args.repo) if args.repo else Path.cwd())
+        img = next((i for i in discover(repo) if i.name == args.image), None)
+        if not img:
+            print(f"error: image {args.image!r} not found", file=sys.stderr)
+            return 2
+        exposed = portal_smoke.exposed_ports(img.text)
+    else:
+        print("error: need one of --exposed / --dockerfile / --image", file=sys.stderr)
+        return 2
+
+    listeners = portal_smoke.parse_ss(ss_text)
+    violations = portal_smoke.check_binds(listeners, exposed, entries)
+    errors = [v for v in violations if v.severity == ERROR]
+    warns = [v for v in violations if v.severity == WARN]
+
+    label = args.image or args.dockerfile or "image"
+    print(f"bind-check {label}: {len(listeners)} listeners | EXPOSE {sorted(exposed) or '∅'} "
+          f"| {len(errors)} errors | {len(warns)} warnings")
+    for v in sorted(violations, key=lambda v: (v.severity != ERROR, v.port)):
+        mark = "✗" if v.severity == ERROR else "·"
+        print(f"  {mark} [{v.severity} :{v.port}] {v.detail}")
+    if not errors:
+        print("bind-check PASS ✓ (nothing reachable is bound public without Caddy in front)")
+    return 1 if errors else 0
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(prog="imagegen")
     sub = ap.add_subparsers(dest="cmd", required=True)
@@ -186,6 +245,16 @@ def main(argv=None) -> int:
     qat = sub.add_parser("qa-teardown", help="tear down the held QA box recorded in the image's ledger")
     qat.add_argument("name", help="image name")
     qat.set_defaults(func=lambda a: __import__("imagegen.qa", fromlist=["teardown"]).teardown(a.name))
+
+    bc = sub.add_parser("bindcheck", help="runtime bind-address smoke gate (ADR 0002 cond. 1)")
+    bc.add_argument("--ss", required=True, help="`ss -ltnp` output (literal or @file)")
+    bc.add_argument("--portal-config", dest="portal_config",
+                    help="rendered PORTAL_CONFIG string (literal or @file)")
+    bc.add_argument("--exposed", help='EXPOSE ports, space-separated (e.g. "7860 8000")')
+    bc.add_argument("--dockerfile", help="read EXPOSE ports from this Dockerfile")
+    bc.add_argument("--image", help="read EXPOSE ports from this image's Dockerfile (by name)")
+    bc.add_argument("--repo", help="repo root (default: autodetect from cwd)")
+    bc.set_defaults(func=cmd_bindcheck)
 
     args = ap.parse_args(argv)
     return args.func(args)

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -19,7 +19,7 @@ from .discover import Image
 from .dockerfile import parse, stages, code_text, ini_sections, arg_defaults, resolve, parse_ref
 from .portal import (
     extract_baked_default, parse_portal_config,
-    proxied_externals, forbidden_expose_ports,
+    proxied_externals, required_expose_ports, forbidden_expose_ports,
 )
 from .portal_smoke import exposed_ports
 
@@ -667,9 +667,10 @@ def _inherited_exposed(img: Image, repo: Path) -> set[int]:
 
 
 def check_expose_portal(img: Image, repo: Path) -> Iterable[Finding]:
-    """L056/L057 — the EFFECTIVE exposed set (this image's own EXPOSE plus what it
-    inherits via FROM) must cover exactly the baked PORTAL_CONFIG's Caddy-front
-    ports, and the image must not itself EXPOSE a port nothing proxies. Fires only
+    """L056/L057 — the effective exposed set (own EXPOSE + inherited via FROM) must
+    cover every baked PORTAL_CONFIG Caddy-front port EXCEPT the base-owned ports
+    (1111/8080), which the template's `ports:` list opens; and the image must not
+    itself EXPOSE a port nothing proxies. Fires only
     once an image declares its OWN EXPOSE, so it ships dormant until migration
     (ADR 0002). L057 is the fast advisory layer over the real bind smoke gate."""
     if img.cls == "base":
@@ -687,12 +688,15 @@ def check_expose_portal(img: Image, repo: Path) -> Iterable[Finding]:
         yield Finding("L056", ERROR, img.name, rel, "baked PORTAL_CONFIG default is malformed (cannot parse)")
         return
 
-    required = proxied_externals(entries)          # full Caddy-front set (no hardcoded allowlist)
+    proxied = proxied_externals(entries)           # all Caddy-front externals (incl base-owned 1111/8080)
+    required = required_expose_ports(entries)      # ...minus BASE_ALLOWLIST: the base portal/Jupyter
+                                                   # ports are opened by the template's `ports:` list,
+                                                   # not the image's EXPOSE, so no image must declare them
     forbidden = forbidden_expose_ports(entries)
     effective = own | _inherited_exposed(img, repo)
 
-    # completeness: every Caddy-front port must end up exposed (own or inherited) so
-    # Vast maps it. Missing ones the base would provide hint "migrate the base first".
+    # completeness: every non-base Caddy-front port must end up exposed (own or inherited)
+    # so Vast maps it. Base-owned fronts (1111/8080) are template-provided, hence exempt.
     missing = sorted(required - effective)
     if missing:
         yield Finding("L056", ERROR, img.name, "Dockerfile",
@@ -705,7 +709,7 @@ def check_expose_portal(img: Image, repo: Path) -> Iterable[Finding]:
         yield Finding("L057", ERROR, img.name, "Dockerfile",
                       f"EXPOSE includes port(s) {bad} that no entry proxies (loopback/internal or "
                       "equal-port-only) — never EXPOSE a port without a Caddy auth front")
-    stray = sorted(own - required - forbidden)
+    stray = sorted(own - proxied - forbidden)   # a base front (e.g. 1111) the image also EXPOSEs is legitimate, not stray
     if stray:
         yield Finding("L056", ERROR, img.name, "Dockerfile",
                       f"EXPOSE port(s) {stray} have no proxied PORTAL_CONFIG entry — Caddy would "

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -17,6 +17,11 @@ from typing import Callable, Iterable
 
 from .discover import Image
 from .dockerfile import parse, stages, code_text, ini_sections, arg_defaults, resolve, parse_ref
+from .portal import (
+    extract_baked_default, parse_portal_config,
+    proxied_externals, forbidden_expose_ports,
+)
+from .portal_smoke import exposed_ports
 
 _DOCKER_HUB = (None, "docker.io", "index.docker.io", "registry-1.docker.io")
 
@@ -73,6 +78,9 @@ RULES: list[tuple[str, str, str]] = [
     ("L053", ERROR, "No baked model weights in a Dockerfile RUN — models arrive at runtime via provisioning / <APP>_MODEL (invariants §6)"),
     ("L054", ERROR, "A template's VRAM floor, IF set, uses a valid key (gpu_ram / gpu_total_ram, MB) with a numeric value — presence is optional (multi-model hosts omit it; qa supplies it)"),
     ("L055", ERROR, "External images set ENV TCLLIBPATH=/usr/lib/tcltk/default (they FROM upstream, not our base, so don't inherit it) — else the pty helper's unbuffer/Expect fails and the app launch dies at boot"),
+    ("L056", ERROR, "Effective EXPOSE (own + inherited via FROM) covers exactly the baked PORTAL_CONFIG Caddy-front ports — fires only once an image declares its own EXPOSE (ADR 0002)"),
+    ("L057", ERROR, "EXPOSE never includes a port no PORTAL_CONFIG entry proxies (loopback/internal or equal-port-only) — never expose a port without a Caddy auth front (ADR 0002)"),
+    ("L058", WARN, "Image bakes a default PORTAL_CONFIG (else it relies on the launch template) — advisory during the ADR 0002 migration"),
     ("L060", ERROR, "No credential-shaped secret committed in docs/adr/** — this repo is public; sensitive specifics live in the internal tracker, not the ADR (ADR 0012)"),
     ("L061", ERROR, "No internal tracker ticket id (CON-/HOST-/CLN-…) in any public-repo file — it leaks the internal tracker and dangles for external readers; the internal issue links to the ADR/commit, not the reverse (ADR 0012)"),
 ]
@@ -612,11 +620,115 @@ def check_external_env(img: Image) -> Iterable[Finding]:
                       "app launch dies at boot")
 
 
+# ---- Portal / EXPOSE conventions (ADR 0002) — ships dormant until an image adds its own EXPOSE
+
+def _baked_portal(img: Image):
+    """Find the image's baked default PORTAL_CONFIG (the `if [[ -z ]]`-guarded
+    literal in a vast_boot.d env script) and parse it. Returns (raw, entries, rel)
+    where raw is None if the image bakes no default. Note: this is the AT-REST
+    baked default — the runtime bind smoke gate (smoke/bind-check.sh) validates the
+    rendered, post-mutation config; this static check is its fast advisory layer."""
+    if not img.root:
+        return None, [], None
+    bootd = img.root / "etc" / "vast_boot.d"
+    if not bootd.is_dir():
+        return None, [], None
+    for sh in sorted(bootd.glob("*.sh")):
+        raw = extract_baked_default(sh.read_text(encoding="utf-8", errors="replace"))
+        if raw is not None:
+            rel = str(sh.relative_to(img.dir))
+            try:
+                return raw, parse_portal_config(raw), rel
+            except ValueError:
+                return raw, None, rel  # malformed — signalled by entries is None
+    return None, [], None
+
+
+def _ancestor_dockerfiles(img: Image, repo: Path) -> list[Path]:
+    """In-repo Dockerfiles whose EXPOSE this image inherits via FROM.
+
+    EXPOSE is cumulative through `FROM` (but NOT through `COPY`). derivative ←
+    base; pytorch-nested ← pytorch ← base. external is `FROM <upstream>` and grafts
+    the base via COPY, so it inherits NO base EXPOSE — it must declare its own
+    Caddy-front ports in full (incl. the Instance Portal). base has no in-repo parent."""
+    if img.cls == "pytorch-nested":
+        return [repo / "derivatives" / "pytorch" / "Dockerfile", repo / "Dockerfile"]
+    if img.cls == "derivative":
+        return [repo / "Dockerfile"]
+    return []  # external, base
+
+
+def _inherited_exposed(img: Image, repo: Path) -> set[int]:
+    ports: set[int] = set()
+    for df in _ancestor_dockerfiles(img, repo):
+        if df.is_file():
+            ports |= exposed_ports(df.read_text(encoding="utf-8", errors="replace"))
+    return ports
+
+
+def check_expose_portal(img: Image, repo: Path) -> Iterable[Finding]:
+    """L056/L057 — the EFFECTIVE exposed set (this image's own EXPOSE plus what it
+    inherits via FROM) must cover exactly the baked PORTAL_CONFIG's Caddy-front
+    ports, and the image must not itself EXPOSE a port nothing proxies. Fires only
+    once an image declares its OWN EXPOSE, so it ships dormant until migration
+    (ADR 0002). L057 is the fast advisory layer over the real bind smoke gate."""
+    if img.cls == "base":
+        return
+    own = exposed_ports(img.text)
+    if not own:
+        return  # dormant: image hasn't opted in by adding its own EXPOSE yet
+    raw, entries, rel = _baked_portal(img)
+    if raw is None:
+        yield Finding("L056", ERROR, img.name, "Dockerfile",
+                      f"EXPOSE {sorted(own)} but no baked PORTAL_CONFIG default to validate "
+                      "against (add a vast_boot.d env script with the `if [[ -z ]]` guarded default)")
+        return
+    if entries is None:
+        yield Finding("L056", ERROR, img.name, rel, "baked PORTAL_CONFIG default is malformed (cannot parse)")
+        return
+
+    required = proxied_externals(entries)          # full Caddy-front set (no hardcoded allowlist)
+    forbidden = forbidden_expose_ports(entries)
+    effective = own | _inherited_exposed(img, repo)
+
+    # completeness: every Caddy-front port must end up exposed (own or inherited) so
+    # Vast maps it. Missing ones the base would provide hint "migrate the base first".
+    missing = sorted(required - effective)
+    if missing:
+        yield Finding("L056", ERROR, img.name, "Dockerfile",
+                      f"Caddy-front port(s) {missing} are in PORTAL_CONFIG but not exposed "
+                      "(declare them here, or ensure an ancestor image EXPOSEs them)")
+    # this image must not itself EXPOSE a non-front port. forbidden ones are the
+    # security case (L057); other strays have no proxied entry at all (L056).
+    bad = sorted(own & forbidden)
+    if bad:
+        yield Finding("L057", ERROR, img.name, "Dockerfile",
+                      f"EXPOSE includes port(s) {bad} that no entry proxies (loopback/internal or "
+                      "equal-port-only) — never EXPOSE a port without a Caddy auth front")
+    stray = sorted(own - required - forbidden)
+    if stray:
+        yield Finding("L056", ERROR, img.name, "Dockerfile",
+                      f"EXPOSE port(s) {stray} have no proxied PORTAL_CONFIG entry — Caddy would "
+                      "not front them (remove, or add a proxied entry)")
+
+
+def check_baked_portal_default(img: Image) -> Iterable[Finding]:
+    """L058 (WARN) — image bakes no default PORTAL_CONFIG (relies on the launch
+    template). Advisory during the ADR 0002 migration; flips to ERROR once every
+    image self-describes."""
+    if img.cls == "base":
+        return
+    raw, _, _ = _baked_portal(img)
+    if raw is None:
+        yield Finding("L058", WARN, img.name, "ROOT/etc/vast_boot.d",
+                      "no baked PORTAL_CONFIG default (relies on the launch template)")
+
+
 IMAGE_CHECKS: list[Callable[[Image], Iterable[Finding]]] = [
     check_labels, check_env_hash, check_copy_root, check_from_class, check_base_pin,
     check_torch_guard, check_no_auto_backend, check_uv_pip,
     check_conf_triple, check_util_order, check_supervisor_executable,
-    check_external_env,
+    check_external_env, check_baked_portal_default,
 ]
 
 
@@ -726,6 +838,7 @@ def lint_image(img: Image, repo: Path, *, apply_exceptions: bool = True) -> list
     out.extend(check_template_vram(img, repo))
     out.extend(check_launch_link_placeholder(img))
     out.extend(check_no_baked_weights(img))
+    out.extend(check_expose_portal(img, repo))
     if apply_exceptions:
         out = [f for f in out if not _suppressed(img.name, f)]
     return out

--- a/tools/imagegen/imagegen/portal.py
+++ b/tools/imagegen/imagegen/portal.py
@@ -1,0 +1,154 @@
+"""Canonical PORTAL_CONFIG model — the single in-repo definition of the field
+order and the EXPOSE port-set logic (ADR 0002).
+
+This MIRRORS the runtime parser (portal-aio/caddy_manager/caddy_config_manager.py):
+
+    hostname, ext_port, int_port, path, name = app_string.split(':', 4)   # line ~26
+
+and its proxy gate:
+
+    if external_port == internal_port or not VAST_TCP_PORT_<external>: continue   # line ~217
+
+i.e. Caddy stands up an auth site on `:external` ONLY when `external != internal`
+AND the host mapped that port. The host-mapping half is runtime-only, so here we
+*over-approximate* "proxied" as `external != internal` — which fails safe: it can
+only treat a port as more-proxied (more EXPOSE-eligible), never less.
+
+If caddy_config_manager.py changes its format or skip rule, update this module and
+the pin test (tests/test_portal.py::test_field_order_pinned_to_runtime_parser).
+
+Field order (authoritative): localhost:<external>:<internal>:<path>:<Label>
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+# Canonical PORTAL_CONFIG field order (see caddy_config_manager.py split above).
+FIELD_ORDER: tuple[str, ...] = ("hostname", "external", "internal", "path", "label")
+
+# Ports the base seeds and the platform auto-opens (Instance Portal 1111, Jupyter
+# 8080); excluded from per-image EXPOSE requirements.
+# NOTE — ADR 0002 binding condition 4: this encodes a platform assumption (that
+# 1111/8080 are mapped for us). Keep in sync with the base 10-prep-env.sh / justify
+# by test before relying on it as a security gate.
+BASE_ALLOWLIST: frozenset[int] = frozenset({1111, 8080})
+
+
+@dataclass(frozen=True)
+class PortalEntry:
+    hostname: str
+    external: int
+    internal: int
+    path: str
+    label: str
+
+    @property
+    def proxied(self) -> bool:
+        """True iff Caddy fronts this entry with an auth site (external != internal).
+
+        Mirrors the `external_port == internal_port` half of caddy_config_manager.py's
+        skip gate; the `VAST_TCP_PORT_<external>` (host-mapped) half is runtime-only
+        and intentionally not modelled (over-approximating proxied fails safe)."""
+        return self.external != self.internal
+
+
+def parse_portal_config(text: str) -> list[PortalEntry]:
+    """Parse a PORTAL_CONFIG string, mirroring the runtime parser: split on '|',
+    then `split(':', 4)`. Blank segments are skipped (a trailing '|' is tolerated).
+
+    Raises ValueError on a segment that does not have exactly 5 colon-fields or
+    whose port fields are not integers — the same shapes that would crash the
+    runtime parser, surfaced early instead of at boot."""
+    entries: list[PortalEntry] = []
+    for seg in text.split("|"):
+        seg = seg.strip()
+        if not seg:
+            continue
+        parts = seg.split(":", 4)
+        if len(parts) != 5:
+            raise ValueError(f"PORTAL_CONFIG entry needs 5 colon-fields, got {len(parts)}: {seg!r}")
+        hostname, ext, intl, path, label = parts
+        try:
+            ext_i, int_i = int(ext), int(intl)
+        except ValueError:
+            raise ValueError(f"PORTAL_CONFIG entry has non-integer port(s): {seg!r}")
+        entries.append(PortalEntry(hostname, ext_i, int_i, path, label))
+    return entries
+
+
+# ---- EXPOSE port-set logic (ADR 0002) ---------------------------------------
+#
+# A port is EXPOSE-safe iff *some* entry proxies it. The forced-proxy entry
+# (external != internal) licenses the EXPOSE; equal-port siblings on the same
+# external port (the multi-URL tab convention) are inert to it. `required` and
+# `forbidden` are disjoint by construction (proxied is subtracted out of
+# forbidden), so a port is never simultaneously required and forbidden.
+
+def proxied_externals(entries: Iterable[PortalEntry]) -> set[int]:
+    """External ports Caddy fronts with an auth site (external != internal)."""
+    return {e.external for e in entries if e.proxied}
+
+
+def internal_ports(entries: Iterable[PortalEntry]) -> set[int]:
+    """All internal (app loopback) ports across entries."""
+    return {e.internal for e in entries}
+
+
+def equal_port_externals(entries: Iterable[PortalEntry]) -> set[int]:
+    """Ports of equal-port entries (external == internal). Caddy skips these — no
+    site, no auth — so they are tab metadata only, never a proxied front."""
+    return {e.external for e in entries if not e.proxied}
+
+
+def required_expose_ports(
+    entries: Iterable[PortalEntry], allowlist: frozenset[int] = BASE_ALLOWLIST
+) -> set[int]:
+    """Caddy-front external ports an image should EXPOSE: proxied externals minus
+    the base-owned/auto-opened allowlist."""
+    entries = list(entries)
+    return proxied_externals(entries) - allowlist
+
+
+def forbidden_expose_ports(entries: Iterable[PortalEntry]) -> set[int]:
+    """Ports that must NEVER be EXPOSEd: any internal or equal-port value that NO
+    entry proxies (EXPOSE-ing them would auto-request a Vast mapping for a port
+    Caddy never fronts → a raw, unauthenticated backend). Disjoint from
+    required_expose_ports because proxied externals are subtracted out."""
+    entries = list(entries)
+    proxied = proxied_externals(entries)
+    return (internal_ports(entries) | equal_port_externals(entries)) - proxied
+
+
+def orphan_equal_ports(entries: Iterable[PortalEntry]) -> set[int]:
+    """Equal-port entries with no proxied sibling on the same external port — a
+    'dead tab or raw unauthenticated port' smell (e.g. a misdeclared entry whose
+    app actually binds elsewhere). Advisory: the bind smoke-check is the real gate
+    (ADR 0002 binding condition 1)."""
+    entries = list(entries)
+    return equal_port_externals(entries) - proxied_externals(entries)
+
+
+# ---- baked-default extraction from a boot env script ------------------------
+
+_GUARD_RE = re.compile(r"if\s*\[\[?\s*-z\s+[^\n]*PORTAL_CONFIG")
+_ASSIGN_RE = re.compile(r"""(?:export\s+)?PORTAL_CONFIG=(["'])(.*?)\1""", re.DOTALL)
+
+
+def extract_baked_default(env_sh_text: str) -> str | None:
+    """Return the literal PORTAL_CONFIG baked behind the `if [[ -z ... ]]` guard in
+    a `05-<name>-env.sh` boot script, or None if the script bakes no default.
+
+    CAVEAT — ADR 0002 binding condition 2: this returns the baked DEFAULT literal.
+    It does NOT apply later runtime mutations *in the same script* (e.g. the
+    linux-desktop selkies `grep -v ':16100:'` strip, which runs after this guard)
+    nor the base 10-prep-env.sh Jupyter rewrite. The authoritative runtime value
+    must come from a dumped rendered config in the smoke test, not this function.
+    Matching is scoped to the assignment that follows the unset-guard, so a later
+    `PORTAL_CONFIG=$(echo ... )` mutation is deliberately ignored."""
+    guard = _GUARD_RE.search(env_sh_text)
+    if not guard:
+        return None
+    m = _ASSIGN_RE.search(env_sh_text, guard.end())
+    return m.group(2) if m else None

--- a/tools/imagegen/imagegen/portal_smoke.py
+++ b/tools/imagegen/imagegen/portal_smoke.py
@@ -1,0 +1,175 @@
+"""Runtime bind-address smoke gate (ADR 0002 binding condition 1).
+
+This is the REAL safety gate that the static L051 check defers to. The static
+linter can prove "EXPOSE only ports some entry proxies", but it cannot see where a
+process actually binds — and app bind ports here are routinely opaque (`npm run
+start`, `--port` flags, env overrides). Both prior loopback-exposure incidents were
+apps binding `0.0.0.0` instead of `127.0.0.1`. So the gate is: boot the image,
+dump `ss -ltnp` + the rendered portal config, and assert nothing reachable is bound
+public without Caddy in front.
+
+Pure verdict logic lives here (unit-tested); the container orchestration is the
+thin bash harness `tools/imagegen/smoke/bind-check.sh`, which collects the artifacts
+and calls `imagegen bindcheck`.
+
+Threat model / rules:
+- A "public" listener binds 0.0.0.0 / :: / * (reachable once the host maps the port);
+  a loopback listener binds 127.0.0.0/8 or ::1.
+- Caddy is the auth front: a Caddy public listener on a *proxied* external port is
+  expected and fine. Any OTHER process public on a mapped port, or anything public
+  on a port Caddy does not front, is a raw unauthenticated exposure.
+- Concretely, FAIL on:
+  1. a public listener on any `forbidden_expose_ports` (internal app ports +
+     equal-port-only ports) — the app-binds-0.0.0.0 root cause;
+  2. a non-Caddy public listener on an EXPOSE'd port — something other than the
+     auth proxy is publicly bound where the host maps traffic;
+  3. an EXPOSE'd port that is equal-port-only (Caddy skips it) with any public
+     listener — externally mapped, no auth front.
+  WARN on a proxied EXPOSE'd port with no Caddy listener (functional: the proxy did
+  not come up; not a security failure).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+from .dockerfile import parse
+from .portal import (
+    PortalEntry,
+    equal_port_externals,
+    forbidden_expose_ports,
+    proxied_externals,
+)
+
+# Processes legitimately allowed to bind a public address on a mapped port.
+# Caddy IS the TLS+token auth front; everything else must bind loopback.
+DEFAULT_PROXY_PROCESSES: frozenset[str] = frozenset({"caddy"})
+
+ERROR = "ERROR"
+WARN = "WARN"
+
+_LOOPBACK_RE = re.compile(r"^(127\.|::1$|\[::1\]$)")
+_PUBLIC_ADDRS = {"0.0.0.0", "*", "::", "[::]", "0", "[::]%0"}
+
+
+@dataclass(frozen=True)
+class Listener:
+    addr: str
+    port: int
+    process: str | None  # process name from ss, or None if not captured
+
+    @property
+    def public(self) -> bool:
+        a = self.addr
+        if _LOOPBACK_RE.match(a):
+            return False
+        return a in _PUBLIC_ADDRS or a == "::" or a.startswith("[::]") or a == "*"
+
+
+@dataclass(frozen=True)
+class Violation:
+    severity: str
+    port: int
+    detail: str
+
+
+def parse_ss(output: str) -> list[Listener]:
+    """Parse `ss -ltnp` output. Tolerant of the header line, IPv6 bracket forms, and
+    a missing process column. The Local Address:Port column has no internal spaces,
+    so whitespace splitting is safe; the address is everything before the last ':'."""
+    listeners: list[Listener] = []
+    for line in output.splitlines():
+        cols = line.split()
+        if len(cols) < 4 or cols[0].upper() != "LISTEN":
+            continue  # skip header and any non-LISTEN row
+        local = cols[3]
+        if ":" not in local:
+            continue
+        addr, _, port_s = local.rpartition(":")
+        try:
+            port = int(port_s)
+        except ValueError:
+            continue
+        proc = None
+        m = re.search(r'users:\(\("([^"]+)"', line)
+        if m:
+            proc = m.group(1)
+        listeners.append(Listener(addr=addr, port=port, process=proc))
+    return listeners
+
+
+def exposed_ports(dockerfile_text: str) -> set[int]:
+    """The set of EXPOSE'd ports declared in a Dockerfile (the externally-mapped set
+    in a no-template run). Strips `/tcp`/`/udp`; ignores unresolved `${VARS}`."""
+    ports: set[int] = set()
+    for ins in parse(dockerfile_text):
+        if ins.cmd != "EXPOSE":
+            continue
+        for tok in ins.value.split():
+            tok = tok.split("/", 1)[0]
+            if tok.isdigit():
+                ports.add(int(tok))
+    return ports
+
+
+def check_binds(
+    listeners: Iterable[Listener],
+    exposed: set[int],
+    entries: Iterable[PortalEntry],
+    *,
+    proxy_processes: frozenset[str] = DEFAULT_PROXY_PROCESSES,
+) -> list[Violation]:
+    """Return the bind-address violations (ADR 0002 condition 1). Empty list = pass."""
+    listeners = list(listeners)
+    entries = list(entries)
+    public = [l for l in listeners if l.public]
+    proxied = proxied_externals(entries)
+    equal_only = equal_port_externals(entries) - proxied
+    forbidden = forbidden_expose_ports(entries)
+
+    out: list[Violation] = []
+
+    # (1) anything public on a loopback-only app port (internals + equal-only) —
+    #     the app-binds-0.0.0.0 root cause, regardless of EXPOSE.
+    for l in public:
+        if l.port in forbidden:
+            out.append(Violation(
+                ERROR, l.port,
+                f"{l.process or '?'} binds {l.addr}:{l.port} — must be loopback "
+                f"(no Caddy auth front; this port is an app/internal or equal-port-only port)"))
+
+    # (2) non-Caddy public listener on an EXPOSE'd (mapped) port.
+    for l in public:
+        if l.port in exposed and (l.process or "") not in proxy_processes:
+            out.append(Violation(
+                ERROR, l.port,
+                f"{l.process or '?'} (not an auth proxy) binds {l.addr}:{l.port}, "
+                f"an EXPOSE'd port — externally mapped without Caddy auth"))
+
+    # (3) EXPOSE'd port that Caddy does not front (equal-port-only) with any public bind.
+    for port in sorted(exposed & equal_only):
+        if any(l.public and l.port == port for l in listeners):
+            out.append(Violation(
+                ERROR, port,
+                f"port {port} is EXPOSE'd but equal-port-only (Caddy skips it) and has a "
+                f"public listener — raw, unauthenticated, externally mapped"))
+
+    # (WARN) proxied EXPOSE'd port with no Caddy listener at all (functional).
+    caddy_ports = {l.port for l in listeners if (l.process or "") in proxy_processes}
+    for port in sorted(exposed & proxied):
+        if port not in caddy_ports:
+            out.append(Violation(
+                WARN, port,
+                f"EXPOSE'd proxied port {port} has no Caddy listener — the proxy did not "
+                f"come up (functional, not a security failure)"))
+
+    # de-dup identical (severity, port, detail)
+    seen: set[tuple[str, int, str]] = set()
+    deduped: list[Violation] = []
+    for v in out:
+        key = (v.severity, v.port, v.detail)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(v)
+    return deduped

--- a/tools/imagegen/imagegen/portal_smoke.py
+++ b/tools/imagegen/imagegen/portal_smoke.py
@@ -1,6 +1,6 @@
 """Runtime bind-address smoke gate (ADR 0002 binding condition 1).
 
-This is the REAL safety gate that the static L051 check defers to. The static
+This is the REAL safety gate that the static L057 check defers to. The static
 linter can prove "EXPOSE only ports some entry proxies", but it cannot see where a
 process actually binds — and app bind ports here are routinely opaque (`npm run
 start`, `--port` flags, env overrides). Both prior loopback-exposure incidents were

--- a/tools/imagegen/smoke/bind-check.sh
+++ b/tools/imagegen/smoke/bind-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Runtime bind-address smoke gate — ADR 0002 binding condition 1.
 #
-# This is the REAL safety gate the static L051 check defers to: a static linter
+# This is the REAL safety gate the static L057 check defers to: a static linter
 # cannot see where a process actually binds, and both prior loopback-exposure
 # incidents were apps binding 0.0.0.0 instead of 127.0.0.1. So we boot the image
 # and assert nothing reachable is bound public without Caddy in front.

--- a/tools/imagegen/smoke/bind-check.sh
+++ b/tools/imagegen/smoke/bind-check.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Runtime bind-address smoke gate — ADR 0002 binding condition 1.
+#
+# This is the REAL safety gate the static L051 check defers to: a static linter
+# cannot see where a process actually binds, and both prior loopback-exposure
+# incidents were apps binding 0.0.0.0 instead of 127.0.0.1. So we boot the image
+# and assert nothing reachable is bound public without Caddy in front.
+#
+# What it does:
+#   1. reads the image's EXPOSE'd ports from its Dockerfile
+#   2. boots the image, simulating the platform's port mapping by exporting
+#      VAST_TCP_PORT_<ext> for each EXPOSE'd port (so Caddy actually stands up its
+#      proxy sites — see caddy_config_manager.py:217)
+#   3. waits for boot to settle, then dumps `ss -ltnp` and the RENDERED runtime
+#      PORTAL_CONFIG (from /etc/portal.yaml, converted in-container where pyyaml
+#      lives — satisfies ADR 0002 condition 2: validate the rendered config, not
+#      the at-rest baked string)
+#   4. feeds both to `imagegen bindcheck`, which is the verdict
+#
+# Usage:
+#   tools/imagegen/smoke/bind-check.sh <image-tag> <image-name> [boot-wait-seconds]
+# Example:
+#   tools/imagegen/smoke/bind-check.sh vastai/vllm:latest vllm 60
+#
+# Exit: 0 = pass, 1 = bind violation (FAIL the build), 2 = harness error.
+set -euo pipefail
+
+IMAGE_TAG="${1:?usage: bind-check.sh <image-tag> <image-name> [boot-wait]}"
+IMAGE_NAME="${2:?usage: bind-check.sh <image-tag> <image-name> [boot-wait]}"
+BOOT_WAIT="${3:-60}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGEGEN_DIR="$(cd "${HERE}/.." && pwd)"
+REPO_ROOT="$(cd "${IMAGEGEN_DIR}/../.." && pwd)"
+DOCKERFILE_PATH=""
+for cand in \
+    "${REPO_ROOT}/external/${IMAGE_NAME}/Dockerfile" \
+    "${REPO_ROOT}/derivatives/${IMAGE_NAME}/Dockerfile" \
+    "${REPO_ROOT}/derivatives/pytorch/derivatives/${IMAGE_NAME}/Dockerfile"; do
+    [[ -f "$cand" ]] && DOCKERFILE_PATH="$cand" && break
+done
+[[ -n "$DOCKERFILE_PATH" ]] || { echo "✗ could not locate Dockerfile for ${IMAGE_NAME}"; exit 2; }
+
+# `imagegen` runner: prefer an installed entrypoint, else module via uv.
+run_imagegen() {
+    if command -v imagegen >/dev/null 2>&1; then
+        imagegen "$@"
+    else
+        ( cd "$IMAGEGEN_DIR" && PYTHONPATH=. uv run --no-project python -m imagegen.cli "$@" )
+    fi
+}
+
+# 1. EXPOSE'd ports (the externally-mapped set in this no-template run).
+EXPOSED="$(grep -hiE '^\s*EXPOSE\s' "$DOCKERFILE_PATH" | sed -E 's/^\s*EXPOSE\s+//I; s#/[a-z]+##g' | tr '\n' ' ' | tr -s ' ')"
+echo "▸ ${IMAGE_NAME}: EXPOSE'd ports = [${EXPOSED:-none}]"
+
+# 2. boot, simulating the platform's port mapping so Caddy stands up its sites.
+ENV_ARGS=()
+for p in $EXPOSED; do
+    [[ "$p" =~ ^[0-9]+$ ]] && ENV_ARGS+=(-e "VAST_TCP_PORT_${p}=${p}")
+done
+# Jupyter/SSH are auto-opened by the platform; mirror that so Caddy fronts 8080.
+ENV_ARGS+=(-e "VAST_TCP_PORT_8080=8080" -e "OPEN_BUTTON_PORT=1111")
+
+CID="$(docker run -d --rm "${ENV_ARGS[@]}" "$IMAGE_TAG")"
+cleanup() { docker rm -f "$CID" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "▸ booted ${CID:0:12}; waiting ${BOOT_WAIT}s for services to settle…"
+sleep "$BOOT_WAIT"
+
+# tooling: ss may be absent in slim images; iproute2 provides it.
+docker exec "$CID" sh -c 'command -v ss >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq iproute2) >/dev/null 2>&1 || true'
+
+SS_DUMP="$(docker exec "$CID" ss -ltnp 2>/dev/null || true)"
+[[ -n "$SS_DUMP" ]] || { echo "✗ could not capture `ss -ltnp` from the container"; exit 2; }
+
+# 3. rendered runtime PORTAL_CONFIG: convert /etc/portal.yaml → pipe string IN the
+#    container (pyyaml lives there). Falls back to the live $PORTAL_CONFIG env.
+PORTAL_CFG="$(docker exec "$CID" python3 - <<'PY' 2>/dev/null || true
+import os, sys
+try:
+    import yaml
+    with open("/etc/portal.yaml") as f:
+        apps = (yaml.safe_load(f) or {}).get("applications", {}) or {}
+    parts = [f'{a.get("hostname","localhost")}:{a["external_port"]}:{a["internal_port"]}:{a.get("open_path","/")}:{name}'
+             for name, a in apps.items()]
+    print("|".join(parts))
+except Exception:
+    print(os.environ.get("PORTAL_CONFIG", ""))
+PY
+)"
+echo "▸ rendered PORTAL_CONFIG: ${PORTAL_CFG:-<empty>}"
+
+# 4. verdict.
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"; cleanup' EXIT
+printf '%s\n' "$SS_DUMP"   > "$TMP/ss.txt"
+printf '%s'   "$PORTAL_CFG" > "$TMP/portal.txt"
+
+run_imagegen bindcheck \
+    --ss "@$TMP/ss.txt" \
+    --portal-config "@$TMP/portal.txt" \
+    --dockerfile "$DOCKERFILE_PATH"

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -691,75 +691,92 @@ _CFG_FULL = ("localhost:1111:11111:/:Instance Portal"
              "|localhost:8080:18080:/:Jupyter")
 
 
-def test_L050_clean_when_effective_covers_fronts(tmp_path):
+def test_L056_clean_when_effective_covers_fronts(tmp_path):
     img = _make_portal(tmp_path, expose="7860", cfg=_CFG_APP)  # no inherited; front == own
     assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
 
 
-def test_L050_fires_on_mismatch(tmp_path):
+def test_L056_fires_on_mismatch(tmp_path):
     img = _make_portal(tmp_path, expose="8000", cfg=_CFG_APP)  # 7860 missing, 8000 stray
     assert has(img, tmp_path, "L056")
 
 
-def test_L050_dormant_without_own_expose(tmp_path):
+def test_L056_dormant_without_own_expose(tmp_path):
     # bakes a default but declares no OWN EXPOSE → checks stay dormant (migration shape).
     img = _make_portal(tmp_path, expose=None, cfg=_CFG_FULL)
     assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
 
 
-def test_L050_expose_without_baked_default_fires(tmp_path):
+def test_L056_expose_without_baked_default_fires(tmp_path):
     img = _make_portal(tmp_path, expose="7860", cfg=None)
     assert has(img, tmp_path, "L056", "no baked PORTAL_CONFIG")
 
 
-def test_L050_inheritance_fills_base_ports(tmp_path):
-    # base EXPOSEs 1111+8080; the derivative only declares its own 7860 and is clean
-    # because the Caddy-front set is covered by own ∪ inherited (the user's point).
-    _seed_ancestors(tmp_path, base_expose="1111 8080", pytorch_expose="")
+def test_L056_base_ports_allowlisted_not_required(tmp_path):
+    # 1111/8080 (Instance Portal, Jupyter) are opened by the template's `ports:` list,
+    # not the image's EXPOSE (BASE_ALLOWLIST). So a derivative baking the full config
+    # but EXPOSEing only its own app port is clean — no inherited base EXPOSE needed.
     img = _make_portal(tmp_path, expose="7860", cfg=_CFG_FULL)
     assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
 
 
-def test_L050_missing_when_ancestors_do_not_expose_fronts(tmp_path):
-    # same derivative, but nothing inherited → 1111/8080 are uncovered fronts.
-    img = _make_portal(tmp_path, expose="7860", cfg=_CFG_FULL)
-    assert has(img, tmp_path, "L056", "1111")
+def test_L056_inheritance_covers_a_non_base_front(tmp_path):
+    # a NON-base Caddy-front (9000) that a parent image EXPOSEs is covered via FROM
+    # inheritance, so the derivative need not re-EXPOSE it (base ports are separately
+    # allowlisted; this exercises the inheritance path for a shared app front).
+    _seed_ancestors(tmp_path, pytorch_expose="9000")
+    cfg = _CFG_APP + "|localhost:9000:19000:/tools:Extra"
+    img = _make_portal(tmp_path, expose="7860", cfg=cfg)
+    assert "L056" not in errs(img, tmp_path)
 
 
-def test_external_must_declare_portal_ports_itself(tmp_path):
-    # external is FROM upstream (grafts base via COPY) → inherits NO base EXPOSE, so
-    # it must EXPOSE the Instance Portal itself. Declaring only 7860 leaves 1111 uncovered.
+def test_L056_missing_non_base_front_fires(tmp_path):
+    # a non-base Caddy-front the image neither EXPOSEs nor inherits is uncovered.
+    cfg = _CFG_APP + "|localhost:8000:18000:/:API"
+    img = _make_portal(tmp_path, expose="7860", cfg=cfg)   # 8000 uncovered
+    assert has(img, tmp_path, "L056", "8000")
+
+
+def test_external_must_declare_its_non_base_fronts(tmp_path):
+    # external inherits no base EXPOSE, but base portal/Jupyter ports are still
+    # template-opened (allowlisted), so it is NOT required to EXPOSE 1111. It must
+    # declare its OWN app fronts though: EXPOSEing 7860 but not 8000 leaves 8000 uncovered.
     img = _make_portal(tmp_path, expose="7860",
-                       cfg="localhost:1111:11111:/:Instance Portal|localhost:7860:17860:/:App UI",
+                       cfg="localhost:1111:11111:/:Instance Portal"
+                           "|localhost:7860:17860:/:App UI"
+                           "|localhost:8000:18000:/:API",
                        cls="external")
-    assert has(img, tmp_path, "L056", "1111")
+    errset = errs(img, tmp_path)
+    assert "L056" in errset and any("8000" in f.msg for f in lint_image(img, tmp_path) if f.code == "L056")
+    # base port 1111 is exempt — not flagged
+    assert not any("1111" in f.msg for f in lint_image(img, tmp_path) if f.code == "L056")
 
 
-def test_L051_internal_port_exposed_fails(tmp_path):
+def test_L057_internal_port_exposed_fails(tmp_path):
     img = _make_portal(tmp_path, expose="17860", cfg=_CFG_APP)
     assert has(img, tmp_path, "L057")
 
 
-def test_L051_equal_port_only_fails(tmp_path):
+def test_L057_equal_port_only_fails(tmp_path):
     cfg = "localhost:1111:11111:/:Instance Portal|localhost:7861:7861:/:Wan2GP"
     img = _make_portal(tmp_path, expose="7861", cfg=cfg)
     assert has(img, tmp_path, "L057")
 
 
-def test_L050_L051_clean_for_proxied_plus_equal_sibling(tmp_path):
+def test_L056_L057_clean_for_proxied_plus_equal_sibling(tmp_path):
     cfg = ("localhost:9000:19000:/:App"
            "|localhost:9000:9000:/tools:App Tools")
     img = _make_portal(tmp_path, expose="9000", cfg=cfg)
     assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
 
 
-def test_L052_warns_when_no_baked_default(tmp_path):
+def test_L058_warns_when_no_baked_default(tmp_path):
     img = _make_portal(tmp_path, expose=None, cfg=None)
     warns = {f.code for f in lint_image(img, tmp_path) if f.severity == L.WARN}
     assert "L058" in warns
 
 
-def test_L052_silent_when_default_present(tmp_path):
+def test_L058_silent_when_default_present(tmp_path):
     img = _make_portal(tmp_path, expose=None, cfg=_CFG_FULL)
     warns = {f.code for f in lint_image(img, tmp_path) if f.severity == L.WARN}
     assert "L058" not in warns

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -649,3 +649,119 @@ def test_L061_baseline_repo_is_clean():
 if __name__ == "__main__":
     from _stdlib_runner import run
     raise SystemExit(run(globals()))
+
+
+# ---- L056/L057/L058 EXPOSE <-> PORTAL_CONFIG (ADR 0002) ---------------------
+
+def _make_portal(tmp: Path, *, expose: str | None, cfg: str | None,
+                 cls: str = "pytorch-nested") -> Image:
+    """An image with an optional `EXPOSE <expose>` line and an optional baked
+    PORTAL_CONFIG default in ROOT/etc/vast_boot.d/05-img-env.sh."""
+    df = VALID_DF
+    if expose is not None:
+        df = df.replace("RUN env-hash > /.env_hash\n",
+                        f"EXPOSE {expose}\nRUN env-hash > /.env_hash\n")
+    img = make(tmp, cls=cls, df=df)
+    if cfg is not None:
+        bootd = img.dir / "ROOT/etc/vast_boot.d"
+        bootd.mkdir(parents=True, exist_ok=True)
+        (bootd / "05-img-env.sh").write_text(
+            "#!/bin/bash\n"
+            "if [[ -z $PORTAL_CONFIG ]]; then\n"
+            f'    export PORTAL_CONFIG="{cfg}"\n'
+            "fi\n")
+    return img
+
+
+def _seed_ancestors(tmp: Path, *, base_expose: str | None = None, pytorch_expose: str | None = None):
+    """Write in-repo ancestor Dockerfiles so _inherited_exposed resolves the FROM
+    chain (base = tmp/Dockerfile, pytorch = tmp/derivatives/pytorch/Dockerfile)."""
+    if base_expose is not None:
+        (tmp / "Dockerfile").write_text(f"FROM x\nEXPOSE {base_expose}\nRUN env-hash > /.env_hash\n")
+    if pytorch_expose is not None:
+        d = tmp / "derivatives" / "pytorch"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "Dockerfile").write_text(f"FROM x\nEXPOSE {pytorch_expose}\nRUN env-hash > /.env_hash\n")
+
+
+_CFG_APP = "localhost:7860:17860:/:App UI"  # one proxied front: {7860}
+# Portal + app + Jupyter — the shape a baked default copies from the base.
+_CFG_FULL = ("localhost:1111:11111:/:Instance Portal"
+             "|localhost:7860:17860:/:App UI"
+             "|localhost:8080:18080:/:Jupyter")
+
+
+def test_L050_clean_when_effective_covers_fronts(tmp_path):
+    img = _make_portal(tmp_path, expose="7860", cfg=_CFG_APP)  # no inherited; front == own
+    assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
+
+
+def test_L050_fires_on_mismatch(tmp_path):
+    img = _make_portal(tmp_path, expose="8000", cfg=_CFG_APP)  # 7860 missing, 8000 stray
+    assert has(img, tmp_path, "L056")
+
+
+def test_L050_dormant_without_own_expose(tmp_path):
+    # bakes a default but declares no OWN EXPOSE → checks stay dormant (migration shape).
+    img = _make_portal(tmp_path, expose=None, cfg=_CFG_FULL)
+    assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
+
+
+def test_L050_expose_without_baked_default_fires(tmp_path):
+    img = _make_portal(tmp_path, expose="7860", cfg=None)
+    assert has(img, tmp_path, "L056", "no baked PORTAL_CONFIG")
+
+
+def test_L050_inheritance_fills_base_ports(tmp_path):
+    # base EXPOSEs 1111+8080; the derivative only declares its own 7860 and is clean
+    # because the Caddy-front set is covered by own ∪ inherited (the user's point).
+    _seed_ancestors(tmp_path, base_expose="1111 8080", pytorch_expose="")
+    img = _make_portal(tmp_path, expose="7860", cfg=_CFG_FULL)
+    assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
+
+
+def test_L050_missing_when_ancestors_do_not_expose_fronts(tmp_path):
+    # same derivative, but nothing inherited → 1111/8080 are uncovered fronts.
+    img = _make_portal(tmp_path, expose="7860", cfg=_CFG_FULL)
+    assert has(img, tmp_path, "L056", "1111")
+
+
+def test_external_must_declare_portal_ports_itself(tmp_path):
+    # external is FROM upstream (grafts base via COPY) → inherits NO base EXPOSE, so
+    # it must EXPOSE the Instance Portal itself. Declaring only 7860 leaves 1111 uncovered.
+    img = _make_portal(tmp_path, expose="7860",
+                       cfg="localhost:1111:11111:/:Instance Portal|localhost:7860:17860:/:App UI",
+                       cls="external")
+    assert has(img, tmp_path, "L056", "1111")
+
+
+def test_L051_internal_port_exposed_fails(tmp_path):
+    img = _make_portal(tmp_path, expose="17860", cfg=_CFG_APP)
+    assert has(img, tmp_path, "L057")
+
+
+def test_L051_equal_port_only_fails(tmp_path):
+    cfg = "localhost:1111:11111:/:Instance Portal|localhost:7861:7861:/:Wan2GP"
+    img = _make_portal(tmp_path, expose="7861", cfg=cfg)
+    assert has(img, tmp_path, "L057")
+
+
+def test_L050_L051_clean_for_proxied_plus_equal_sibling(tmp_path):
+    cfg = ("localhost:9000:19000:/:App"
+           "|localhost:9000:9000:/tools:App Tools")
+    img = _make_portal(tmp_path, expose="9000", cfg=cfg)
+    assert "L056" not in errs(img, tmp_path) and "L057" not in errs(img, tmp_path)
+
+
+def test_L052_warns_when_no_baked_default(tmp_path):
+    img = _make_portal(tmp_path, expose=None, cfg=None)
+    warns = {f.code for f in lint_image(img, tmp_path) if f.severity == L.WARN}
+    assert "L058" in warns
+
+
+def test_L052_silent_when_default_present(tmp_path):
+    img = _make_portal(tmp_path, expose=None, cfg=_CFG_FULL)
+    warns = {f.code for f in lint_image(img, tmp_path) if f.severity == L.WARN}
+    assert "L058" not in warns
+
+

--- a/tools/imagegen/tests/test_portal.py
+++ b/tools/imagegen/tests/test_portal.py
@@ -1,0 +1,187 @@
+"""PORTAL_CONFIG parser + EXPOSE port-set logic tests (ADR 0002).
+
+Run: cd tools/imagegen && PYTHONPATH=. python -m pytest -q test_portal.py
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from imagegen.discover import find_repo_root
+from imagegen.portal import (
+    BASE_ALLOWLIST,
+    FIELD_ORDER,
+    PortalEntry,
+    equal_port_externals,
+    extract_baked_default,
+    forbidden_expose_ports,
+    internal_ports,
+    orphan_equal_ports,
+    parse_portal_config,
+    proxied_externals,
+    required_expose_ports,
+)
+
+# The real external/vllm baked default — a representative multi-service string
+# with a proxied set, the Instance Portal, and the Jupyter proxied+terminal pair.
+VLLM = (
+    "localhost:1111:11111:/:Instance Portal"
+    "|localhost:7860:17860:/:Model UI"
+    "|localhost:8000:18000:/docs:vLLM API"
+    "|localhost:8265:28265:/:Ray Dashboard"
+    "|localhost:8080:18080:/:Jupyter"
+    "|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+)
+
+
+# ---- parsing ----------------------------------------------------------------
+
+def test_parse_field_order_external_then_internal():
+    e = parse_portal_config("localhost:7860:17860:/:Model UI")[0]
+    assert (e.hostname, e.external, e.internal, e.path, e.label) == (
+        "localhost", 7860, 17860, "/", "Model UI")
+    assert e.proxied  # 7860 != 17860
+
+
+def test_parse_path_may_contain_colon_is_not_split():
+    # split(':', 4) caps fields at 5 — a colon in the label/path stays intact.
+    e = parse_portal_config("localhost:9000:19000:/a:Tool: Beta")[0]
+    assert e.path == "/a"
+    assert e.label == "Tool: Beta"
+
+
+def test_parse_skips_blank_and_trailing_pipe():
+    assert len(parse_portal_config("localhost:1:2:/:A|")) == 1
+    assert parse_portal_config("") == []
+
+
+def test_parse_rejects_short_entry():
+    with pytest.raises(ValueError):
+        parse_portal_config("localhost:7860:/:NoInternal")
+
+
+def test_parse_rejects_non_integer_ports():
+    with pytest.raises(ValueError):
+        parse_portal_config("localhost:abc:17860:/:Bad")
+
+
+def test_equal_port_entry_is_not_proxied():
+    e = parse_portal_config("localhost:8080:8080:/terminals/1:Jupyter Terminal")[0]
+    assert not e.proxied
+
+
+# ---- set logic over the real vllm config ------------------------------------
+
+def test_vllm_proxied_and_required():
+    es = parse_portal_config(VLLM)
+    assert proxied_externals(es) == {1111, 7860, 8000, 8265, 8080}
+    # required strips the base-owned 1111/8080; the image EXPOSEs only its own apps.
+    assert required_expose_ports(es) == {7860, 8000, 8265}
+
+
+def test_vllm_forbidden_never_includes_a_proxied_front():
+    es = parse_portal_config(VLLM)
+    forbidden = forbidden_expose_ports(es)
+    # internals must be forbidden ...
+    assert {11111, 17860, 18000, 28265, 18080} <= forbidden
+    # ... but 8080 is proxied (8080:18080) so it is NOT forbidden, even though the
+    # terminal entry 8080:8080 makes it an equal-port external too. (The multi-URL
+    # convention: proxied by one entry ⇒ EXPOSE-safe.)
+    assert 8080 not in forbidden
+    assert required_expose_ports(es).isdisjoint(forbidden)
+
+
+# ---- the multi-URL / equal-port convention (the heart of ADR 0002) ----------
+
+def test_proxied_plus_equal_port_sibling_is_expose_safe():
+    # One proxied entry forces Caddy; the equal-port sibling is a tab only.
+    es = parse_portal_config("localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Terminal")
+    assert proxied_externals(es) == {8080}
+    assert 8080 not in forbidden_expose_ports(es)   # proxied wins
+    assert orphan_equal_ports(es) == set()          # 8080 has a proxied sibling
+
+
+def test_orphan_equal_port_is_forbidden_and_flagged():
+    # aio-studio's Wan2GP `7861:7861` with no proxied sibling: raw/unauth smell.
+    es = parse_portal_config("localhost:7861:7861:/:Wan2GP")
+    assert proxied_externals(es) == set()
+    assert 7861 in forbidden_expose_ports(es)
+    assert orphan_equal_ports(es) == {7861}
+
+
+def test_swapped_internal_low_port_is_forbidden():
+    # aio-studio's `13000:3000`: EXPOSE-ing the internal 3000 would be a raw backend.
+    es = parse_portal_config("localhost:13000:3000:/:App")
+    assert required_expose_ports(es) == {13000}
+    assert 3000 in forbidden_expose_ports(es)
+
+
+def test_required_and_forbidden_are_always_disjoint():
+    es = parse_portal_config(VLLM + "|localhost:7861:7861:/:Wan2GP|localhost:13000:3000:/:App")
+    assert required_expose_ports(es).isdisjoint(forbidden_expose_ports(es))
+
+
+def test_internal_and_equal_helpers():
+    es = parse_portal_config("localhost:9000:19000:/:A|localhost:5000:5000:/:B")
+    assert internal_ports(es) == {19000, 5000}
+    assert equal_port_externals(es) == {5000}
+
+
+# ---- baked-default extraction from a boot env script ------------------------
+
+def test_extract_baked_default_inside_guard():
+    sh = (
+        "#!/bin/bash\n"
+        "if [[ -z $PORTAL_CONFIG ]]; then\n"
+        '    export PORTAL_CONFIG="localhost:8000:18000:/:API"\n'
+        "fi\n"
+        'export OTHER="x"\n'
+    )
+    assert extract_baked_default(sh) == "localhost:8000:18000:/:API"
+
+
+def test_extract_ignores_later_runtime_mutation():
+    # linux-desktop shape: bake a default, then mutate PORTAL_CONFIG below the guard.
+    # We must return the baked literal, NOT the mutated form (caveat: the mutation
+    # itself is out of scope — ADR 0002 condition 2 / smoke test).
+    sh = (
+        "if [[ -z $PORTAL_CONFIG ]]; then\n"
+        '    export PORTAL_CONFIG="localhost:6100:16100:/:Desktop|localhost:1:2:/:X"\n'
+        "fi\n"
+        'PORTAL_CONFIG=$(echo "$PORTAL_CONFIG" | grep -v \':16100:\')\n'
+    )
+    assert extract_baked_default(sh) == "localhost:6100:16100:/:Desktop|localhost:1:2:/:X"
+
+
+def test_extract_returns_none_when_no_default():
+    assert extract_baked_default("#!/bin/bash\nexport MODEL_NAME=foo\n") is None
+
+
+# ---- pins against ground truth (must not silently drift) --------------------
+
+def test_field_order_pinned_to_runtime_parser():
+    """FIELD_ORDER must match caddy_config_manager.py's `split(':', 4)` unpacking —
+    external is field 2, internal is field 3. If the runtime parser changes, this
+    fails so portal.py is updated in lockstep (ADR 0002)."""
+    repo = find_repo_root(Path(__file__).resolve().parent)
+    src = (repo / "portal-aio" / "caddy_manager" / "caddy_config_manager.py").read_text()
+    m = re.search(r"(\w+),\s*(\w+),\s*(\w+),\s*(\w+),\s*(\w+)\s*=\s*\w+\.split\(\s*['\"]:['\"]\s*,\s*4\s*\)", src)
+    assert m, "could not find the PORTAL_CONFIG split in caddy_config_manager.py"
+    names = [g.lower() for g in m.groups()]
+    assert names[1].startswith("ext") and names[2].startswith("int"), \
+        f"runtime parser order changed: {names} — update FIELD_ORDER + this test"
+    assert FIELD_ORDER == ("hostname", "external", "internal", "path", "label")
+
+
+def test_contributing_documents_correct_field_order():
+    """ADR 0002 P0: CONTRIBUTING.md must document external-before-internal and must
+    not resurrect the false `internal + 10000` convention."""
+    repo = find_repo_root(Path(__file__).resolve().parent)
+    txt = (repo / "CONTRIBUTING.md").read_text()
+    assert "localhost:external:internal:path:Label" in txt
+    assert "localhost:internal:external:path:Label" not in txt
+    # the false-claim phrasing must be gone (the doc may still *mention* the rule
+    # only to say it does not exist).
+    assert "convention: internal + 10000" not in txt
+    # the External-port row must appear before the Internal-port row in the table
+    assert txt.index("| External port |") < txt.index("| Internal port |")

--- a/tools/imagegen/tests/test_portal_smoke.py
+++ b/tools/imagegen/tests/test_portal_smoke.py
@@ -1,0 +1,130 @@
+"""Bind-address smoke-gate verdict tests (ADR 0002 binding condition 1).
+
+The verdict logic is the testable brain of the gate; the container orchestration
+(smoke/bind-check.sh) is the thin integration layer around it.
+
+Run: cd tools/imagegen && PYTHONPATH=. python -m pytest -q test_portal_smoke.py
+"""
+from imagegen.portal import parse_portal_config
+from imagegen.portal_smoke import (
+    ERROR,
+    WARN,
+    Listener,
+    check_binds,
+    exposed_ports,
+    parse_ss,
+)
+
+# A realistic `ss -ltnp` dump: Caddy public on the front ports, apps on loopback.
+SS_GOOD = """\
+State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process
+LISTEN 0      4096   0.0.0.0:7860        0.0.0.0:*         users:(("caddy",pid=10,fd=3))
+LISTEN 0      4096   127.0.0.1:17860     0.0.0.0:*         users:(("python",pid=20,fd=5))
+LISTEN 0      128    [::]:8080           [::]:*            users:(("caddy",pid=10,fd=7))
+LISTEN 0      128    127.0.0.1:18080     0.0.0.0:*         users:(("jupyter",pid=30,fd=8))
+LISTEN 0      128    *:22                *:*               users:(("sshd",pid=5,fd=3))
+"""
+
+CFG = "localhost:7860:17860:/:Model UI|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/t:Term"
+
+
+# ---- ss parsing -------------------------------------------------------------
+
+def test_parse_ss_addr_port_process_and_public_flag():
+    ls = parse_ss(SS_GOOD)
+    by_port = {l.port: l for l in ls}
+    assert by_port[7860].process == "caddy" and by_port[7860].public
+    assert by_port[17860].addr == "127.0.0.1" and not by_port[17860].public
+    assert by_port[8080].public  # [::] is public
+    assert not by_port[18080].public  # 127.0.0.1
+    assert by_port[22].public  # *
+
+
+def test_parse_ss_skips_header_and_blank():
+    assert parse_ss("State Recv-Q ...\n\n") == []
+
+
+# ---- exposed-port extraction ------------------------------------------------
+
+def test_exposed_ports_from_dockerfile():
+    df = "FROM x\nEXPOSE 7860 8000\nEXPOSE 8265/tcp\nRUN env-hash > /.env_hash\n"
+    assert exposed_ports(df) == {7860, 8000, 8265}
+
+
+def test_exposed_ports_ignores_unresolved_vars():
+    assert exposed_ports("EXPOSE ${PORTS}\nEXPOSE 9000\n") == {9000}
+
+
+# ---- the verdict: the good case is clean ------------------------------------
+
+def test_clean_topology_passes():
+    entries = parse_portal_config(CFG)
+    v = check_binds(parse_ss(SS_GOOD), {7860}, entries)  # 8080 is base-allowlisted, app EXPOSEs 7860
+    assert v == []
+
+
+# ---- FAIL (1): an app binds 0.0.0.0 on its loopback/internal port -----------
+
+def test_app_binding_public_on_internal_port_fails():
+    ss = SS_GOOD.replace("127.0.0.1:17860", "0.0.0.0:17860")
+    entries = parse_portal_config(CFG)
+    v = check_binds(parse_ss(ss), {7860}, entries)
+    assert any(f.severity == ERROR and f.port == 17860 for f in v)
+
+
+# ---- FAIL (2): a non-Caddy process public on an EXPOSE'd port ---------------
+
+def test_non_caddy_public_on_exposed_port_fails():
+    ss = """\
+LISTEN 0 4096 0.0.0.0:7860 0.0.0.0:* users:(("python",pid=20,fd=5))
+"""
+    entries = parse_portal_config("localhost:7860:17860:/:Model UI")
+    v = check_binds(parse_ss(ss), {7860}, entries)
+    assert any(f.severity == ERROR and f.port == 7860 and "not an auth proxy" in f.detail for f in v)
+
+
+def test_caddy_public_on_exposed_proxied_port_is_ok():
+    ss = """\
+LISTEN 0 4096 0.0.0.0:7860 0.0.0.0:* users:(("caddy",pid=10,fd=3))
+LISTEN 0 4096 127.0.0.1:17860 0.0.0.0:* users:(("python",pid=20,fd=5))
+"""
+    entries = parse_portal_config("localhost:7860:17860:/:Model UI")
+    assert check_binds(parse_ss(ss), {7860}, entries) == []
+
+
+# ---- FAIL (3): an equal-port-only port is EXPOSE'd and has a public bind -----
+
+def test_equal_port_only_exposed_with_public_listener_fails():
+    # Wan2GP-style: 7861:7861 (Caddy skips), app binds 0.0.0.0:7861, and it's EXPOSE'd.
+    ss = """\
+LISTEN 0 4096 0.0.0.0:7861 0.0.0.0:* users:(("python",pid=40,fd=9))
+"""
+    entries = parse_portal_config("localhost:7861:7861:/:Wan2GP")
+    v = check_binds(parse_ss(ss), {7861}, entries)
+    # both the forbidden-port rule and the equal-port-only rule should bite
+    assert any(f.severity == ERROR and f.port == 7861 for f in v)
+
+
+# ---- multi-URL convention: proxied + equal sibling, app on loopback = clean --
+
+def test_multi_url_jupyter_pattern_clean():
+    ss = """\
+LISTEN 0 4096 0.0.0.0:8080 0.0.0.0:* users:(("caddy",pid=10,fd=3))
+LISTEN 0 4096 127.0.0.1:18080 0.0.0.0:* users:(("jupyter",pid=30,fd=8))
+"""
+    entries = parse_portal_config("localhost:8080:18080:/:Jupyter|localhost:8080:8080:/t:Term")
+    # 8080 is allowlisted out of `exposed` for per-image images; pass it anyway to
+    # prove caddy-on-8080 is accepted and the loopback jupyter is fine.
+    assert check_binds(parse_ss(ss), {8080}, entries) == []
+
+
+# ---- WARN: proxied EXPOSE'd port with no Caddy listener (functional) --------
+
+def test_proxied_exposed_port_without_caddy_warns_not_errors():
+    ss = """\
+LISTEN 0 4096 127.0.0.1:17860 0.0.0.0:* users:(("python",pid=20,fd=5))
+"""
+    entries = parse_portal_config("localhost:7860:17860:/:Model UI")
+    v = check_binds(parse_ss(ss), {7860}, entries)
+    assert [f.severity for f in v] == [WARN]
+    assert v[0].port == 7860


### PR DESCRIPTION
The portal-config lint subsystem, extracted from the old #207 and reconciled onto `main` after #206 (the imagegen linter) landed. Part of the portal/exposure cluster (#205, #208, ADR 0006).

#207 predated the #206 rebase, so its rule codes were stale — its portal rules `L050/L051/L052` collided with 206's (compute-cap floor / supervisor-executable / launch-link). They are **renumbered here to L056/L057/L058** and grafted onto 206's newer linter.

## What's in it
- **linter.py** — `L056` (effective EXPOSE, own + inherited via FROM, covers exactly the baked PORTAL_CONFIG Caddy-front ports), `L057` (never EXPOSE a port no entry proxies — the security case), `L058` (WARN: bakes a default PORTAL_CONFIG). **All ship dormant** — L056/L057 fire only once an image declares its own EXPOSE, so the ADR-0002 migration is opt-in and baseline stays clean.
- **`imagegen bindcheck`** (cli.py + `smoke/bind-check.sh`) — the runtime bind-address smoke gate (ADR 0002 cond. 1): inspects `ss -ltnp` on a live box and fails on any public bind not behind Caddy.
- **portal.py / portal_smoke.py** — PORTAL_CONFIG parsing + the EXPOSE/bind analysis.
- **CONTRIBUTING.md** — corrected the Portal Integration docs: killed the false `internal + 10000` convention and the reversed field order (invariants §3).
- **docs/invariants.md** — §6 entry for L056–L058; **docs/lint-rules.md** regenerated.
- **portal-aio/caddy_manager** — field-order fix (3-way onto main; main never touched it) + `test_caddy_config.py`.
- **.github/workflows/portal-aio-tests.yml** — gates the portal-aio tests (installs `portal-aio/requirements.txt`, matching the image). Runs the 5 new caddy tests **plus ~30 pre-existing portal-aio tests that had no CI** — closes that gap.
- **ADR 0002** (portal-config / EXPOSE conventions) + **ADR 0003** (portal HF-space installer).

## Validation
imagegen suite **172 pass** · portal-aio **35 pass** · baseline lint **clean (27 images, 0 errors)** · lint-rules catalog in sync. Both CI workflows (`imagegen-tests`, `portal-aio-tests`) gate this PR.