### PR TITLE
ci(base): get current (cuda 13.3.1), fix CI test collection, record ADR 0019

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -78,7 +78,7 @@ jobs:
             "cuda-13.0-24|nvidia/cuda:13.0.3-cudnn-devel-ubuntu24.04|cuda-13.0.3-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
             "cuda-13.1-24|nvidia/cuda:13.1.2-cudnn-devel-ubuntu24.04|cuda-13.1.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
             "cuda-13.2-24|nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04|cuda-13.2.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.3-24|nvidia/cuda:13.3.0-cudnn-devel-ubuntu24.04|cuda-13.3.0-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.3-24|nvidia/cuda:13.3.1-cudnn-devel-ubuntu24.04|cuda-13.3.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
           )
 
           BUILD_MATRIX="[]"

--- a/.github/workflows/extend-base-image.yml
+++ b/.github/workflows/extend-base-image.yml
@@ -64,7 +64,7 @@ jobs:
             "cuda-13.0-24|cuda-13.0.3-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
             "cuda-13.1-24|cuda-13.1.2-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
             "cuda-13.2-24|cuda-13.2.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
-            "cuda-13.3-24|cuda-13.3.0-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
+            "cuda-13.3-24|cuda-13.3.1-cudnn-devel-ubuntu24.04|linux/amd64,linux/arm64|3.12"
           )
 
           BUILD_MATRIX="[]"

--- a/.github/workflows/imagegen-tests.yml
+++ b/.github/workflows/imagegen-tests.yml
@@ -36,3 +36,9 @@ jobs:
       - name: Run imagegen test suite
         working-directory: tools/imagegen
         run: python -m pytest -q
+      # Collection is rooted at working-directory, so the template_manager suite
+      # needs its own invocation — without it, these tests (including
+      # test_qa_gate_floor_guard.py, the pre-merge guard ADR 0005 relies on)
+      # never ran in CI despite the paths filter above (ADR 0018 condition 1).
+      - name: Run template_manager test suite
+        run: python -m pytest -q tools/template_manager

--- a/.github/workflows/imagegen-tests.yml
+++ b/.github/workflows/imagegen-tests.yml
@@ -39,6 +39,6 @@ jobs:
       # Collection is rooted at working-directory, so the template_manager suite
       # needs its own invocation — without it, these tests (including
       # test_qa_gate_floor_guard.py, the pre-merge guard ADR 0005 relies on)
-      # never ran in CI despite the paths filter above (ADR 0018 condition 1).
+      # never ran in CI despite the paths filter above (ADR 0019 condition 1).
       - name: Run template_manager test suite
         run: python -m pytest -q tools/template_manager

--- a/.github/workflows/promote-base-image.yml
+++ b/.github/workflows/promote-base-image.yml
@@ -58,7 +58,7 @@ jobs:
             "cuda-13.0-24|cuda-13.0.3-cudnn-devel-ubuntu24.04|3.12"
             "cuda-13.1-24|cuda-13.1.2-cudnn-devel-ubuntu24.04|3.12"
             "cuda-13.2-24|cuda-13.2.1-cudnn-devel-ubuntu24.04|3.12"
-            "cuda-13.3-24|cuda-13.3.0-cudnn-devel-ubuntu24.04|3.12"
+            "cuda-13.3-24|cuda-13.3.1-cudnn-devel-ubuntu24.04|3.12"
           )
 
           CONFIGS_JSON="[]"

--- a/docs/adr/0005-live-gpu-qa-gate.md
+++ b/docs/adr/0005-live-gpu-qa-gate.md
@@ -318,7 +318,7 @@ these, or the gate's safety properties invert at scale:
   `merge-manifests`.)* Onboarding images must instead bound their own matrix
   (`max-parallel`), stagger their crons away from other gates' schedules, and rely
   on the client's 429/5xx backoff; the account-aware semaphore remains the planned
-  proper fix. See [ADR 0018](0018-base-image-promotion-qa-gate.md) condition 9 for
+  proper fix. See [ADR 0019](0019-base-image-promotion-qa-gate.md) condition 9 for
   the base image's posture.
 - **Smoke model ≠ production model.** Mirror the production template's *launch path*
   (runtype, ports, PORTAL_CONFIG, args) but **not** its model/floors: production

