### PR TITLE
fix(comfyui/provisioning): clone custom nodes into ComfyUI, not beside it

### DIFF
--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/default.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/default.sh
@@ -86,7 +86,7 @@ function provisioning_get_pip_packages() {
 function provisioning_get_nodes() {
     for repo in "${NODES[@]}"; do
         dir="${repo##*/}"
-        path="${COMFYUI_DIR}custom_nodes/${dir}"
+        path="${COMFYUI_DIR}/custom_nodes/${dir}"
         requirements="${path}/requirements.txt"
         if [[ -d $path ]]; then
             if [[ ${AUTO_UPDATE,,} != "false" ]]; then

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/flux.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/flux.sh
@@ -83,7 +83,7 @@ function provisioning_get_pip_packages() {
 function provisioning_get_nodes() {
     for repo in "${NODES[@]}"; do
         dir="${repo##*/}"
-        path="${COMFYUI_DIR}custom_nodes/${dir}"
+        path="${COMFYUI_DIR}/custom_nodes/${dir}"
         requirements="${path}/requirements.txt"
         if [[ -d $path ]]; then
             if [[ ${AUTO_UPDATE,,} != "false" ]]; then

--- a/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/hunyuan3d.sh
+++ b/derivatives/pytorch/derivatives/comfyui/provisioning_scripts/hunyuan3d.sh
@@ -89,7 +89,7 @@ function provisioning_get_pip_packages() {
 function provisioning_get_nodes() {
     for repo in "${NODES[@]}"; do
         dir="${repo##*/}"
-        path="${COMFYUI_DIR}custom_nodes/${dir}"
+        path="${COMFYUI_DIR}/custom_nodes/${dir}"
         requirements="${path}/requirements.txt"
         if [[ -d $path ]]; then
             if [[ ${AUTO_UPDATE,,} != "false" ]]; then


### PR DESCRIPTION
`COMFYUI_DIR` is `${WORKSPACE}/ComfyUI` with no trailing slash, so `"${COMFYUI_DIR}custom_nodes/${dir}"` resolved to `/workspace/ComfyUIcustom_nodes/` — a sibling directory ComfyUI never scans.

Effect: every custom node a user listed in `NODES` was cloned somewhere it could not be loaded from, and since the `[[ -d $path ]]` guard never matched, each provisioning run re-cloned all of them.

```
before: /workspace/ComfyUIcustom_nodes/mynode
after:  /workspace/ComfyUI/custom_nodes/mynode
```

Still present in `default.sh`, `flux.sh` and `hunyuan3d.sh`. The same line was already correct in `lora.sh`, `image-tools.sh`, `ltx-video.sh` and `text_to_video_wan.sh` — which is presumably why it survived this long.

**Credit:** reported independently by @amgad-naiem in #5 and @nprabhakar in #6, in March 2025. Both PRs are superseded by this one, which also covers `hunyuan3d.sh` (added after they were opened).