### PR TITLE
fix(vllm-qa): floor host reliability (reliability2>=0.95) to stop drawing flaky hosts

### DIFF
--- a/external/vllm/templates/vllm-qa/template.yml
+++ b/external/vllm/templates/vllm-qa/template.yml
@@ -68,4 +68,14 @@ extra_filters:
   # a single ~9-10 GB card — observed live on the cu13.0 cell (GPU 0 = 9.64 GiB).
   gpu_ram:
     gte: 16384                    # 16 GB PER GPU (single-GPU smoke — not the sum)
+  # Host-reliability floor. The QA account kept drawing the cheapest boxes, and
+  # cheap unreliable hosts fail in host-specific ways the image can't fix: a
+  # truncated image pull ("unexpected eof"), and a host with no outbound egress
+  # ('[Errno 101] Network is unreachable' fetching the model from HuggingFace) —
+  # both observed live on cu13.0. reliability2 is Vast's aggregate host score
+  # (good hosts ~0.92-0.99); 0.95 excludes the flaky tail with margin while
+  # keeping a healthy offer pool at this VRAM band. Tunable: lower if the pool
+  # thins, raise toward `verified` if flakes persist.
+  reliability2:
+    gte: 0.95
 recommended_disk_space: 32.0      # vLLM image + small model + workspace


### PR DESCRIPTION
## What

Add `reliability2 >= 0.95` to the vLLM QA template's `extra_filters`, so live-GPU QA stops selecting flaky low-reliability hosts.

## Why

The QA account was repeatedly drawing the cheapest boxes, and cheap unreliable hosts fail in host-specific ways the image cannot fix — a **different** flake per re-dispatch on the cu13.0 cell:

- **Truncated image pull** — `...unexpected eof while reading` (now fast-failed + machine-blacklisted by #230, confirmed firing live).
- **No outbound egress** — `[Errno 101] Network is unreachable` fetching `Qwen/Qwen2.5-0.5B-Instruct` from HuggingFace, so vLLM never loads the model and `vllm.d/10-vllm-serving` EXITs. This surfaces only *after* the instance is "running", so it lands as a test BLOCK, not a fast-fail.

Meanwhile cu12.9 passed on both runs — the image is fine; this is host roulette. `reliability2` is Vast's aggregate host score (good hosts ~0.92–0.99, a flaky one in the deverified set scored 0.69); a 0.95 floor skips the flaky tail while keeping a healthy offer pool at this VRAM band (RTX 3080/4090 at ~$0.11–0.5/hr, well under the $2/hr cap).

Tunable: lower if the pool thins, raise toward a `verified`-host filter if flakes persist. Scoped to `external/vllm/templates/vllm-qa/template.yml`.