--- a/docs/adr/0005-live-gpu-qa-gate.md
+++ b/docs/adr/0005-live-gpu-qa-gate.md
@@ -310,12 +310,16 @@ these, or the gate's safety properties invert at scale:
   ever candidates). The default (30) is sized above full-rollout concurrency
   (images × matrix cells × in-flight); raise it as images are gated. A ceiling sized
   for one image fail-closes into a leak once concurrency exceeds it.
-- **One QA account → serialize launches.** All qa jobs share the
-  `concurrency: qa-vast-account` group so concurrent builds can't 429-storm the
-  single capped key — a 429 maps to `no_offers`/inconclusive, which the schedule
-  path soft-passes, i.e. silent promotion. Onboarded images **must** join the group
-  **and** stagger their build crons (the group alone drops excess matrix cells under
-  contention → those images held, not tested).
+- **One QA account → bounded concurrency, NOT a shared concurrency group.**
+  *(Corrected 2026-08-05 — this bullet previously instructed onboarded images to
+  join a `concurrency: qa-vast-account` group, contradicting condition 6 above and
+  the shipped `qa-gate.yml`, which removed that group as harmful: it allows only
+  1 running + 1 pending and cancels the rest, and a cancelled qa cell blocks
+  `merge-manifests`.)* Onboarding images must instead bound their own matrix
+  (`max-parallel`), stagger their crons away from other gates' schedules, and rely
+  on the client's 429/5xx backoff; the account-aware semaphore remains the planned
+  proper fix. See [ADR 0018](0018-base-image-promotion-qa-gate.md) condition 9 for
+  the base image's posture.
 - **Smoke model ≠ production model.** Mirror the production template's *launch path*
   (runtype, ports, PORTAL_CONFIG, args) but **not** its model/floors: production
   models are large (e.g. llama-cpp's default is a ~35B GGUF) and would brick the

--- a/docs/adr/0018-base-image-promotion-qa-gate.md
+++ b/docs/adr/0018-base-image-promotion-qa-gate.md
@@ -1,0 +1,264 @@
+# ADR 0018 — QA-gated, human-approved base-image `-auto` promotion
+
+- **Status:** Accepted (conditional — see Binding conditions; build sequenced from condition 1)
+- **Date:** 2026-08-05
+- **Decision owner:** Rob Ballantyne
+- **Extends:** [ADR 0005](0005-live-gpu-qa-gate.md) (live-GPU QA gate). Where this ADR
+  admits the base image to the gating allowlist and adds conditions 12–15, it extends
+  0005 explicitly; nothing in 0005 is silently overridden.
+- **Process:** idea brief → critical-review gate (which cut an upstream-version-detection
+  component after measuring its value case) → three competing designs → independent
+  scoring on feasibility/value/risk → synthesis → final critical review of the written
+  plan (verdict: serious-but-fixable; every surviving finding folded into the Decision
+  and Binding conditions below).
+
+## Context
+
+The base image is the highest-blast-radius artifact in this repo: every derivative
+`FROM`s it directly or via pytorch, and the patch-versioned `cuda-X.Y.Z-auto` prod tags
+feed Vast's `@vastai-automatic-tag` backend used by live customer templates. Until now
+**nothing tested the base image at any point**: `build-base-image.yml` (dispatch-only)
+pushes 12 configs × 5 pythons × 2 arches to dated staging tags with zero tests, and
+`promote-base-image.yml` (dispatch-only, `environment: production` with required
+reviewers) crane-retags a whole staging date to prod and repoints every auto tag via a
+two-phase "dance" whose push order the Vast backend depends on.
+
+Two structural facts shaped the design:
+
+- **The vLLM pattern does not transfer.** In `build-vllm.yml`, QA sits between build and
+  the production write *in one run*. Base promotion is a separate workflow, dispatched
+  days later, keyed by a **mutable** date tag (same-day partial re-dispatch rewrites it),
+  and CI artifacts expire in one day — so any cross-workflow "QA passed" record that is
+  not digest-bound can certify bytes that are no longer what gets copied.
+- **ADR 0005's allowlist principle** forbids presenting boot-and-curl as "QA passed".
+  0005 rejected boot-level gates because they launder "booted" into "QA'd" *for the
+  product above the boot*. For the base image there is no product above the boot: the
+  platform layer (supervisor, portal, Caddy TLS/auth, the exposure gate, python/venv,
+  CUDA userland vs driver) **is** the product, and `ROOT/opt/instance-tools/tests/base/`
+  exercises it — including real driver-API CUDA work (`cuInit`/alloc via ctypes, library
+  loads). Base therefore earns a legitimate allowlist seat **only if** the suite cannot
+  silently skip: today `60-gpu-cuda`/`61-cuda-compute`/`62-gpu-libraries` self-skip
+  (exit 77) on a GPU-less or driver-broken box and the runner reports green — the exact
+  skip-as-pass class 0005 documented for `vllm.d`.
+
+Constraints carried throughout: the QA account is single-key and 429-prone with no
+account-level semaphore yet (0005 cond 6); the owner requires **all 12 configs** tested
+per promotion (bounded parallelism, not a sample) and `-auto` promotion to remain
+**always human-approved**; the batch promotion model (one staging date, one approval) is
+preserved; upstream version detection was cut from scope after review showed 11/12
+configs already at their minor's terminal patch (~4–8 automatable events/year) and the
+existing detection primitive cannot even see 11 of the 12 tracked minors.
+
+## Options considered
+
+- **A. QA at promote time, in the same run as the prod write (chosen).** The promote
+  workflow resolves the digests it is about to copy, live-GPU-tests them pre-approval,
+  and the human approves with the evidence table in view. **Why it won:** same-run
+  evidence structurally deletes the cross-run trust problem (no evidence carrier, no
+  schema, no stale/forged/retried-until-green record can exist); smallest delta to a
+  working system (build workflow untouched; the dance changes by one ref substitution);
+  the only rollout that is enforcing from birth rather than metered over promotion
+  cycles a two-person team will not sustain.
+- **B. QA at build time + a digest-keyed attestation artifact in the registry, verified
+  fail-closed at promote.** The strongest single mechanism reviewed (a positive
+  digest-keyed pass record is immune to every absence-of-red failure mode, and handles
+  same-day partial rebuilds with no special-casing) and the best floor reasoning.
+  **Rejected for v1:** the largest permanent surface (a payload schema to version, a
+  five-module tool, a fourth workflow, never-GC'd artifact tags, registry write
+  credentials granted to the shared `qa-gate.yml` that has never held any); an
+  unbounded retry-until-green residual (a maintainer can re-dispatch the standalone QA
+  workflow until a flaky cell passes, invisibly to the approver); and a multi-phase
+  rollout keyed to promotion cycles that at this cadence realistically never reaches
+  enforcement. The risk reviewer **dissented in favour of B** (positive-artifact
+  predicate; flake measured before enforcement; zero-cost rollback) and named the
+  condition that closes the gap for A: a rollback path — adopted (see Decision).
+  Recorded as the evolution path if promoting older already-QA'd dates becomes routine.
+- **C. Collapse build+promote into one release pipeline.** Contributed four ideas the
+  decision adopts (config-table extraction, a dance-only rollback mode, the
+  flip⇒evidence predicate, the pre-committed de-scoping fallback). **Rejected as a
+  whole:** it rewrites and deletes both working workflows — including the dance, whose
+  ordering semantics depend on an untestable external backend — in one move; it shipped
+  a one-checkbox QA bypass (`QA=skip`) and an "INERT" pass-on-no-offers verdict whose
+  premise is false (QA's `no_offers` reflects QA's own cost/reliability filters, not
+  customer serveability — customers face none of those filters), i.e. two designed-in
+  ways to flip an auto tag to untested bits; and its hand-maintained auto-version field
+  was shown to rename the customer-facing auto tag undetectably (its own worked example
+  would have stranded `cuda-13.3.1-auto`'s audience).
+- **CPU-container harness only (no live GPU).** Only 3 of the 24 base tests strictly
+  require a GPU. **Rejected as the whole answer** (as in 0005): the live boot also
+  validates portal/Caddy/supervisor/exposure under real Vast driver injection per
+  config, which is precisely the surface recent field defects came from. Revisited only
+  as the degraded mode of binding condition 15.
+- **Atomic batch gating (any red cell blocks the whole promotion).** The original shape
+  of option A. **Superseded during the final review:** with 12 cells the gate's success
+  is pⁿ in per-cell reliability (≈54% clean-run at an optimistic 95%/cell), which
+  predictably drives operators to route around the gate. Chosen instead: flip-passing /
+  hold-failing (Decision), which keeps every flip tested while making one flaky cell
+  cost one held tag instead of a multi-hour re-dispatch.
+
+## Decision
+
+Wire a live-GPU QA phase into `promote-base-image.yml` itself, pre-approval, and make
+the prod write digest-pinned and evidence-verified. The enforced invariant:
+
+> **No `cuda-X.Y.Z-auto` tag flips to a digest whose amd64 manifest has not passed a
+> live-GPU QA run of those exact bits in the same workflow run that writes it, and no
+> prod write happens without an `environment: production` human approval given after
+> the QA evidence is visible.**
+
+Shape:
+
+- **Job graph:** `preflight` (fail-closed on missing `VAST_API_KEY` + all DockerHub
+  secrets) → `generate-configs` (from a single extracted config table) →
+  `resolve-digests` (existence pre-flight moved before approval; `crane digest`
+  manifest of record; pre-capture of every auto tag's digest; **immutable run-scoped
+  alias tags** `qa-<run_id>-<config>` published in staging at the exact index digests
+  the auto tags will hold; `PYTHON_VERSION` provenance assertion) → `qa` (matrix ×12
+  via the extended reusable `qa-gate.yml`: `require_key: true`, `timeout: 2400` **plus**
+  `PROV_TIMEOUT/INSTANCE_TEST_DEFAULT_TIMEOUT/VLLM_HEALTH_TIMEOUT=900` in `extra_env`
+  — the client only ever lifts a too-short `--timeout`, so both halves are required;
+  `retries` on `no_offers` only, 5–10 min jittered backoff, wall-clock deadline guard;
+  `fail-fast: false`, `max-parallel: 2`) → `qa-summary` (12-row evidence table into the
+  job summary + Slack ping; does **not** fail the run on a red cell) → `promote`
+  (`environment: production`): `verify-evidence` (every auto tag that would flip must
+  be covered by a passing evidence record at the matching digest; alias tags
+  re-resolved; concurrent-promotion abort on moved auto tags) → copy **by digest** →
+  dance with digest-ref targets, Phase A/B ordering and the full-config sweep
+  byte-identical.
+- **Partial failure: flip passing, hold failing.** Auto tags with passing evidence
+  flip; failing/inconclusive configs keep their pre-captured digest (the dance
+  re-pushes them unchanged, preserving ordering) and are named loudly — verdict class
+  and held-digest age — in the approval summary and Slack. Dated-tag copies proceed for
+  all configs (dated tags are opt-in by explicit reference; the gate's claim is the
+  `-auto` surface). There is no `EXCLUDE` input and no `SKIP_QA` input.
+- **Fail-not-skip:** the in-instance runner gains a required-pass gate
+  (`INSTANCE_TEST_REQUIRE_PASS`: a named test that is skipped, **missing**, or
+  unreached marks the suite failed), and CI independently re-asserts the per-cell
+  required set from the machine-readable verdict before accepting a pass. The required
+  set is defined **per cell in the workflow matrix** (cuda configs: the GPU trio;
+  stock configs: the non-GPU subset, stated plainly as CPU-verified) and pinned by a
+  guard test; the template's baseline env is defense in depth (linter rule L057).
+- **Floors:** one lintable QA template (`templates/base-qa/`), `compute_cap >= 750`,
+  per-GPU `gpu_ram >= 8192`, `reliability2 >= 0.95`, and **major-baseline**
+  `cuda_max_good` (11.8 / 12.0 / 13.0): within a CUDA major, minor compatibility is
+  guaranteed and the suite's own compat branch passes same-major skew, so
+  major-baseline is both representative (a 13.0-driver host legitimately serves 13.3
+  bits) and keeps the offer pool wide. CI tightening of floors is **raise-only**
+  (`create.py --set-filter`), preserving the linted floor guarantee at rent time.
+- **Rollback:** a separate tiny dispatch workflow runs **only the dance** against
+  already-promoted prod dated tags of a prior staging date — no build, no copies, no
+  QA, seconds, still `environment: production`, and **in the same
+  `base-image-promote` concurrency group** as promote so the two dances can never
+  interleave. Safe because it can only repoint auto tags at bits that already went
+  through promotion; rolling *forward* untested bits remains impossible.
+- **Config table extracted** to a single machine-readable file consumed by both
+  workflows (matrices proven byte-identical before anything else moves). The auto-tag
+  version stays **derived** from `tag_template` (no hand-maintained field — a second
+  source of truth for a customer-facing name was shown to be a silent-rename hazard),
+  with a unit test asserting every cuda config yields a version and stock configs none.
+- **Linter:** L050/L054 base-class exemptions removed (no-op on today's baseline);
+  new L057 for the base QA template; `docs/lint-rules.md` regenerated; mutation tests
+  for every new check, including one that pins today's skip-as-pass bug before fixing it.
+- **Sequenced prerequisites:** (0) get current — bump the one stale config
+  `cuda-13.3.0 → 13.3.1` in both workflows and rebuild/promote once on the existing
+  path; (1) fix `imagegen-tests.yml` so `tools/template_manager/tests/` actually runs
+  in CI (it never has — pytest is rooted at `tools/imagegen`, so 0005's own named
+  pre-merge guard has never executed); then harness+linter, config extraction,
+  gate parameterization, template+floors, the condition-10 floor sweep, wiring, and
+  staged first exercises (dry-run → full unapproved run against the live date →
+  idempotent approved re-promotion of the live date → first real promotion).
+
+## Binding conditions
+
+Non-negotiable; each needs its enforcing artifact (0005 cond 11 applies). If any is
+refused, this decision is void.
+
+1. **The CI test-collection fix lands first.** Every guard and mutation test below is
+   decorative while `tools/template_manager/tests/` is uncollected. Artifact: the
+   updated `imagegen-tests.yml` plus a green run showing the suite executing.
+2. **(extends 0005 as cond 12) Flip ⇒ same-run digest-verified evidence.** An auto tag
+   may only flip to a digest whose amd64 manifest is covered by a passing,
+   digest-matching QA evidence record produced in the same workflow run. Artifact:
+   `verify-evidence` unit tests including the mutation case (evidence at digest D,
+   promote about to flip to D′ → refuse).
+3. **(extends 0005 as cond 13) No bypass, no schedule, fail-closed.** The promote path
+   has no soft-pass, no bypass input, and no `schedule:` trigger; a missing
+   `VAST_API_KEY` fails the run before any spend. The only un-QA'd prod write is the
+   rollback workflow, which can only repoint to already-promoted bits and shares the
+   promote concurrency group. Artifacts: dispatch-inputs, trigger, needs-edge,
+   concurrency-group and `require_key` guard tests.
+4. **(extends 0005 as cond 14) Pre-committed de-scoping fallback.** If more than 1 in 3
+   promotions hold on infrastructure (not real image defects), the gating set is cut to
+   a representative 4 (oldest CUDA, newest CUDA, each ubuntu base) and the rest labeled
+   non-gating — honestly, by ADR amendment, never by per-run exemptions.
+5. **(extends 0005 as cond 15) Coverage is stated, not implied.** amd64 manifest only
+   (the promoted index's arm64 child is never booted); default-python index only (the
+   exact `-auto` surface); mini variants and non-default pythons promote untested via
+   dated tags; single-GPU; no pre-Turing. The approval summary and the ADR say so.
+6. **Fail-not-skip proven by mutation.** The GPU-less-box case turns the suite red under
+   the required-pass gate (and stays green-skip without it); required-test
+   missing/unreached cases covered; per-cell matrix required-sets pinned by a guard
+   test. No mutation test, no gate.
+7. **Floors validated by real runs before gating** (0005 cond 10): one recorded passing
+   run per config at its declared floors against an already-promoted staging date.
+8. **Recovery mechanics verified:** alias tags carry no `run_attempt`; cleanup deletes
+   them only after successful promote (next run sweeps strays); "Re-run failed jobs"
+   demonstrated to re-test the same pinned digest.
+9. **Honest operating numbers:** ~2.5 h typical dispatch→approval at `max-parallel: 2`
+   (6 waves), 4–5 h bad day; GPU ~$2.50 typical, $10 budgeted, `max_price 1.00`. The
+   account-level semaphore (0005 cond 6) remains deferred; promotions are staggered off
+   the other gates' cron edges, and the semaphore is revisited at the next image
+   onboarding.
+10. **Known carried defect recorded:** the dance's Phase A points each auto tag at
+    another config's (QA-passed) image for a seconds-long window — pre-existing,
+    unchanged in v1 to keep the dance byte-identical. Named follow-up: prefer the same
+    config's previous digest as the Phase A anchor, foreign anchor only as fallback.
+11. **ADR 0010 exemption is explicit.** Base cannot satisfy 0010's one-template rule:
+    its customer launch templates live on the Vast side, outside this repo.
+    `templates/base-qa/` is an approximation of a customer launch; its drift from the
+    real Vast-side template is a stated risk no in-repo check can detect, and "QA
+    passed" claims are worded accordingly. This is an exemption recorded here, not
+    silent drift.
+12. **Operational assumptions carry their probes.** The Vast automatic-tag backend
+    resolving by newest push per CUDA version (which makes patch-bump auto-tag renames
+    and historical orphans like `cuda-12.8-auto` harmless) is an owner-confirmed
+    operational assumption, not a verified fact: the phase-0 bump includes a post-promote
+    probe that new instances resolve the renamed tag before orphan cleanup. ADR 0005's
+    stale "all qa jobs share the `concurrency: qa-vast-account` group" sentence (its
+    rollout section contradicts its own Decision) is corrected as part of this work.
+
+## Consequences
+
+- The highest-blast-radius artifact in the repo stops promoting untested: every `-auto`
+  flip is backed by a live-GPU run of the exact amd64 bits, the reviewer approves with
+  the evidence in view, and a red or thin-market cell holds one tag loudly instead of
+  blocking the fleet or shipping untested.
+- Incident response gains a seconds-fast, approval-gated rollback that cannot ship
+  untested bits — removing the pressure that historically deletes gates.
+- Promotion becomes a same-half-day operation (~2.5 h to approval) instead of
+  same-hour; accepted against the blast radius, with the rollback path keeping
+  emergencies fast.
+- Accepted-untested surface remains and is stated: arm64 children, mini variants,
+  non-default pythons, multi-GPU, pre-Turing, and the Phase A window (condition 10).
+- Standing surface: one QA template + floor table, a verdict/manifest/evidence toolset,
+  four `qa-gate.yml` inputs (defaults preserve the existing consumers byte-for-byte),
+  two linter rules + two exemption removals, one config file, one rollback workflow,
+  and guard tests — all of it only trustworthy because of condition 1.
+- The approval reviewers' environment protection is the load-bearing human gate and
+  lives in GitHub settings, observed by no repo artifact. Owner decision (2026-08-05):
+  prevent-self-review stays off (a dispatcher may approve their own promotion — the
+  evidence table, not a second human, is the check), and no additional QA-account
+  spend-ceiling work is taken on beyond the existing capped balance.
+
+## What would reverse this
+
+- Promoting older, already-QA'd staging dates becoming routine (not exceptional) — the
+  same-run topology then taxes every re-promotion with a fresh sweep, and option B's
+  digest-keyed attestation carrier becomes the right evolution; this ADR records it as
+  the named successor design.
+- The gate holding on infrastructure at the condition-4 threshold — triggers the
+  de-scope to a representative 4, and if even that flakes, collapse toward the
+  CPU-harness + minimal-GPU-cells shape rather than keep a red check nobody trusts.
+- Vast shipping scoped keys, first-class ephemeral instances, or an in-repo view of the
+  live launch templates — each simplifies (the reaper/concurrency posture, or the
+  condition-11 exemption) without changing the gate's principle.

--- a/docs/adr/0018-base-image-promotion-qa-gate.md
+++ b/docs/adr/0018-base-image-promotion-qa-gate.md
@@ -81,7 +81,9 @@ existing detection primitive cannot even see 11 of the 12 tracked minors.
   a one-checkbox QA bypass (`QA=skip`) and an "INERT" pass-on-no-offers verdict whose
   premise is false (QA's `no_offers` reflects QA's own cost/reliability filters, not
   customer serveability — customers face none of those filters), i.e. two designed-in
-  ways to flip an auto tag to untested bits; and its hand-maintained auto-version field
+  ways to flip an auto tag to untested bits (a guarded variant of its skip flag was
+  later adopted by owner decision — see condition 3's amendment); and its
+  hand-maintained auto-version field
   was shown to rename the customer-facing auto tag undetectably (its own worked example
   would have stranded `cuda-13.3.1-auto`'s audience).
 - **CPU-container harness only (no live GPU).** Only 3 of the 24 base tests strictly
@@ -130,7 +132,8 @@ Shape:
   re-pushes them unchanged, preserving ordering) and are named loudly — verdict class
   and held-digest age — in the approval summary and Slack. Dated-tag copies proceed for
   all configs (dated tags are opt-in by explicit reference; the gate's claim is the
-  `-auto` surface). There is no `EXCLUDE` input and no `SKIP_QA` input.
+  `-auto` surface). There is no `EXCLUDE` input; a loud, reasoned, human-approved
+  `SKIP_QA` bypass exists under condition 3's guardrails (2026-08-05 amendment).
 - **Fail-not-skip:** the in-instance runner gains a required-pass gate
   (`INSTANCE_TEST_REQUIRE_PASS`: a named test that is skipped, **missing**, or
   unreached marks the suite failed), and CI independently re-asserts the per-cell
@@ -181,12 +184,30 @@ refused, this decision is void.
    digest-matching QA evidence record produced in the same workflow run. Artifact:
    `verify-evidence` unit tests including the mutation case (evidence at digest D,
    promote about to flip to D′ → refuse).
-3. **(extends 0005 as cond 13) No bypass, no schedule, fail-closed.** The promote path
-   has no soft-pass, no bypass input, and no `schedule:` trigger; a missing
-   `VAST_API_KEY` fails the run before any spend. The only un-QA'd prod write is the
-   rollback workflow, which can only repoint to already-promoted bits and shares the
-   promote concurrency group. Artifacts: dispatch-inputs, trigger, needs-edge,
-   concurrency-group and `require_key` guard tests.
+3. **(extends 0005 as cond 13) No silent or automated bypass; fail-closed.** The
+   promote path has no soft-pass and no `schedule:` trigger; when QA is not skipped, a
+   missing `VAST_API_KEY` fails the run before any spend.
+   *(Amended 2026-08-05, owner decision. This condition originally read "no bypass
+   input"; the final critical review rated a skip input the single most likely
+   gate-erosion path — "used the first time the gate is inconvenient, then every time
+   after" — and that finding stands recorded, not overturned. The owner accepts the
+   risk because some promotions are preceded by hands-on manual testing.)*
+   A `SKIP_QA` dispatch input exists, under four non-negotiable guardrails:
+   - `SKIP_REASON` is mandatory — an empty reason fails pre-flight;
+   - it is loud at the moment of decision: the approval summary renders a prominent
+     warning naming every auto tag that will flip **without automated evidence**, with
+     the reason verbatim, and the Slack notification carries a distinct
+     "promoted WITHOUT automated QA" headline;
+   - the skip waives only the flip⇒evidence requirement — digest pinning,
+     copy-by-digest, the concurrent-promotion abort and the staging-drift checks all
+     still run (the bypass skips the test, never the integrity chain);
+   - **usage tripwire:** if more than 1 of any 4 consecutive promotions is skipped,
+     the flag's premise is void — either the gate is too painful (fix the gate) or
+     skipping is becoming the default path (remove the flag); resolved by ADR
+     amendment, with the run history as the record.
+   The rollback workflow remains the only other un-QA'd prod write and can only
+   repoint to already-promoted bits. Artifacts: dispatch-inputs, trigger, needs-edge,
+   concurrency-group, `require_key`, mandatory-reason and warning-banner guard tests.
 4. **(extends 0005 as cond 14) Pre-committed de-scoping fallback.** If more than 1 in 3
    promotions hold on infrastructure (not real image defects), the gating set is cut to
    a representative 4 (oldest CUDA, newest CUDA, each ubuntu base) and the rest labeled
@@ -244,6 +265,11 @@ refused, this decision is void.
   four `qa-gate.yml` inputs (defaults preserve the existing consumers byte-for-byte),
   two linter rules + two exemption removals, one config file, one rollback workflow,
   and guard tests — all of it only trustworthy because of condition 1.
+- An owner-accepted bypass exists (condition 3, 2026-08-05 amendment): a promotion
+  preceded by manual testing may skip the automated sweep. This is recorded against
+  the final review's top-ranked erosion finding; the mandatory reason, the
+  warning banner at approval, the distinct notification and the usage tripwire are
+  the mitigations, and the tripwire is the tripcord.
 - The approval reviewers' environment protection is the load-bearing human gate and
   lives in GitHub settings, observed by no repo artifact. Owner decision (2026-08-05):
   prevent-self-review stays off (a dispatcher may approve their own promotion — the
@@ -252,6 +278,9 @@ refused, this decision is void.
 
 ## What would reverse this
 
+- **The `SKIP_QA` tripwire firing** (more than 1 of any 4 consecutive promotions
+  skipped): the flag is removed or the gate's pain point is fixed — either way by ADR
+  amendment, never by letting skips quietly become the norm.
 - Promoting older, already-QA'd staging dates becoming routine (not exceptional) — the
   same-run topology then taxes every re-promotion with a fresh sweep, and option B's
   digest-keyed attestation carrier becomes the right evolution; this ADR records it as

--- a/docs/adr/0019-base-image-promotion-qa-gate.md
+++ b/docs/adr/0019-base-image-promotion-qa-gate.md
@@ -1,4 +1,4 @@
-# ADR 0018 — QA-gated, human-approved base-image `-auto` promotion
+# ADR 0019 — QA-gated, human-approved base-image `-auto` promotion
 
 - **Status:** Accepted (conditional — see Binding conditions; build sequenced from condition 1)
 - **Date:** 2026-08-05
@@ -232,8 +232,11 @@ refused, this decision is void.
    onboarding.
 10. **Known carried defect recorded:** the dance's Phase A points each auto tag at
     another config's (QA-passed) image for a seconds-long window — pre-existing,
-    unchanged in v1 to keep the dance byte-identical. Named follow-up: prefer the same
-    config's previous digest as the Phase A anchor, foreign anchor only as fallback.
+    unchanged in v1 to keep the dance byte-identical. Named follow-up with a **proven
+    in-repo donor**: `promote-pytorch.yml`'s dance already fixes this exact hole
+    (changed target → single direct copy, no hop; unchanged target → bump via the
+    py310 sibling of the SAME image, so a mid-hop reader never sees wrong-CUDA bits).
+    Port that pattern to the base dance as its own change after v1 lands.
 11. **ADR 0010 exemption is explicit.** Base cannot satisfy 0010's one-template rule:
     its customer launch templates live on the Vast side, outside this repo.
     `templates/base-qa/` is an approximation of a customer launch; its drift from the


### PR DESCRIPTION
## What

Phase 0 and prerequisite 1 of ADR 0019 (QA-gated, human-approved base-image `-auto` promotion), plus the ADR itself.

- **Get current:** bump the one stale config, `cuda-13.3.0 -> 13.3.1` (upstream tag published 2026-07-28, amd64+arm64 verified via the DockerHub API), in **all three** copies of the config list: `build-base-image.yml`, `promote-base-image.yml`, `extend-base-image.yml`. Note: this renames the auto tag to `cuda-13.3.1-auto` on the next promotion; the backend resolves by newest push per CUDA version, and ADR 0019 condition 12 adds a post-promote probe before any orphan cleanup.
- **CI test collection fix:** `imagegen-tests.yml` rooted pytest at `tools/imagegen`, so the 112-test `tools/template_manager` suite — including `test_qa_gate_floor_guard.py`, the pre-merge guard ADR 0005 names — has never run in CI despite the paths filter. Added a repo-root invocation (ADR 0019 condition 1: everything later in the plan is gated on this).
- **ADR 0019** recorded: QA cells for all 12 configs inside the promote workflow pre-approval, digest-pinned end to end, flip-passing/hold-failing partial semantics, dance-only rollback workflow, major-baseline driver floors, fail-not-skip harness contract. Extends ADR 0005 (conditions 12–15), explicitly exempts base from ADR 0010, records rejected alternatives and the dissenting design as the named evolution path. Build is sequenced in the ADR; nothing beyond the two prerequisites above is built in this PR.
- **ADR 0005 correction:** its rollout section still instructed onboarding images to join the `qa-vast-account` concurrency group that its own Decision (condition 6) removed as harmful; corrected in place with a dated note.

## Evidence

Both suites green from the exact invocations CI uses:
- `tools/imagegen`: 135 passed
- `tools/template_manager` (repo root): 112 passed

## After merge

Dispatch `build-base-image.yml` (full fleet rebuild on the updated configs), then `promote-base-image.yml` on the resulting staging date — the last promotion on the pre-gate path. Then the ADR 0019 build proceeds in its sequenced order (harness fail-not-skip, config-table extraction, qa-gate parameterization, template+floors, wiring).
