### PR TITLE
fix(vllm): pin NCCL to 2.28.9 to dodge B300 NVLS MoE hang (nccl#2167) [rebuild base, do not merge]

### DIFF
--- a/external/vllm/Dockerfile
+++ b/external/vllm/Dockerfile
@@ -67,6 +67,21 @@ RUN \
 # vllm pick them up.  Also enables volume sync of the environment.
 RUN sed -i '1s|#!/usr/bin/python3|#!/venv/main/bin/python|' /usr/local/bin/vllm
 
+# Pin NCCL below the 2.30.4 NVLS regression (NVIDIA/nccl#2167).  NCCL >= 2.30.4's
+# NVSwitch-multicast (NVLS) code path deadlocks during high-expert-count MoE weight
+# loading on Blackwell: reproduced bare on 8x B300 with Kimi-K3 (896 routed experts)
+# — every rank freezes at "NVLS tuning" and Init COMPLETE is never reached, so no
+# weights ever download.  The upstream vllm/vllm-openai:kimi-k3 image ships NCCL
+# 2.30.7; 2.28.9 (the version the working lmsysorg/sglang:kimi-k3 image runs) predates
+# the regression and retains Blackwell sm_100/sm_103 support.  Override via
+# --build-arg NCCL_PIN=... (e.g. 2.30.3, the last good 2.30.x per nccl#2167).
+# NOTE: nvidia-nccl-cu13 targets the CUDA-13 builds; use -cu12 for CUDA-12 tags.
+ARG NCCL_PIN=2.28.9
+RUN \
+    set -euo pipefail && \
+    uv pip install --system --no-cache-dir "nvidia-nccl-cu13==${NCCL_PIN}" && \
+    /venv/main/bin/python -c "import torch; print('pinned torch.cuda.nccl:', torch.cuda.nccl.version())"
+
 # Defend against environment clashes when syncing to volume
 RUN env-hash > /.env_hash
 


### PR DESCRIPTION
**Purpose:** a rebuild base for Kimi-K3 B300 bring-up — **not intended to merge**.

## Problem
`vastai/vllm:kimi-k3-cuda-13.0` (and the upstream `vllm/vllm-openai:kimi-k3` it's built from) hangs on 8× B300 during multi-GPU init. Diagnosed to **[NVIDIA/nccl#2167](https://github.com/NVIDIA/nccl/issues/2167)**: NCCL's NVLS (NVSwitch-multicast) path regressed in **2.30.4** and deadlocks during high-expert-count MoE weight loading on Blackwell.

- Reproduced **bare** by running `vllm serve moonshotai/Kimi-K3 --tensor-parallel-size 8 …` directly on the raw upstream image (no vast layer, no template) → every rank freezes at `NCCL INFO NVLS tuning: nChannels 24`, `Init COMPLETE` never reached, 0% GPU, no weight download.
- Upstream image ships **NCCL 2.30.7** (in the buggy range). Kimi-K3 has **896 routed experts** — squarely the MoE case nccl#2167 flags (Kimi K2.6 / 384 experts also hangs there).
- The vast `external/vllm` layer is exonerated: it only `FROM`s the upstream image and never touches torch/CUDA/NCCL.

## Fix
Pin `nvidia-nccl-cu13` to **2.28.9** — the exact NCCL the *working* `lmsysorg/sglang:kimi-k3` image runs (predates the 2.30.4 regression, keeps Blackwell sm_100/sm_103). Installed via `uv pip install --system` (same mechanism as the existing `ray` line) so it replaces the NCCL torch loads at runtime; a build-time check prints the resulting `torch.cuda.nccl.version()`.

Configurable: \`--build-arg NCCL_PIN=2.30.3\` for the last-good 2.30.x.

## Rebuild
\`\`\`
docker build external/vllm \
  --build-arg VLLM_BASE=vllm/vllm-openai:kimi-k3 \
  --build-arg NCCL_PIN=2.28.9 \
  -t vastai/vllm:kimi-k3-cuda-13.0
\`\`\`

## Caveat
`nvidia-nccl-cu13` targets CUDA-13 tags; swap to `-cu12` for CUDA-12 builds (this branch is single-purpose for the cuda-13 k3 image).