### PR TITLE
fix(vllm): build both CUDA variants on nightly; raise QA VRAM floor to 16GB

### DIFF
--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -71,7 +71,11 @@ jobs:
         run: |
           echo "is-nightly=true" >> $GITHUB_OUTPUT
           echo "version=nightly-$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          echo 'matrix=[{"tag":"nightly","cuda":"12.9"}]' >> $GITHUB_OUTPUT
+          # Upstream flipped the default CUDA on nightlies: the bare "nightly"
+          # tag is now the CUDA 13.0 image, and the 12.9 variant moved to the
+          # "cu129-nightly" PREFIX tag (unlike releases, which suffix -cu129).
+          # Build both so nightly matches the release matrix's CUDA coverage.
+          echo 'matrix=[{"tag":"nightly","cuda":"13.0"},{"tag":"cu129-nightly","cuda":"12.9"}]' >> $GITHUB_OUTPUT
           echo "Nightly build requested - skipping version matching"
 
       - name: Check release and resolve version

--- a/external/vllm/templates/vllm-qa/template.yml
+++ b/external/vllm/templates/vllm-qa/template.yml
@@ -14,7 +14,8 @@
 #    service we omit: it's optional and skipping it avoids a port check on a service the
 #    serving smoke doesn't exercise. A portal entry whose port isn't listening fails the
 #    harness's port check, so we list only entries that actually bind.
-#  - Selection floors tuned for the tiny model, not production's 24GB.
+#  - Selection floors tuned for serving-path headroom (below production's 24GB floor —
+#    see the gpu_total_ram note for why the floor is NOT sized to the tiny model).
 # CI overrides image/tag with the freshly-built staging tag via create.py --tag.
 name: "vLLM QA — tiny-model smoke"
 image: vastai/vllm
@@ -53,6 +54,13 @@ extra_filters:
     gte: 800                      # sm_80 — matches the production vLLM floor (vLLM kernels)
   cuda_max_good:
     gte: 13.0                     # host driver must satisfy the newest matrix variant (cuda-13.0)
+  # Headroom floor, not model size (ADR 0005: "floors carry headroom, not the
+  # model's resting size"). vLLM fills gpu_memory_utilization (0.92 on current
+  # nightlies) with KV cache during sizing, then allocates AFTER sizing during
+  # kernel warmup (FlashInfer sampling workspace, ~150 MiB). On an 8 GB card the
+  # post-budget margin is ~30 MiB and the engine OOMs on startup even with a
+  # 0.5B model; 16 GB leaves >1 GiB above the budget. Small-card viability of
+  # upstream defaults is upstream's concern, not what this smoke certifies.
   gpu_total_ram:
-    gte: 8192                     # 8 GB — ample for a 0.5B model + KV cache
+    gte: 16384                    # 16 GB (3x selector bound: 16-48 GB)
 recommended_disk_space: 32.0      # vLLM image + small model + workspace


### PR DESCRIPTION
## What

Two coupled vLLM CI fixes:

1. **QA VRAM floor 8 GB -> 16 GB.** The live-GPU QA gate floored at `gpu_total_ram >= 8192`, sized to the tiny 0.5B smoke model rather than to serving-path headroom. vLLM fills `gpu_memory_utilization` (0.92 on current nightlies) with KV cache during sizing, then allocates a ~150 MiB FlashInfer sampling workspace *after* sizing during kernel warmup. On an 8 GB card that leaves ~30 MiB and the engine OOMs at startup even with a 0.5B model; 16 GB leaves >1 GiB above the budget. Applies ADR 0005's rule: floors carry headroom, not the model's resting size. (Production vLLM floors at 24 GB; small-card viability of upstream defaults is upstream's concern, not what this smoke certifies.)

2. **Nightly builds both CUDA variants.** Upstream flipped nightly's default CUDA: the bare `nightly` tag is now the CUDA 13.0 build and 12.9 moved to a `cu129`-prefixed tag. The hardcoded nightly matrix pulled `nightly` and mislabeled it `cuda-12.9` (a CUDA 13 image), building no real 12.9 variant. The matrix now builds both, mirroring the release matrix.

## Why now

Without the floor bump, every live-GPU QA run (nightly on main, and any dispatch) plays VRAM roulette: cells that draw an 8 GB card (e.g. RTX 3070, 7.65 GiB) OOM at vLLM engine-core init and BLOCK, while cells drawing a bigger card pass — same template, luck of the offer draw. Observed on a recent dispatch: the 13.0 cell passed and the 12.9 cell BLOCKed on a 3070, purely by card draw.

Both changes are confined to `external/vllm/` (the QA template floor + the nightly build matrix). No behaviour change to the shipped image.
