### PR TITLE
fix(qa): fail fast on 'unexpected eof' pull errors so a broken host is blacklisted

### DIFF
--- a/tools/template_manager/test_template.py
+++ b/tools/template_manager/test_template.py
@@ -495,6 +495,10 @@ BAD_STATUS_PATTERNS = (
     "no space left on device",
     "manifest unknown",
     "unauthorized",
+    "unexpected eof",                  # truncated container pull on a broken host
+                                       # (e.g. "...unexpected EOF while reading") — never
+                                       # recovers, so fail fast to blacklist + retry the
+                                       # next offer rather than waiting out POLL_TIMEOUT.
 )
 
 

--- a/tools/template_manager/tests/test_poll.py
+++ b/tools/template_manager/tests/test_poll.py
@@ -37,6 +37,39 @@ def test_poll_uses_byid_per_tick_and_list_once(monkeypatch):
     assert api.list_calls == 1        # heavy list-all fetched exactly once (at running)
 
 
+class _FakeAPIWithMsg:
+    """Reports a status_msg alongside actual_status (the by-id poll's real shape),
+    so a bad-status message can be exercised. Stays 'loading' forever — only the
+    message should end the poll."""
+    def __init__(self, status_msg, actual_status="loading"):
+        self._status_msg = status_msg
+        self._actual_status = actual_status
+        self.list_calls = 0
+
+    def get_instance_status(self, instance_id, safe=False):
+        return {"actual_status": self._actual_status, "status_msg": self._status_msg}
+
+    def get_instance(self, instance_id, safe=False):
+        self.list_calls += 1
+        return {"public_ipaddr": "1.2.3.4", "jupyter_token": "tok", "ports": {}}
+
+
+def test_poll_fastfails_on_unexpected_eof(monkeypatch):
+    # A broken host truncates the image pull ("unexpected EOF while reading") and
+    # never leaves 'loading'. poll_until_running must fail fast on the message
+    # (return None,None) so the caller destroys + blacklists + retries the next
+    # offer — NOT wait out the 40-min POLL_TIMEOUT. Regression: this signature
+    # was absent from BAD_STATUS_PATTERNS and leaked stuck instances on a bad host.
+    monkeypatch.setattr(tt.time, "sleep", lambda s: None)
+    # A generous deadline: if the fix regresses, the loop would spin here, not exit.
+    monkeypatch.setattr(tt.time, "time", iter([0, 1, 2, 3, 4, 5]).__next__)
+    api = _FakeAPIWithMsg("failed to register layer: unexpected EOF while reading")
+    url, token = tt.poll_until_running(api, 42, timeout=100)
+
+    assert (url, token) == (None, None)   # fast-failed on the message
+    assert api.list_calls == 0            # never reached running; no heavy fetch
+
+
 def test_poll_does_not_hit_list_endpoint_while_loading(monkeypatch):
     # If it never reaches running before the deadline, the list endpoint is
     # never touched at all — the whole (bounded) boot wait stays O(1)-per-tick.


### PR DESCRIPTION
## What

Add `unexpected eof` to `test_template.py`'s `BAD_STATUS_PATTERNS`, so the live-GPU QA client fast-fails on a broken host that truncates the image pull.

## Why

`poll_until_running` treats a small set of status messages as unrecoverable and returns immediately (destroy + blacklist the machine + retry the next offer). A host with a broken/truncated pull reports `...unexpected EOF while reading`, which matched **none** of the five existing patterns — so the client waited out the full `POLL_TIMEOUT = 2400` (40 min) on a box that would never run.

Compounding it: offer selection is deterministic (cheapest box above the VRAM floor). So every fresh QA run re-picked the **same** broken host, and cancelling before the 40-min timeout meant the in-run machine blacklist never armed — leaking stuck `loading` instances (observed: four RTX 3080 boxes on one bad host in a single incident).

With this signature in the fatal set, the client fails in seconds, blacklists the machine, and lands on the next offer — self-recovering instead of stalling and re-landing.

## Test

`tests/test_poll.py::test_poll_fastfails_on_unexpected_eof` drives a forever-`loading` instance whose `status_msg` carries the EOF signature and asserts `poll_until_running` returns `(None, None)` without the heavy list call. Mutation-verified: removing the pattern fails the test. Full `tools/template_manager` suite: 112 passed.

Scoped to `tools/template_manager/` (QA client only) — no image or workflow changes.
