### PR TITLE
ci: widen release-check window to per_page=100 so newest release is detected

### DIFF
--- a/.github/actions/check-github-release/action.yml
+++ b/.github/actions/check-github-release/action.yml
@@ -69,11 +69,18 @@ runs:
         
         # --retry rides out transient 5xx/connection blips; the timeouts bound
         # each attempt so a stalled endpoint cannot hang the job.
+        # per_page must be large enough that the genuinely-newest release is in
+        # the response: some upstreams (e.g. ai-dock/llama.cpp-cuda) report an
+        # identical created_at on every release (a bulk migration), so GitHub's
+        # created_at-desc list order stops reflecting recency and the newest tag
+        # can land deep in the list (b10091 was at index ~54 while a per_page=10
+        # window only ever saw the stale b9993). We fetch a wide window and let
+        # the client-side sort_by(.updated_at) below pick the true latest.
         HTTP_RESPONSE=$(curl -sS --retry 5 --retry-max-time 60 \
           --connect-timeout 10 --max-time 30 -w "\n%{http_code}" \
           -H "Accept: application/vnd.github+json" \
           ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
-          "https://api.github.com/repos/${{ inputs.repository }}/releases?per_page=10") || HTTP_RESPONSE=$'\n000'
+          "https://api.github.com/repos/${{ inputs.repository }}/releases?per_page=100") || HTTP_RESPONSE=$'\n000'
         # A connection-level failure (curl non-zero, no HTTP response) is caught
         # above so bash -e does not kill the step: HTTP_CODE parses as 000 and we
         # fall through to the non-200 warning + graceful-skip path below.


### PR DESCRIPTION
## Problem

Llama.cpp CI kept resolving and rebuilding **b9993** while newer upstream builds (b10012 … b10091) existed but were never detected.

## Root cause

The shared `check-github-release` action fetched only the first **10** entries of GitHub's `/releases` list, then sorted that window by `updated_at`. That is fine when the list order tracks recency — but `ai-dock/llama.cpp-cuda` tags every daily build at the same static commit, so all ~60 releases share one `created_at` and GitHub's `created_at`-desc list order buries the genuinely-newest tags deep in the list:

- `b10091` (published Jul 23) sat at **index ~54**
- stale `b9993` held **index 0**

The 10-item window never saw the newer tags, so the `sort_by(.updated_at)` only ever picked b9993.

## Fix

Widen the fetch to `per_page=100`; the existing `sort_by(.updated_at) | reverse` then selects the true latest. Verified against the live endpoint — resolves **b10091**.

Strictly a larger, more-correct sample for the other 6 workflows sharing this action (comfyui, invokeai, openwebui, voicebox, whisper, aio-studio); same filters and sort.

## Relationship to the upstream fix

This is defense-in-depth. The real root cause is fixed upstream in **ai-dock/llama.cpp-cuda#7**, which makes each release's tag point at an advancing commit so `created_at` tracks recency again. This `per_page` change fixes the symptom immediately and hardens the action against any upstream that develops the same tie in future.