### PR TITLE
feat(qa): gate pytorch promotion on live-GPU QA (ADR 0020, ADR 0021)

### DIFF
--- a/.github/workflows/build-pytorch.yml
+++ b/.github/workflows/build-pytorch.yml
@@ -68,6 +68,8 @@ jobs:
       has-multi: ${{ steps.matrix.outputs.has-multi }}
       build-date: ${{ steps.matrix.outputs.build-date }}
     steps:
+      # Needed for configs/pytorch.json — this job previously ran with no checkout.
+      - uses: actions/checkout@v4
       - name: Generate matrices
         id: matrix
         run: |
@@ -80,70 +82,23 @@ jobs:
           # All pytorch versions and their configs
           # Config format: torch_ver|key|cuda_ver|torch_backend|arches|python_versions
           # Mini format:   torch_ver|key|mini_base_tag|torch_backend|python_versions (always multi-arch)
-          ALL_CONFIGS=(
-            # 2.6.0
-            "2.6.0|cu126|12.6.3-cudnn-devel|cu126|linux/amd64,linux/arm64|310 311 312"
-            # 2.7.1
-            "2.7.1|cu126|12.6.3-cudnn-devel|cu126|linux/amd64|310 311 312"
-            "2.7.1|cu128|12.8.1-cudnn-devel|cu128|linux/amd64,linux/arm64|310 311 312 313"
-            # 2.8.0
-            "2.8.0|cu126|12.6.3-cudnn-devel|cu126|linux/amd64|310 311 312"
-            "2.8.0|cu128|12.8.1-cudnn-devel|cu128|linux/amd64|310 311 312 313"
-            "2.8.0|cu129|12.9.2-cudnn-devel|cu129|linux/amd64|310 311 312 313"
-            # 2.9.1 (patch versions maintain ABI compat — 2.9.0 superseded)
-            "2.9.1|cu126|12.6.3-cudnn-devel|cu126|linux/amd64|310 311 312"
-            "2.9.1|cu128|12.8.1-cudnn-devel|cu128|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.9.1|cu130|13.0.3-cudnn-devel|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-            # 2.10.0
-            "2.10.0|cu126|12.6.3-cudnn-devel|cu126|linux/amd64|310 311 312"
-            "2.10.0|cu128|12.8.1-cudnn-devel|cu128|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.10.0|cu130|13.0.3-cudnn-devel|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-            # 2.11.0
-            "2.11.0|cu126|12.6.3-cudnn-devel|cu126|linux/amd64|310 311 312"
-            "2.11.0|cu128|12.8.1-cudnn-devel|cu128|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.11.0|cu130|13.0.3-cudnn-devel|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-            # 2.12.0 — cu126 (non-Blackwell) + cu130 (Blackwell, on the 13.0.3
-            # base), both multi-arch cp310-cp314. cu132 is deferred: torch 2.12
-            # publishes cu132 wheels, but uv's --torch-backend has no cu132 value
-            # yet (tops out at cu130), so the build can't select it. Re-add
-            # cu132 on the 13.2.1 base once uv gains it, or switch the install to
-            # an explicit --index-url https://download.pytorch.org/whl/cu132.
-            "2.12.0|cu126|12.6.3-cudnn-devel|cu126|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.12.0|cu130|13.0.3-cudnn-devel|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_CONFIGS < <(jq -r '.configs[] | "\(.torch)|\(.key)|\(.cuda_ver)|\(.backend)|\(.arches | join(","))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_CONFIGS"; exit 1; }
 
           # Multi-torch configs: a primary mini pytorch image with
           # additional torch venvs layered in. Each produces
           #   ${NS}/pytorch:${key}-py${py}-${date}-${arch}
           # and is later merged into a multi-arch manifest.
           # Format: key|primary_torch|primary_backend|cuda_minor|arches|python_versions
-          ALL_MULTI_CONFIGS=(
-            "multi-210-291-271|2.10.0|cu128|12.9|linux/amd64,linux/arm64|312"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_MULTI_CONFIGS < <(jq -r '.multi[] | "\(.key)|\(.primary_torch)|\(.primary_backend)|\(.cuda_minor)|\(.arches | join(","))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_MULTI_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_MULTI_CONFIGS"; exit 1; }
 
           # Mini format: torch_ver|key|mini_base_tag|torch_backend|arches|python_versions
-          ALL_MINI_CONFIGS=(
-            # 2.6.0 — cu126 is multi-arch
-            "2.6.0|cu126-mini|cuda-12.9-mini|cu126|linux/amd64,linux/arm64|310 311 312 313"
-            # 2.7.1 — cu128 is multi-arch
-            "2.7.1|cu128-mini|cuda-12.9-mini|cu128|linux/amd64,linux/arm64|310 311 312 313"
-            # 2.8.0 — cu128 is amd64-only (no arm64 wheels)
-            "2.8.0|cu128-mini|cuda-12.9-mini|cu128|linux/amd64|310 311 312 313"
-            # 2.9.1 — cu128 multi-arch, cu130 multi-arch
-            "2.9.1|cu128-mini|cuda-12.9-mini|cu128|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.9.1|cu130-mini|cuda-13.2-mini|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-            # 2.10.0 — cu128 multi-arch, cu130 multi-arch
-            "2.10.0|cu128-mini|cuda-12.9-mini|cu128|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.10.0|cu130-mini|cuda-13.2-mini|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-            # 2.11.0 — cu128 multi-arch, cu130 multi-arch
-            "2.11.0|cu128-mini|cuda-12.9-mini|cu128|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.11.0|cu130-mini|cuda-13.2-mini|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-            # 2.12.0 — no cu128, so the CUDA-12 mini rides cu126 on the 12.9-mini
-            # base (minor-version compat); the CUDA-13 mini keeps cu130 on the
-            # 13.2-mini base (minor compat within 13.x). Both multi-arch.
-            "2.12.0|cu126-mini|cuda-12.9-mini|cu126|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.12.0|cu130-mini|cuda-13.2-mini|cu130|linux/amd64,linux/arm64|310 311 312 313 314"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_MINI_CONFIGS < <(jq -r '.mini[] | "\(.torch)|\(.key)|\(.mini_base_tag)|\(.backend)|\(.arches | join(","))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_MINI_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_MINI_CONFIGS"; exit 1; }
 
           BUILD_MATRIX="[]"
           MERGE_MATRIX="[]"

--- a/.github/workflows/build-pytorch.yml
+++ b/.github/workflows/build-pytorch.yml
@@ -92,7 +92,12 @@ jobs:
           # and is later merged into a multi-arch manifest.
           # Format: key|primary_torch|primary_backend|cuda_minor|arches|python_versions
           # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
-          mapfile -t ALL_MULTI_CONFIGS < <(jq -r '.multi[] | "\(.key)|\(.primary_torch)|\(.primary_backend)|\(.cuda_minor)|\(.arches | join(","))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          # `extra_venvs` is derived from .venvs by dropping "main" (the base image's own
+          # venv, not something this build installs) and stripping the "torch-" prefix
+          # to get bare versions for install-torch-venv.sh. Deriving it here rather than
+          # storing a second list keeps ONE statement of what a variant contains — the
+          # same list 05-venv-manifest.sh asserts against at QA time.
+          mapfile -t ALL_MULTI_CONFIGS < <(jq -r '.multi[] | "\(.key)|\(.primary_torch)|\(.primary_backend)|\(.cuda_minor)|\(.arches | join(","))|\(.python_versions | join(" "))|\(.venvs | map(select(. != "main")) | map(ltrimstr("torch-")) | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
           [ "${#ALL_MULTI_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_MULTI_CONFIGS"; exit 1; }
 
           # Mini format: torch_ver|key|mini_base_tag|torch_backend|arches|python_versions
@@ -151,7 +156,7 @@ jobs:
           # it (e.g. FILTER=multi excludes every mini by substring).
           REQUIRED_MINI_PAIRS="|"
           for multi_config in "${ALL_MULTI_CONFIGS[@]}"; do
-            IFS='|' read -r mkey primary_torch primary_backend mcuda_minor marches mpython_versions <<< "$multi_config"
+            IFS='|' read -r mkey primary_torch primary_backend mcuda_minor marches mpython_versions mextra_venvs <<< "$multi_config"
             if [[ -n "$FILTER" && "$mkey" != *"$FILTER"* && "$primary_torch" != *"$FILTER"* && "multi" != *"$FILTER"* && "mini" != *"$FILTER"* ]]; then
               continue
             fi
@@ -219,7 +224,8 @@ jobs:
           MULTI_MERGE_MATRIX="[]"
 
           for multi_config in "${ALL_MULTI_CONFIGS[@]}"; do
-            IFS='|' read -r key primary_torch primary_backend cuda_minor arches python_versions <<< "$multi_config"
+            IFS='|' read -r key primary_torch primary_backend cuda_minor arches python_versions extra_venvs <<< "$multi_config"
+            [ -n "$extra_venvs" ] || { echo "::error::${key}: no supplementary venvs derived from .venvs — a multi with only 'main' is not a multi"; exit 1; }
 
             # FILTER=mini also includes multi since multi layers on mini.
             if [[ -n "$FILTER" && "$key" != *"$FILTER"* && "$primary_torch" != *"$FILTER"* && "multi" != *"$FILTER"* && "mini" != *"$FILTER"* ]]; then
@@ -248,7 +254,8 @@ jobs:
                 --arg arch_suffix "$arch_suffix" \
                 --arg runs_on "$runs_on" \
                 --arg python_versions "$python_versions" \
-                '. + [{"config_key": $key, "primary_torch": $primary_torch, "primary_backend": $primary_backend, "cuda_minor": $cuda_minor, "arch": $arch, "arch_suffix": $arch_suffix, "runs_on": $runs_on, "python_versions": $python_versions}]')
+                --arg extra_venvs "$extra_venvs" \
+                '. + [{"config_key": $key, "primary_torch": $primary_torch, "primary_backend": $primary_backend, "cuda_minor": $cuda_minor, "arch": $arch, "arch_suffix": $arch_suffix, "runs_on": $runs_on, "python_versions": $python_versions, "extra_venvs": $extra_venvs}]')
             done
           done
 
@@ -603,6 +610,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
           ARCH_SUFFIX: ${{ matrix.arch_suffix }}
           PYTHON_VERSIONS: ${{ matrix.python_versions }}
+          EXTRA_VENVS: ${{ matrix.extra_venvs }}
           BUILD_DATE: ${{ needs.generate-matrix.outputs.build-date }}
         run: |
           mkdir -p "$GITHUB_WORKSPACE/built-tags"
@@ -621,6 +629,7 @@ jobs:
               -f Dockerfile.multi-torch \
               --build-arg PYTORCH_BASE="${BASE}" \
               --build-arg PYTORCH_BACKEND="${PRIMARY_BACKEND}" \
+              --build-arg EXTRA_TORCH_VERSIONS="${EXTRA_VENVS}" \
               --tag "${TAG}" \
               --push .
 

--- a/.github/workflows/extend-pytorch.yml
+++ b/.github/workflows/extend-pytorch.yml
@@ -47,6 +47,8 @@ jobs:
       has-multi: ${{ steps.matrix.outputs.has-multi }}
       build-date: ${{ steps.matrix.outputs.build-date }}
     steps:
+      # Needed for configs/pytorch.json — this job previously ran with no checkout.
+      - uses: actions/checkout@v4
       - name: Generate matrices
         id: matrix
         run: |
@@ -58,46 +60,20 @@ jobs:
 
           # All pytorch versions — extend sources from prod, no base_image needed
           # Format: torch_ver|key|cuda_short|arches|python_versions
-          ALL_CONFIGS=(
-            "2.6.0|cu126|12.6.3|linux/amd64,linux/arm64|310 311 312"
-            "2.7.1|cu126|12.6.3|linux/amd64|310 311 312"
-            "2.7.1|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313"
-            "2.8.0|cu126|12.6.3|linux/amd64|310 311 312"
-            "2.8.0|cu128|12.8.1|linux/amd64|310 311 312 313"
-            "2.8.0|cu129|12.9.2|linux/amd64|310 311 312 313"
-            "2.9.1|cu126|12.6.3|linux/amd64|310 311 312"
-            "2.9.1|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.9.1|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.10.0|cu126|12.6.3|linux/amd64|310 311 312"
-            "2.10.0|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.10.0|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.11.0|cu126|12.6.3|linux/amd64|310 311 312"
-            "2.11.0|cu128|12.8.1|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.11.0|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.12.0|cu126|12.6.3|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.12.0|cu130|13.0.3|linux/amd64,linux/arm64|310 311 312 313 314"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_CONFIGS < <(jq -r '.configs[] | "\(.torch)|\(.key)|\(.cuda_ver | split("-")[0])|\(.arches | join(","))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_CONFIGS"; exit 1; }
 
           # Mini format: torch_ver|key|torch_backend|cuda_minor|arches|python_versions
-          ALL_MINI_CONFIGS=(
-            "2.6.0|cu126-mini|cu126|12.9|linux/amd64,linux/arm64|310 311 312 313"
-            "2.7.1|cu128-mini|cu128|12.9|linux/amd64,linux/arm64|310 311 312 313"
-            "2.8.0|cu128-mini|cu128|12.9|linux/amd64|310 311 312 313"
-            "2.9.1|cu128-mini|cu128|12.9|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.9.1|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.10.0|cu128-mini|cu128|12.9|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.10.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.11.0|cu128-mini|cu128|12.9|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.11.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.12.0|cu126-mini|cu126|12.9|linux/amd64,linux/arm64|310 311 312 313 314"
-            "2.12.0|cu130-mini|cu130|13.2|linux/amd64,linux/arm64|310 311 312 313 314"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_MINI_CONFIGS < <(jq -r '.mini[] | "\(.torch)|\(.key)|\(.backend)|\(.mini_base_tag | ltrimstr("cuda-") | rtrimstr("-mini"))|\(.arches | join(","))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_MINI_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_MINI_CONFIGS"; exit 1; }
 
           # Multi-torch format: key|primary_torch|primary_backend|cuda_minor|arches|python_versions
           # (key already encodes the full tag; extend overlays the prod manifest per arch)
-          ALL_MULTI_CONFIGS=(
-            "multi-210-291-271|2.10.0|cu128|12.9|linux/amd64,linux/arm64|312"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_MULTI_CONFIGS < <(jq -r '.multi[] | "\(.key)|\(.primary_torch)|\(.primary_backend)|\(.cuda_minor)|\(.arches | join(","))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_MULTI_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_MULTI_CONFIGS"; exit 1; }
 
           BUILD_MATRIX="[]"
           MERGE_MATRIX="[]"

--- a/.github/workflows/promote-pytorch.yml
+++ b/.github/workflows/promote-pytorch.yml
@@ -635,12 +635,29 @@ jobs:
           # force a 2.12 bump — cu126 has no Blackwell kernels, so a Blackwell
           # card on a 12.8/12.9 host would get an unusable image.
           #
-          # cu132 isn't built yet (uv has no --torch-backend value for it), so
-          # there is no native 13.1/13.2 image. The cuda-13.1.2-auto and
-          # cuda-13.2.1-auto entries alias those hosts onto cu130 — it runs on
-          # any CUDA 13.x driver via minor-version compatibility. Without them
-          # the platform falls back to the 13.2 mini for 13.1/13.2 hosts, which
-          # we don't want. When cu132 ships, point cuda-13.2.1-auto at cu132.
+          # cu132 IS built now (the blocker was uv: `--torch-backend cu132` did
+          # not exist until uv 0.12.0 — verified 2026-08-10 against uv's
+          # TorchBackend enum; the base installs uv unpinned, so a build today
+          # gets it). Upstream wheels: download.pytorch.org/whl/cu132, torch
+          # 2.12.0/2.12.1/2.13.0, all five pythons, both arches.
+          #
+          # ONLY cuda-13.2.1-auto moves to it. That host tier gets a natively
+          # matched image, strictly better than the cu130 it replaces.
+          #
+          # cuda-13.1.2-auto deliberately STAYS on cu130, and the reason is the
+          # direction of CUDA minor-version compatibility. The safe direction is
+          # an OLDER-built image on a NEWER driver — a cuda-11.8 image is fine on
+          # a 13.x box, which is why every floor in the QA templates is a `gte`.
+          # The reverse is the fragile one. `cuda_max_good` is the newest CUDA a
+          # host's driver supports, so a host at 13.1 served a 13.2-built image
+          # is relying on compat in the direction that can fail, across a whole
+          # host tier at once. cu131 has no wheel index upstream (404s), so there
+          # is no native option for that tier; cu130 is the newest build every
+          # 13.1 driver can definitely run.
+          #
+          # If this is ever revisited, the QA floor must move with it: the cu132
+          # cell rents at cuda_max_good >= 13.2, so 13.1 hosts are not exercised
+          # by any cell today.
           AUTO_TAG_MAP=(
             "cuda-12.1.1-auto|cu126"
             "cuda-12.4.1-auto|cu126"
@@ -649,7 +666,7 @@ jobs:
             "cuda-12.9.2-auto|cu128"
             "cuda-13.0.3-auto|cu130"
             "cuda-13.1.2-auto|cu130"
-            "cuda-13.2.1-auto|cu130"
+            "cuda-13.2.1-auto|cu132"
           )
 
           # Pre-flight: every staging source we plan to promote must
@@ -1033,12 +1050,29 @@ jobs:
           # force a 2.12 bump — cu126 has no Blackwell kernels, so a Blackwell
           # card on a 12.8/12.9 host would get an unusable image.
           #
-          # cu132 isn't built yet (uv has no --torch-backend value for it), so
-          # there is no native 13.1/13.2 image. The cuda-13.1.2-auto and
-          # cuda-13.2.1-auto entries alias those hosts onto cu130 — it runs on
-          # any CUDA 13.x driver via minor-version compatibility. Without them
-          # the platform falls back to the 13.2 mini for 13.1/13.2 hosts, which
-          # we don't want. When cu132 ships, point cuda-13.2.1-auto at cu132.
+          # cu132 IS built now (the blocker was uv: `--torch-backend cu132` did
+          # not exist until uv 0.12.0 — verified 2026-08-10 against uv's
+          # TorchBackend enum; the base installs uv unpinned, so a build today
+          # gets it). Upstream wheels: download.pytorch.org/whl/cu132, torch
+          # 2.12.0/2.12.1/2.13.0, all five pythons, both arches.
+          #
+          # ONLY cuda-13.2.1-auto moves to it. That host tier gets a natively
+          # matched image, strictly better than the cu130 it replaces.
+          #
+          # cuda-13.1.2-auto deliberately STAYS on cu130, and the reason is the
+          # direction of CUDA minor-version compatibility. The safe direction is
+          # an OLDER-built image on a NEWER driver — a cuda-11.8 image is fine on
+          # a 13.x box, which is why every floor in the QA templates is a `gte`.
+          # The reverse is the fragile one. `cuda_max_good` is the newest CUDA a
+          # host's driver supports, so a host at 13.1 served a 13.2-built image
+          # is relying on compat in the direction that can fail, across a whole
+          # host tier at once. cu131 has no wheel index upstream (404s), so there
+          # is no native option for that tier; cu130 is the newest build every
+          # 13.1 driver can definitely run.
+          #
+          # If this is ever revisited, the QA floor must move with it: the cu132
+          # cell rents at cuda_max_good >= 13.2, so 13.1 hosts are not exercised
+          # by any cell today.
           AUTO_TAG_MAP=(
             "cuda-12.1.1-auto|cu126"
             "cuda-12.4.1-auto|cu126"
@@ -1047,7 +1081,7 @@ jobs:
             "cuda-12.9.2-auto|cu128"
             "cuda-13.0.3-auto|cu130"
             "cuda-13.1.2-auto|cu130"
-            "cuda-13.2.1-auto|cu130"
+            "cuda-13.2.1-auto|cu132"
           )
 
           # Pre-flight: mirror the real promote so missing images

--- a/.github/workflows/promote-pytorch.yml
+++ b/.github/workflows/promote-pytorch.yml
@@ -298,8 +298,12 @@ jobs:
               d=$(crane digest "$ref" 2>/dev/null || echo "")
               d_map=$(jq -c --arg k "py${pt}" --arg v "$d" '.[$k]=$v' <<<"$d_map")
             done
-            e=$(jq -nc --arg k "$key" --arg c "$cm" --arg v "$venvs" --argjson d "$d_map" \
-                  '{key:$k, cuda_minor:$c, venvs:$v, digests:$d}')
+            # `ptorch`, not `pt` — `pt` is the python-tag loop variable just above,
+            # and reusing it would work only by accident of the loop having ended.
+            ptorch=$(jq -r --arg k "$key" '.multi[] | select(.key==$k) | .primary_torch' \
+              "$GITHUB_WORKSPACE/configs/pytorch.json")
+            e=$(jq -nc --arg k "$key" --arg c "$cm" --arg v "$venvs" --arg p "$ptorch" --argjson d "$d_map" \
+                  '{key:$k, cuda_minor:$c, venvs:$v, primary_torch:$p, digests:$d}')
             jq --argjson e "$e" '.multi += [$e]' manifest.json > m.tmp && mv m.tmp manifest.json
           done
 
@@ -323,7 +327,33 @@ jobs:
           # not exist, which the promote job would fail on anyway. Better to see it
           # here, before renting anything.
           DEFAULT_PY=$(jq -r '.default_python' "$GITHUB_WORKSPACE/configs/pytorch.json")
-          jq -c --arg dpy "py${DEFAULT_PY}" '
+
+          # WHICH TESTS A CELL REQUIRES DEPENDS ON WHAT THE IMAGE SHIPS.
+          #
+          # torchaudio does not exist upstream past torch 2.11 (no cu130 wheel
+          # beyond 2.11.0, none at all on cu132), so 2.12+ images correctly do
+          # not carry it and pytorch.d/30-torchaudio correctly self-skips with
+          # "torchaudio not installed in any torch venv (expected for torch >=
+          # 2.12)". Requiring it everywhere made the gate block 20 healthy
+          # artifacts on the first real run — the gate was right and the
+          # required list was wrong.
+          #
+          # Derived from torch-companions.json, which is the same file that
+          # decides whether torchaudio is installed. A second hand-maintained
+          # list would drift from it the first time a companion changed.
+          AUDIO_VERSIONS=$(jq -r 'to_entries | map(select(.value.packages.torchaudio)) | map(.key) | join(" ")' \
+            "$GITHUB_WORKSPACE/derivatives/pytorch/torch-companions.json")
+          echo "torch versions shipping torchaudio: ${AUDIO_VERSIONS}"
+
+          jq -c --arg dpy "py${DEFAULT_PY}" --arg audio "$AUDIO_VERSIONS" '
+            ( $audio | split(" ") ) as $has_audio
+            | def base_req: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries "
+                          + "pytorch.d/05-venv-manifest pytorch.d/10-torch-core "
+                          + "pytorch.d/20-torchvision pytorch.d/40-nccl-init";
+              def req(vers): base_req
+                + (if (vers | any(. as $v | $has_audio | index($v)))
+                   then " pytorch.d/30-torchaudio" else "" end);
+
             # newest torch per backend, by numeric version — the artifact each
             # -auto tag actually resolves to
             ( .configs
@@ -335,6 +365,7 @@ jobs:
                       digest: .digests[$dpy],
                       floor: (.cuda_short | split(".")[0:2] | join(".")),
                       venvs: "main",
+                      require_tests: req([.torch]),
                       describe: (.torch + "-cuda-" + .cuda_short + "-" + $dpy) })
             )
             +
@@ -346,6 +377,7 @@ jobs:
                              digest: .value,
                              floor: $m.cuda_minor,
                              venvs: "main",
+                             require_tests: req([$m.torch]),
                              describe: ($m.torch + "-" + $m.backend + "-cuda-" + $m.cuda_minor + "-mini-" + .key) }) )
               | flatten
             )
@@ -358,6 +390,20 @@ jobs:
                              digest: .value,
                              floor: $u.cuda_minor,
                              venvs: $u.venvs,
+                             # A multi requires torchaudio if ANY of its venvs
+                             # ships it — 30-torchaudio iterates every venv and
+                             # only skips when none has it.
+                             #
+                             # "main" is not a version string: it is the base
+                             # own venv of the base image, i.e. primary_torch. Mapping
+                             # rather than passing it through matters for a
+                             # variant whose PRIMARY ships torchaudio while its
+                             # supplementaries do not — that would otherwise
+                             # read as "no torchaudio anywhere" and leave a test
+                             # that does run unrequired.
+                             require_tests: req($u.venvs | split(" ")
+                               | map(if . == "main" then $u.primary_torch
+                                     else ltrimstr("torch-") end)),
                              describe: ($u.key + "-" + .key) }) )
               | flatten
             )
@@ -430,7 +476,12 @@ jobs:
       # which is the point. `.d` is not a typo: runner.sh names a derivative test
       # by its directory (pytorch.d/), and getting it wrong fails closed on every
       # cell. Pinned by test_required_test_names.py.
-      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries pytorch.d/05-venv-manifest pytorch.d/10-torch-core pytorch.d/20-torchvision pytorch.d/30-torchaudio pytorch.d/40-nccl-init"
+      # PER CELL, derived in resolve-digests from torch-companions.json: an image
+      # that legitimately does not ship torchaudio must not be required to pass
+      # pytorch.d/30-torchaudio. Also pushed in-instance via extra_env below, so
+      # the runner's own gate and this one agree — they fail differently, which
+      # is the point, but they must not disagree about WHAT is required.
+      require_tests: ${{ matrix.require_tests }}
       set_filters: "cuda_max_good.gte=${{ matrix.floor }}"
       retries: 2
       # Mini is 5-6 GB and the full config images 8-12 GB; no cell downloads a
@@ -447,6 +498,7 @@ jobs:
         PROV_TIMEOUT=900
         INSTANCE_TEST_DEFAULT_TIMEOUT=900
         EXPECTED_TORCH_VENVS=${{ matrix.venvs }}
+        INSTANCE_TEST_REQUIRE_PASS=${{ matrix.require_tests }}
       evidence_name: qa-evidence-${{ matrix.cell }}
     secrets:
       VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
@@ -484,7 +536,6 @@ jobs:
         env:
           STAGING_NS: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
           RUN_ID: ${{ github.run_id }}
-          REQUIRE_TESTS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries pytorch.d/05-venv-manifest pytorch.d/10-torch-core pytorch.d/20-torchvision pytorch.d/30-torchaudio pytorch.d/40-nccl-init"
         run: |
           set -euo pipefail
           # Each cell's verdict is recomputed with qa_verdict.py — the SAME function
@@ -502,7 +553,6 @@ jobs:
           from qa_verdict import classify, parse_required
 
           ns, run_id = os.environ["STAGING_NS"], os.environ["RUN_ID"]
-          required = parse_required(os.environ["REQUIRE_TESTS"])
           planned = {c["cell"]: c for c in json.load(open("qa-set.json"))}
 
           rows = []
@@ -515,6 +565,12 @@ jobs:
                   lines = [l for l in raw.read_text().splitlines() if l.strip().startswith("{")]
                   if lines:
                       p = json.loads(lines[-1])
+                      # The cell's OWN required list, from the plan — not one
+                      # global list. Cells legitimately differ (a torch >= 2.12
+                      # image ships no torchaudio), and recomputing with the
+                      # wrong list would manufacture a block here that the cell
+                      # itself never reported.
+                      required = parse_required(plan.get("require_tests", ""))
                       verdict, reason = classify(p.get("exit_code", 1), p, required)
               # Re-resolve the tested digest from the run-scoped alias rather than
               # trusting the payload: the link is checked at the point of use.

--- a/.github/workflows/promote-pytorch.yml
+++ b/.github/workflows/promote-pytorch.yml
@@ -164,8 +164,440 @@ jobs:
           echo "Configs: $(echo "$CONFIGS_JSON" | jq length)"
           echo "Mini configs: $(echo "$MINI_CONFIGS_JSON" | jq length)"
 
-  promote:
+  preflight:
     needs: generate-configs
+    if: ${{ !inputs.DRY_RUN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the gate can actually run
+        env:
+          VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+          NS_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          NS_PROD: ${{ secrets.DOCKERHUB_NAMESPACE }}
+          DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          DH_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          STAGING_DATE: ${{ inputs.STAGING_DATE }}
+        run: |
+          # Every secret the run needs, checked before a human is asked to approve
+          # and before any GPU spend — a missing namespace otherwise surfaces as a
+          # malformed ref deep into the promote.
+          missing=()
+          [ -z "${NS_STAGING}" ] && missing+=("DOCKERHUB_NAMESPACE_STAGING")
+          [ -z "${NS_PROD}" ] && missing+=("DOCKERHUB_NAMESPACE")
+          [ -z "${DH_USER}" ] && missing+=("DOCKERHUB_USERNAME")
+          [ -z "${DH_TOKEN}" ] && missing+=("DOCKERHUB_TOKEN")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+          # STAGING_DATE is free dispatch text that ends up in every registry ref
+          # this run touches. Pin its shape here, where checking costs nothing.
+          if [[ ! "${STAGING_DATE}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "::error::STAGING_DATE must be YYYY-MM-DD, got '${STAGING_DATE}'"
+            exit 1
+          fi
+          # Fail here, before a human is asked to approve anything, rather than
+          # letting 56 cells skip and report green (ADR 0019 cond 3). There is
+          # deliberately no bypass input.
+          if [ -z "${VAST_API_KEY}" ]; then
+            echo "::error::VAST_API_KEY is not set — the QA gate cannot run, so nothing may be promoted. Fix the secret and re-dispatch; there is deliberately no bypass (ADR 0021)."
+            exit 1
+          fi
+          echo "QA gate ready"
+
+  resolve-digests:
+    needs: [generate-configs, preflight]
+    if: ${{ !inputs.DRY_RUN }}
+    runs-on: ubuntu-latest
+    outputs:
+      qa-matrix: ${{ steps.plan.outputs.qa-matrix }}
+      cell-count: ${{ steps.plan.outputs.cell-count }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: imjasonh/setup-crane@v0.4
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pin the digests this run will promote
+        id: plan
+        env:
+          NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          NAMESPACE_PROD: ${{ secrets.DOCKERHUB_NAMESPACE }}
+          STAGING_DATE: ${{ inputs.STAGING_DATE }}
+          CONFIGS: ${{ needs.generate-configs.outputs.configs }}
+          MINI_CONFIGS: ${{ needs.generate-configs.outputs.mini-configs }}
+          MULTI_CONFIGS: ${{ needs.generate-configs.outputs.multi-configs }}
+        run: |
+          set -euo pipefail
+          # The manifest of record. Everything downstream — what QA tests, what the
+          # approver sees, what gets copied — is keyed on these digests, NOT on the
+          # dated staging tag. Staging tags are MUTABLE: a same-day partial rebuild
+          # rewrites them, so a tag-keyed pipeline can certify one set of bits and
+          # ship another (ADR 0019, and the reason base pins ~70 digests).
+          echo '{"configs":[],"mini":[],"multi":[]}' > manifest.json
+
+          # ---- configs -------------------------------------------------------
+          COUNT=$(echo "$CONFIGS" | jq length)
+          for ((i=0; i<COUNT; i++)); do
+            torch=$(echo "$CONFIGS" | jq -r ".[$i].torch_version")
+            key=$(echo "$CONFIGS"   | jq -r ".[$i].key")
+            cs=$(echo "$CONFIGS"    | jq -r ".[$i].cuda_short")
+            pys=$(echo "$CONFIGS"   | jq -r ".[$i].python_versions")
+            d_map="{}"
+            for pt in ${pys}; do
+              ref="${NAMESPACE_STAGING}/pytorch:${torch}-cuda-${cs}-py${pt}-24.04-${STAGING_DATE}"
+              d=$(crane digest "$ref" 2>/dev/null || echo "")
+              d_map=$(jq -c --arg k "py${pt}" --arg v "$d" '.[$k]=$v' <<<"$d_map")
+            done
+            e=$(jq -nc --arg t "$torch" --arg k "$key" --arg c "$cs" \
+                  --argjson d "$d_map" \
+                  '{torch:$t, key:$k, cuda_short:$c, digests:$d}')
+            jq --argjson e "$e" '.configs += [$e]' manifest.json > m.tmp && mv m.tmp manifest.json
+          done
+
+          # ---- mini ----------------------------------------------------------
+          MCOUNT=$(echo "$MINI_CONFIGS" | jq length)
+          for ((i=0; i<MCOUNT; i++)); do
+            torch=$(echo "$MINI_CONFIGS" | jq -r ".[$i].torch_version")
+            key=$(echo "$MINI_CONFIGS"   | jq -r ".[$i].key")
+            be=$(echo "$MINI_CONFIGS"    | jq -r ".[$i].torch_backend")
+            cm=$(echo "$MINI_CONFIGS"    | jq -r ".[$i].cuda_minor")
+            pys=$(echo "$MINI_CONFIGS"   | jq -r ".[$i].python_versions")
+            d_map="{}"
+            for pt in ${pys}; do
+              ref="${NAMESPACE_STAGING}/pytorch:${torch}-${be}-cuda-${cm}-mini-py${pt}-${STAGING_DATE}"
+              d=$(crane digest "$ref" 2>/dev/null || echo "")
+              d_map=$(jq -c --arg k "py${pt}" --arg v "$d" '.[$k]=$v' <<<"$d_map")
+            done
+            e=$(jq -nc --arg t "$torch" --arg k "$key" --arg b "$be" --arg c "$cm" \
+                  --argjson d "$d_map" \
+                  '{torch:$t, key:$k, backend:$b, cuda_minor:$c, digests:$d}')
+            jq --argjson e "$e" '.mini += [$e]' manifest.json > m.tmp && mv m.tmp manifest.json
+          done
+
+          # ---- multi ---------------------------------------------------------
+          UCOUNT=$(echo "$MULTI_CONFIGS" | jq length)
+          for ((i=0; i<UCOUNT; i++)); do
+            key=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].key")
+            cm=$(echo "$MULTI_CONFIGS"  | jq -r ".[$i].cuda_minor")
+            pys=$(echo "$MULTI_CONFIGS" | jq -r ".[$i].python_versions")
+            # The venv list the image is SUPPOSED to ship, from the config table.
+            # 05-venv-manifest.sh compares against it, which is the only way to
+            # detect a MISSING venv — discovery-based tests validate what they find
+            # and report green when two thirds of the artifact is absent.
+            venvs=$(jq -r --arg k "$key" \
+              '.multi[] | select(.key==$k) | .venvs | join(" ")' \
+              "$GITHUB_WORKSPACE/configs/pytorch.json")
+            [ -n "$venvs" ] || { echo "::error::${key}: no venvs declared in configs/pytorch.json"; exit 1; }
+            d_map="{}"
+            for pt in ${pys}; do
+              ref="${NAMESPACE_STAGING}/pytorch:${key}-py${pt}-${STAGING_DATE}"
+              d=$(crane digest "$ref" 2>/dev/null || echo "")
+              d_map=$(jq -c --arg k "py${pt}" --arg v "$d" '.[$k]=$v' <<<"$d_map")
+            done
+            e=$(jq -nc --arg k "$key" --arg c "$cm" --arg v "$venvs" --argjson d "$d_map" \
+                  '{key:$k, cuda_minor:$c, venvs:$v, digests:$d}')
+            jq --argjson e "$e" '.multi += [$e]' manifest.json > m.tmp && mv m.tmp manifest.json
+          done
+
+          echo "pinned $(jq '[.configs[].digests[], .mini[].digests[], .multi[].digests[]] | map(select(. != "")) | length' manifest.json) artifacts by digest"
+
+          # ---- build the QA matrix ------------------------------------------
+          #
+          # WHAT IS GATED (ADR 0021 decision 2):
+          #   * every mini artifact, every python — exhaustive, not sampled. Mini is
+          #     the base layer for 15 of 15 pytorch derivatives, and a python-specific
+          #     defect (a wheel built against the wrong ABI that still imports) is
+          #     invisible to a default-python sweep.
+          #   * the multi alias — the family's only non-`-auto` mutable tag, and the
+          #     base for the AIO studio image.
+          #   * one config cell per BACKEND at default python — the 8 `-auto` tags
+          #     resolve to 3 distinct images, so 3 cells cover 100% of the automatic
+          #     blast radius. Testing all 17 configs would certify artifacts no
+          #     pointer points at.
+          #
+          # A missing digest is NOT silently dropped: it means the staging tag does
+          # not exist, which the promote job would fail on anyway. Better to see it
+          # here, before renting anything.
+          DEFAULT_PY=$(jq -r '.default_python' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          jq -c --arg dpy "py${DEFAULT_PY}" '
+            # newest torch per backend, by numeric version — the artifact each
+            # -auto tag actually resolves to
+            ( .configs
+              | map(select(.digests[$dpy] != null and .digests[$dpy] != ""))
+              | group_by(.key)
+              | map(max_by(.torch | split(".") | map(tonumber)))
+              | map({ cell: ("auto-" + .key),
+                      kind: "auto",
+                      digest: .digests[$dpy],
+                      floor: (.cuda_short | split(".")[0:2] | join(".")),
+                      venvs: "main",
+                      describe: (.torch + "-cuda-" + .cuda_short + "-" + $dpy) })
+            )
+            +
+            ( .mini
+              | map( . as $m
+                     | ($m.digests | to_entries | map(select(.value != "")))
+                     | map({ cell: ("mini-" + $m.torch + "-" + $m.key + "-" + .key),
+                             kind: "mini",
+                             digest: .value,
+                             floor: $m.cuda_minor,
+                             venvs: "main",
+                             describe: ($m.torch + "-" + $m.backend + "-cuda-" + $m.cuda_minor + "-mini-" + .key) }) )
+              | flatten
+            )
+            +
+            ( .multi
+              | map( . as $u
+                     | ($u.digests | to_entries | map(select(.value != "")))
+                     | map({ cell: ("multi-" + $u.key + "-" + .key),
+                             kind: "multi",
+                             digest: .value,
+                             floor: $u.cuda_minor,
+                             venvs: $u.venvs,
+                             describe: ($u.key + "-" + .key) }) )
+              | flatten
+            )
+          ' manifest.json > qa-set.json
+
+          CELLS=$(jq length qa-set.json)
+          [ "$CELLS" -gt 0 ] || { echo "::error::no cells to test — nothing resolved in staging for ${STAGING_DATE}"; exit 1; }
+          echo "cell-count=${CELLS}" >> "$GITHUB_OUTPUT"
+          echo "qa-matrix=$(jq -c '{include: .}' qa-set.json)" >> "$GITHUB_OUTPUT"
+          echo "cells to test: ${CELLS}"
+          jq -r '.[] | "  \(.kind)\t\(.describe)\tfloor=\(.floor)"' qa-set.json
+
+      - name: Publish run-scoped QA refs
+        env:
+          NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+        run: |
+          set -euo pipefail
+          # Pin each tested artifact to an immutable, run-scoped tag. QA then tests
+          # THAT, so a concurrent rebuild cannot swap the bits under the test. The
+          # name carries no run_attempt: a re-run of failed jobs must find the same
+          # refs (resolve-digests will not re-run, having succeeded).
+          jq -r '.[] | "\(.cell) \(.digest)"' qa-set.json |
+          while read -r cell digest; do
+            ref="${NAMESPACE_STAGING}/pytorch:qa-${{ github.run_id }}-${cell}"
+            crane copy "${NAMESPACE_STAGING}/pytorch@${digest}" "$ref"
+            echo "  $ref -> ${digest:0:19}…"
+          done
+
+      - name: Upload manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: promotion-manifest
+          path: |
+            manifest.json
+            qa-set.json
+          retention-days: 7
+
+  qa:
+    needs: [generate-configs, resolve-digests]
+    if: ${{ !inputs.DRY_RUN }}
+    strategy:
+      fail-fast: false
+      # 8, per ADR 0021 cond 8 — chosen deliberately and recorded, not defaulted.
+      #
+      # Base runs 10 cells at 4. This matrix is 56, so at 4 the QA phase would be
+      # ~14 waves. 8 halves that to ~7 while staying inside what the single-key QA
+      # account has been observed to tolerate (ADR 0005 cond 6's account-aware
+      # semaphore is still the proper fix and is still not built).
+      #
+      # Not higher, for a reason that is not rate limits: concurrent cells query
+      # the same thin offer market, and two cells racing for one box surfaces as
+      # bad_instance. Under ADR 0020 that is now inconclusive-and-retried rather
+      # than a block, so it costs money and wall-clock instead of producing a
+      # false red — better, but still a real cost. Revisit with measured 429 and
+      # retry rates after the first runs.
+      max-parallel: 8
+      matrix: ${{ fromJson(needs.resolve-digests.outputs.qa-matrix) }}
+    uses: ./.github/workflows/qa-gate.yml
+    with:
+      repo: pytorch
+      tag: qa-${{ github.run_id }}-${{ matrix.cell }}
+      template_dir: templates/pytorch-qa
+      # MUST start with the reaper's scope prefix: reap_orphans.py matches
+      # instance labels with startswith(), so a label outside it would leave
+      # orphaned instances unreaped while the reaper reported success.
+      label: base-image-qa-pytorch
+      require_key: true
+      # Named here as well as in the template so a template that lost the line
+      # still cannot produce a passing verdict — the two layers fail differently,
+      # which is the point. `.d` is not a typo: runner.sh names a derivative test
+      # by its directory (pytorch.d/), and getting it wrong fails closed on every
+      # cell. Pinned by test_required_test_names.py.
+      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries pytorch.d/05-venv-manifest pytorch.d/10-torch-core pytorch.d/20-torchvision pytorch.d/30-torchaudio pytorch.d/40-nccl-init"
+      set_filters: "cuda_max_good.gte=${{ matrix.floor }}"
+      retries: 2
+      # Mini is 5-6 GB and the full config images 8-12 GB; no cell downloads a
+      # model. 15 min is well clear of the slowest observed base cell and stops a
+      # pathologically slow host burning the client's 40 min default per launch
+      # attempt (observed on base run 31174508116).
+      poll_timeout: "900"
+      max_price: "1.00"
+      timeout: "2400"
+      # EXPECTED_TORCH_VENVS is what makes absence detectable: 05-venv-manifest.sh
+      # compares the venvs it finds against this, so a multi image shipping one of
+      # its three venvs fails instead of validating that one and reporting green.
+      extra_env: |
+        PROV_TIMEOUT=900
+        INSTANCE_TEST_DEFAULT_TIMEOUT=900
+        EXPECTED_TORCH_VENVS=${{ matrix.venvs }}
+      evidence_name: qa-evidence-${{ matrix.cell }}
+    secrets:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  qa-summary:
+    needs: [resolve-digests, qa]
+    # always(): a red cell must still produce the table — that is exactly the run
+    # where someone needs to see which artifact failed and why.
+    if: ${{ always() && !inputs.DRY_RUN }}
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.decide.outputs.tested }}
+      passed: ${{ steps.decide.outputs.passed }}
+      blocked: ${{ steps.decide.outputs.blocked }}
+      inconclusive: ${{ steps.decide.outputs.inconclusive }}
+      image-list: ${{ steps.decide.outputs.image-list }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: imjasonh/setup-crane@v0.4
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with: { name: promotion-manifest, path: . }
+      - uses: actions/download-artifact@v4
+        with: { pattern: qa-evidence-*, path: evidence, merge-multiple: false }
+        continue-on-error: true
+
+      - name: Decide whether this promotion may proceed
+        id: decide
+        env:
+          STAGING_NS: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          RUN_ID: ${{ github.run_id }}
+          REQUIRE_TESTS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries pytorch.d/05-venv-manifest pytorch.d/10-torch-core pytorch.d/20-torchvision pytorch.d/30-torchaudio pytorch.d/40-nccl-init"
+        run: |
+          set -euo pipefail
+          # Each cell's verdict is recomputed with qa_verdict.py — the SAME function
+          # the cell ran, with the same required-tests list. Re-deriving a predicate
+          # here from (state, got_result_event) would silently drop the
+          # required-tests assertion, which is the only BLOCK class those two fields
+          # cannot see: a self-skipping GPU test yields state=passed +
+          # got_result_event=true.
+          #
+          # A cell with NO evidence is a block, not an absence. A cancelled or
+          # crashed cell must never read as "nothing to report".
+          python - <<'PY'
+          import json, os, pathlib, subprocess, sys
+          sys.path.insert(0, "tools/template_manager")
+          from qa_verdict import classify, parse_required
+
+          ns, run_id = os.environ["STAGING_NS"], os.environ["RUN_ID"]
+          required = parse_required(os.environ["REQUIRE_TESTS"])
+          planned = {c["cell"]: c for c in json.load(open("qa-set.json"))}
+
+          rows = []
+          root = pathlib.Path("evidence")
+          for cell, plan in sorted(planned.items()):
+              d = root / f"qa-evidence-{cell}"
+              raw = d / "qa-raw.json"
+              verdict, reason = "block", "no verdict payload for this cell"
+              if raw.is_file():
+                  lines = [l for l in raw.read_text().splitlines() if l.strip().startswith("{")]
+                  if lines:
+                      p = json.loads(lines[-1])
+                      verdict, reason = classify(p.get("exit_code", 1), p, required)
+              # Re-resolve the tested digest from the run-scoped alias rather than
+              # trusting the payload: the link is checked at the point of use.
+              ref = f"{ns}/pytorch:qa-{run_id}-{cell}"
+              try:
+                  digest = subprocess.run(["crane", "digest", ref], capture_output=True,
+                                          text=True, timeout=120).stdout.strip()
+              except Exception:
+                  digest = ""
+              ok = digest != "" and digest == plan["digest"]
+              if verdict == "pass" and not ok:
+                  verdict, reason = "block", (
+                      f"tested digest {digest[:19] or '<unresolved>'} != planned "
+                      f"{plan['digest'][:19]} — the cell did not test what this run pins")
+              rows.append({"cell": cell, "kind": plan["kind"],
+                           "describe": plan["describe"], "verdict": verdict,
+                           "reason": reason, "digest": plan["digest"]})
+
+          json.dump(rows, open("verdicts.json", "w"), indent=2)
+
+          n = len(rows)
+          by = lambda v: [r for r in rows if r["verdict"] == v]
+          passed, blocked, inconc = by("pass"), by("block"), by("inconclusive")
+
+          out = open(os.environ["GITHUB_OUTPUT"], "a")
+          out.write(f"tested={n}\npassed={len(passed)}\n")
+          out.write(f"blocked={len(blocked)}\ninconclusive={len(inconc)}\n")
+
+          # The image list the approver and Slack both read. Truncated for Slack,
+          # complete in the step summary — 56 lines is unreadable in a chat message
+          # and unarguable in a job summary.
+          shown = [r["describe"] for r in passed[:12]]
+          more = len(passed) - len(shown)
+          image_list = ", ".join(shown) + (f" (+{more} more)" if more > 0 else "")
+          out.write(f"image-list={image_list}\n")
+          out.close()
+
+          s = open(os.environ["GITHUB_STEP_SUMMARY"], "a")
+          s.write(f"## PyTorch QA — {len(passed)}/{n} passed\n\n")
+          s.write("Every artifact below was booted on a live GPU and ran the full "
+                  "suite. Coverage: amd64 only; single GPU; mini exhaustively "
+                  "(every python built); auto surface and multi at default python "
+                  "only (ADR 0021).\n\n")
+          s.write("| verdict | kind | artifact | digest | reason |\n")
+          s.write("|---|---|---|---|---|\n")
+          icon = {"pass": "PASS", "block": "BLOCK", "inconclusive": "INCONCLUSIVE"}
+          for r in sorted(rows, key=lambda r: (r["verdict"] != "block",
+                                               r["verdict"] != "inconclusive",
+                                               r["cell"])):
+              s.write(f"| {icon.get(r['verdict'], r['verdict'])} | {r['kind']} | "
+                      f"`{r['describe']}` | `{r['digest'][:19]}` | {r['reason']} |\n")
+          s.close()
+          PY
+
+          echo "--- verdicts ---"
+          jq -r '.[] | "  \(.verdict)\t\(.describe)"' verdicts.json
+
+          BLOCKED=$(jq '[.[] | select(.verdict=="block")] | length' verdicts.json)
+          INCONC=$(jq '[.[] | select(.verdict=="inconclusive")] | length' verdicts.json)
+
+          # THE GATE (ADR 0021 decision 3 and 4). Any block, or any exhausted
+          # inconclusive, stops the WHOLE promotion — no auto tags, no dated tags,
+          # nothing. This is stricter than base-image, which promotes dated tags
+          # regardless and holds only auto tags; the difference is deliberate and
+          # justified by mini being the base layer for the derivative estate.
+          #
+          # Inconclusive stops it too, and that is not an oversight: letting "we
+          # never got a clean box" through would promote untested bits while every
+          # run looked green, which is SKIP_QA in a new hat. Under ADR 0020 each of
+          # those cells has already been retried on fresh offers, so this is the
+          # exhausted case, and re-dispatching draws a new market.
+          if [ "$BLOCKED" -gt 0 ] || [ "$INCONC" -gt 0 ]; then
+            echo "::error::QA did not clear: ${BLOCKED} blocked, ${INCONC} inconclusive of $(jq length verdicts.json) cells. Nothing will be promoted."
+            jq -r '.[] | select(.verdict!="pass") | "::error::\(.verdict): \(.describe) — \(.reason)"' verdicts.json
+            exit 1
+          fi
+          echo "all $(jq length verdicts.json) cells passed"
+
+      - uses: actions/upload-artifact@v4
+        with: { name: promotion-verdicts, path: "verdicts.json", retention-days: 7 }
+
+  promote:
+    needs: [generate-configs, qa-summary]
     if: ${{ !inputs.DRY_RUN }}
     runs-on: ubuntu-latest
     environment: production
@@ -501,6 +933,37 @@ jobs:
           path: built-tags/
           retention-days: 1
 
+  cleanup-qa-refs:
+    needs: [promote]
+    # Only after a successful promote, and never on a dry run. A failed promote
+    # keeps this run's aliases so the digests it tested stay pullable while
+    # someone works out what happened.
+    if: ${{ always() && !inputs.DRY_RUN && needs.promote.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: imjasonh/setup-crane@v0.4
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Sweep stray qa-* alias tags from previous runs
+        env:
+          NS: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+          KEEP: ${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          # This matrix publishes 56 run-scoped aliases per promotion, so without a
+          # sweep the staging namespace accumulates them faster than base's 10.
+          # This run's are kept for forensics and expire on the next promotion.
+          swept=0
+          for tag in $(crane ls "${NS}/pytorch" 2>/dev/null | grep -E '^qa-[0-9]+-' || true); do
+            run_id="${tag#qa-}"; run_id="${run_id%%-*}"
+            [ "$run_id" = "$KEEP" ] && continue
+            crane delete "${NS}/pytorch:${tag}" 2>/dev/null && swept=$((swept+1))
+          done
+          echo "swept ${swept} stray qa-* alias tag(s); kept this run's for forensics"
+
   collect-tags:
     needs: [promote]
     if: always() && !inputs.DRY_RUN
@@ -833,11 +1296,25 @@ jobs:
           done
 
   notify:
-    needs: [generate-configs, promote, collect-tags]
+    needs: [generate-configs, qa-summary, promote, collect-tags]
     if: always() && !inputs.DRY_RUN
     uses: ./.github/workflows/notify-slack.yml
     with:
       build-result: ${{ needs.promote.result }}
+      # WHICH IMAGES WERE TESTED, not just whether the run went green. A promotion
+      # message that says only "success" makes the reader open the run to find out
+      # what it covered, which in practice means nobody checks. The counts come
+      # from qa-summary's recomputed verdicts (the same qa_verdict.py the cells
+      # ran), and image-list names the artifacts that actually passed — truncated
+      # here because 56 lines is unreadable in a chat message; the complete table
+      # is in the job summary.
+      status: ${{ needs.qa-summary.result != 'success' && 'warning' || '' }}
+      headline: >-
+        ${{ needs.qa-summary.result != 'success'
+            && format('PyTorch promotion BLOCKED by QA — {0} blocked, {1} inconclusive of {2} cells. NOTHING was promoted (ADR 0021: any red stops the whole run).',
+                      needs.qa-summary.outputs.blocked, needs.qa-summary.outputs.inconclusive, needs.qa-summary.outputs.tested)
+            || format('PyTorch promoted — {0}/{1} artifacts QA''d on live GPUs (amd64, single GPU; mini exhaustively, auto+multi at default python). Tested: {2}',
+                      needs.qa-summary.outputs.passed, needs.qa-summary.outputs.tested, needs.qa-summary.outputs.image-list) }}
       image-name: "PyTorch (Production)"
       image-ref: ${{ inputs.STAGING_DATE }}
       image-tags: ${{ needs.collect-tags.outputs.all-tags || '[]' }}

--- a/.github/workflows/promote-pytorch.yml
+++ b/.github/workflows/promote-pytorch.yml
@@ -302,8 +302,11 @@ jobs:
             # and reusing it would work only by accident of the loop having ended.
             ptorch=$(jq -r --arg k "$key" '.multi[] | select(.key==$k) | .primary_torch' \
               "$GITHUB_WORKSPACE/configs/pytorch.json")
-            e=$(jq -nc --arg k "$key" --arg c "$cm" --arg v "$venvs" --arg p "$ptorch" --argjson d "$d_map" \
-                  '{key:$k, cuda_minor:$c, venvs:$v, primary_torch:$p, digests:$d}')
+            pbackend=$(jq -r --arg k "$key" '.multi[] | select(.key==$k) | .primary_backend' \
+              "$GITHUB_WORKSPACE/configs/pytorch.json")
+            e=$(jq -nc --arg k "$key" --arg c "$cm" --arg v "$venvs" --arg p "$ptorch" \
+                  --arg pb "$pbackend" --argjson d "$d_map" \
+                  '{key:$k, cuda_minor:$c, venvs:$v, primary_torch:$p, primary_backend:$pb, digests:$d}')
             jq --argjson e "$e" '.multi += [$e]' manifest.json > m.tmp && mv m.tmp manifest.json
           done
 
@@ -350,6 +353,23 @@ jobs:
             | def base_req: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries "
                           + "pytorch.d/05-venv-manifest pytorch.d/10-torch-core "
                           + "pytorch.d/20-torchvision pytorch.d/40-nccl-init";
+              # ARCHITECTURE CEILING, the counterpart to the cuda_max_good FLOOR.
+              #
+              # cuda_max_good bounds the host DRIVER from below. Nothing bounded
+              # the GPU ARCHITECTURE from above, so a cu126 cell could rent a
+              # Blackwell card (sm_120) whose wheels contain no kernels for it.
+              # Run 31591093625 hit that on six different RTX 5070 offers:
+              # cudaErrorNoKernelImageForDevice, torch matmul and conv2d failing,
+              # reproducible across hosts. The image was fine; it was tested on
+              # hardware it is never served, since a Blackwell host needs a 12.8+
+              # driver and so is never matched by the 12.x auto tags pointing at
+              # cu126.
+              #
+              # PyTorch cu126 wheels target up to sm_90 (Hopper); cu128 was the
+              # first backend with Blackwell kernels, so only cu126 needs a cap.
+              # 900 = sm_90. An lte TIGHTENS under create.py raise-only rules, so
+              # it can never widen selection.
+              def cap(backend): if backend == "cu126" then " compute_cap.lte=900" else "" end;
               def req(vers): base_req
                 + (if (vers | any(. as $v | $has_audio | index($v)))
                    then " pytorch.d/30-torchaudio" else "" end);
@@ -364,6 +384,7 @@ jobs:
                       kind: "auto",
                       digest: .digests[$dpy],
                       floor: (.cuda_short | split(".")[0:2] | join(".")),
+                      cap: cap(.key),
                       venvs: "main",
                       require_tests: req([.torch]),
                       describe: (.torch + "-cuda-" + .cuda_short + "-" + $dpy) })
@@ -376,6 +397,7 @@ jobs:
                              kind: "mini",
                              digest: .value,
                              floor: $m.cuda_minor,
+                             cap: cap($m.backend),
                              venvs: "main",
                              require_tests: req([$m.torch]),
                              describe: ($m.torch + "-" + $m.backend + "-cuda-" + $m.cuda_minor + "-mini-" + .key) }) )
@@ -389,6 +411,7 @@ jobs:
                              kind: "multi",
                              digest: .value,
                              floor: $u.cuda_minor,
+                             cap: cap($u.primary_backend),
                              venvs: $u.venvs,
                              # A multi requires torchaudio if ANY of its venvs
                              # ships it — 30-torchaudio iterates every venv and
@@ -482,7 +505,7 @@ jobs:
       # the runner's own gate and this one agree — they fail differently, which
       # is the point, but they must not disagree about WHAT is required.
       require_tests: ${{ matrix.require_tests }}
-      set_filters: "cuda_max_good.gte=${{ matrix.floor }}"
+      set_filters: "cuda_max_good.gte=${{ matrix.floor }}${{ matrix.cap }}"
       retries: 2
       # Mini is 5-6 GB and the full config images 8-12 GB; no cell downloads a
       # model. 15 min is well clear of the slowest observed base cell and stops a

--- a/.github/workflows/promote-pytorch.yml
+++ b/.github/workflows/promote-pytorch.yml
@@ -43,6 +43,8 @@ jobs:
       multi-configs: ${{ steps.configs.outputs.multi-configs }}
       has-multi: ${{ steps.configs.outputs.has-multi }}
     steps:
+      # Needed for configs/pytorch.json — this job previously ran with no checkout.
+      - uses: actions/checkout@v4
       - name: Generate filtered config list
         id: configs
         run: |
@@ -50,49 +52,14 @@ jobs:
 
           # All pytorch versions and their configs
           # Format: torch_ver|key|cuda_short|python_versions
-          ALL_CONFIGS=(
-            # 2.6.0
-            "2.6.0|cu126|12.6.3|310 311 312"
-            # 2.7.1
-            "2.7.1|cu126|12.6.3|310 311 312"
-            "2.7.1|cu128|12.8.1|310 311 312 313"
-            # 2.8.0
-            "2.8.0|cu126|12.6.3|310 311 312"
-            "2.8.0|cu128|12.8.1|310 311 312 313"
-            "2.8.0|cu129|12.9.2|310 311 312 313"
-            # 2.9.1 (patch versions maintain ABI compat — 2.9.0 superseded)
-            "2.9.1|cu126|12.6.3|310 311 312"
-            "2.9.1|cu128|12.8.1|310 311 312 313 314"
-            "2.9.1|cu130|13.0.3|310 311 312 313 314"
-            # 2.10.0
-            "2.10.0|cu126|12.6.3|310 311 312"
-            "2.10.0|cu128|12.8.1|310 311 312 313 314"
-            "2.10.0|cu130|13.0.3|310 311 312 313 314"
-            # 2.11.0
-            "2.11.0|cu126|12.6.3|310 311 312"
-            "2.11.0|cu128|12.8.1|310 311 312 313 314"
-            "2.11.0|cu130|13.0.3|310 311 312 313 314"
-            # 2.12.0 — cu126 / cu130 (cu132 deferred; uv has no --torch-backend
-            # value for it yet). Must mirror build-pytorch.yml.
-            "2.12.0|cu126|12.6.3|310 311 312 313 314"
-            "2.12.0|cu130|13.0.3|310 311 312 313 314"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_CONFIGS < <(jq -r '.configs[] | "\(.torch)|\(.key)|\(.cuda_ver | split("-")[0])|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_CONFIGS"; exit 1; }
 
           # Mini format: torch_ver|key|torch_backend|cuda_minor|python_versions
-          ALL_MINI_CONFIGS=(
-            "2.6.0|cu126-mini|cu126|12.9|310 311 312 313"
-            "2.7.1|cu128-mini|cu128|12.9|310 311 312 313"
-            "2.8.0|cu128-mini|cu128|12.9|310 311 312 313"
-            "2.9.1|cu128-mini|cu128|12.9|310 311 312 313 314"
-            "2.9.1|cu130-mini|cu130|13.2|310 311 312 313 314"
-            "2.10.0|cu128-mini|cu128|12.9|310 311 312 313 314"
-            "2.10.0|cu130-mini|cu130|13.2|310 311 312 313 314"
-            "2.11.0|cu128-mini|cu128|12.9|310 311 312 313 314"
-            "2.11.0|cu130-mini|cu130|13.2|310 311 312 313 314"
-            # 2.12.0 — CUDA-12 mini rides cu126 (no cu128); CUDA-13 mini keeps cu130.
-            "2.12.0|cu126-mini|cu126|12.9|310 311 312 313 314"
-            "2.12.0|cu130-mini|cu130|13.2|310 311 312 313 314"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_MINI_CONFIGS < <(jq -r '.mini[] | "\(.torch)|\(.key)|\(.backend)|\(.mini_base_tag | ltrimstr("cuda-") | rtrimstr("-mini"))|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_MINI_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_MINI_CONFIGS"; exit 1; }
 
           CONFIGS_JSON="[]"
           ALL_CONFIGS_JSON="[]"
@@ -122,9 +89,9 @@ jobs:
           #   ${NS}/pytorch:${key}-py${py}-${date}
           # plus a default-python dated alias and a no-date latest alias.
           # Format: key|primary_torch|primary_backend|cuda_minor|python_versions
-          ALL_MULTI_CONFIGS=(
-            "multi-210-291-271|2.10.0|cu128|12.9|312"
-          )
+          # Config table lives in configs/pytorch.json (ADR 0019 pattern) — it was inline in three workflows, so a version bump had to land three times and a miss was silent. jq preserves array order, which the auto-tag dance depends on.
+          mapfile -t ALL_MULTI_CONFIGS < <(jq -r '.multi[] | "\(.key)|\(.primary_torch)|\(.primary_backend)|\(.cuda_minor)|\(.python_versions | join(" "))"' "$GITHUB_WORKSPACE/configs/pytorch.json")
+          [ "${#ALL_MULTI_CONFIGS[@]}" -gt 0 ] || { echo "::error::configs/pytorch.json yielded no ALL_MULTI_CONFIGS"; exit 1; }
 
           MINI_CONFIGS_JSON="[]"
 

--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -541,6 +541,23 @@
         "313",
         "314"
       ]
+    },
+    {
+      "torch": "2.13.0",
+      "key": "cu132-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu132",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
     }
   ],
   "multi": [
@@ -554,6 +571,41 @@
         "torch-2.7.1"
       ],
       "cuda_minor": "12.9",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "312"
+      ]
+    },
+    {
+      "key": "multi-2130-2121-2110",
+      "primary_torch": "2.13.0",
+      "primary_backend": "cu130",
+      "venvs": [
+        "main",
+        "torch-2.12.1",
+        "torch-2.11.0"
+      ],
+      "cuda_minor": "13.2",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "312"
+      ]
+    },
+    {
+      "key": "multi-2130-2121",
+      "primary_torch": "2.13.0",
+      "primary_backend": "cu132",
+      "venvs": [
+        "main",
+        "torch-2.12.1"
+      ],
+      "cuda_minor": "13.2",
       "arches": [
         "linux/amd64",
         "linux/arm64"

--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -268,6 +268,125 @@
         "313",
         "314"
       ]
+    },
+    {
+      "torch": "2.12.1",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.1",
+      "key": "cu129",
+      "cuda_ver": "12.9.2-cudnn-devel",
+      "backend": "cu129",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.1",
+      "key": "cu130",
+      "cuda_ver": "13.0.3-cudnn-devel",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.13.0",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.13.0",
+      "key": "cu129",
+      "cuda_ver": "12.9.2-cudnn-devel",
+      "backend": "cu129",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.13.0",
+      "key": "cu130",
+      "cuda_ver": "13.0.3-cudnn-devel",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.13.0",
+      "key": "cu132",
+      "cuda_ver": "13.2.1-cudnn-devel",
+      "backend": "cu132",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
     }
   ],
   "mini": [
@@ -439,6 +558,74 @@
     },
     {
       "torch": "2.12.0",
+      "key": "cu130-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.1",
+      "key": "cu126-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.1",
+      "key": "cu130-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.13.0",
+      "key": "cu126-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.13.0",
       "key": "cu130-mini",
       "mini_base_tag": "cuda-13.2-mini",
       "backend": "cu130",

--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -460,6 +460,11 @@
       "key": "multi-210-291-271",
       "primary_torch": "2.10.0",
       "primary_backend": "cu128",
+      "venvs": [
+        "main",
+        "torch-2.9.1",
+        "torch-2.7.1"
+      ],
       "cuda_minor": "12.9",
       "arches": [
         "linux/amd64",

--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -1,0 +1,473 @@
+{
+  "_comment": "Single source of truth for the pytorch image matrices (ADR 0019 pattern). Previously duplicated verbatim across build/extend/promote-pytorch.yml, so a version bump had to land in three places and a miss was silent. Array ORDER matters: the auto-tag dance depends on it, and jq preserves it. cuda_short (used by extend/promote) is derived as cuda_ver up to the first '-'.",
+  "default_python": "312",
+  "configs": [
+    {
+      "torch": "2.6.0",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312"
+      ]
+    },
+    {
+      "torch": "2.7.1",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312"
+      ]
+    },
+    {
+      "torch": "2.7.1",
+      "key": "cu128",
+      "cuda_ver": "12.8.1-cudnn-devel",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313"
+      ]
+    },
+    {
+      "torch": "2.8.0",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312"
+      ]
+    },
+    {
+      "torch": "2.8.0",
+      "key": "cu128",
+      "cuda_ver": "12.8.1-cudnn-devel",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313"
+      ]
+    },
+    {
+      "torch": "2.8.0",
+      "key": "cu129",
+      "cuda_ver": "12.9.2-cudnn-devel",
+      "backend": "cu129",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313"
+      ]
+    },
+    {
+      "torch": "2.9.1",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312"
+      ]
+    },
+    {
+      "torch": "2.9.1",
+      "key": "cu128",
+      "cuda_ver": "12.8.1-cudnn-devel",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.9.1",
+      "key": "cu130",
+      "cuda_ver": "13.0.3-cudnn-devel",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.10.0",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312"
+      ]
+    },
+    {
+      "torch": "2.10.0",
+      "key": "cu128",
+      "cuda_ver": "12.8.1-cudnn-devel",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.10.0",
+      "key": "cu130",
+      "cuda_ver": "13.0.3-cudnn-devel",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.11.0",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312"
+      ]
+    },
+    {
+      "torch": "2.11.0",
+      "key": "cu128",
+      "cuda_ver": "12.8.1-cudnn-devel",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.11.0",
+      "key": "cu130",
+      "cuda_ver": "13.0.3-cudnn-devel",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.0",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.0",
+      "key": "cu130",
+      "cuda_ver": "13.0.3-cudnn-devel",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    }
+  ],
+  "mini": [
+    {
+      "torch": "2.6.0",
+      "key": "cu126-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313"
+      ]
+    },
+    {
+      "torch": "2.7.1",
+      "key": "cu128-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313"
+      ]
+    },
+    {
+      "torch": "2.8.0",
+      "key": "cu128-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313"
+      ]
+    },
+    {
+      "torch": "2.9.1",
+      "key": "cu128-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.9.1",
+      "key": "cu130-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.10.0",
+      "key": "cu128-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.10.0",
+      "key": "cu130-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.11.0",
+      "key": "cu128-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu128",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.11.0",
+      "key": "cu130-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.0",
+      "key": "cu126-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.12.0",
+      "key": "cu130-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    }
+  ],
+  "multi": [
+    {
+      "key": "multi-210-291-271",
+      "primary_torch": "2.10.0",
+      "primary_backend": "cu128",
+      "cuda_minor": "12.9",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "312"
+      ]
+    }
+  ]
+}

--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -62,21 +62,6 @@
       ]
     },
     {
-      "torch": "2.8.0",
-      "key": "cu129",
-      "cuda_ver": "12.9.2-cudnn-devel",
-      "backend": "cu129",
-      "arches": [
-        "linux/amd64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313"
-      ]
-    },
-    {
       "torch": "2.9.1",
       "key": "cu126",
       "cuda_ver": "12.6.3-cudnn-devel",
@@ -225,23 +210,6 @@
       "key": "cu126",
       "cuda_ver": "12.6.3-cudnn-devel",
       "backend": "cu126",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313",
-        "314"
-      ]
-    },
-    {
-      "torch": "2.12.1",
-      "key": "cu129",
-      "cuda_ver": "12.9.2-cudnn-devel",
-      "backend": "cu129",
       "arches": [
         "linux/amd64",
         "linux/arm64"
@@ -276,23 +244,6 @@
       "key": "cu126",
       "cuda_ver": "12.6.3-cudnn-devel",
       "backend": "cu126",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313",
-        "314"
-      ]
-    },
-    {
-      "torch": "2.13.0",
-      "key": "cu129",
-      "cuda_ver": "12.9.2-cudnn-devel",
-      "backend": "cu129",
       "arches": [
         "linux/amd64",
         "linux/arm64"

--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -3,21 +3,6 @@
   "default_python": "312",
   "configs": [
     {
-      "torch": "2.6.0",
-      "key": "cu126",
-      "cuda_ver": "12.6.3-cudnn-devel",
-      "backend": "cu126",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312"
-      ]
-    },
-    {
       "torch": "2.7.1",
       "key": "cu126",
       "cuda_ver": "12.6.3-cudnn-devel",
@@ -220,40 +205,6 @@
     },
     {
       "torch": "2.11.0",
-      "key": "cu130",
-      "cuda_ver": "13.0.3-cudnn-devel",
-      "backend": "cu130",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313",
-        "314"
-      ]
-    },
-    {
-      "torch": "2.12.0",
-      "key": "cu126",
-      "cuda_ver": "12.6.3-cudnn-devel",
-      "backend": "cu126",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313",
-        "314"
-      ]
-    },
-    {
-      "torch": "2.12.0",
       "key": "cu130",
       "cuda_ver": "13.0.3-cudnn-devel",
       "backend": "cu130",
@@ -391,22 +342,6 @@
   ],
   "mini": [
     {
-      "torch": "2.6.0",
-      "key": "cu126-mini",
-      "mini_base_tag": "cuda-12.9-mini",
-      "backend": "cu126",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313"
-      ]
-    },
-    {
       "torch": "2.7.1",
       "key": "cu128-mini",
       "mini_base_tag": "cuda-12.9-mini",
@@ -524,40 +459,6 @@
     },
     {
       "torch": "2.11.0",
-      "key": "cu130-mini",
-      "mini_base_tag": "cuda-13.2-mini",
-      "backend": "cu130",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313",
-        "314"
-      ]
-    },
-    {
-      "torch": "2.12.0",
-      "key": "cu126-mini",
-      "mini_base_tag": "cuda-12.9-mini",
-      "backend": "cu126",
-      "arches": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
-      "python_versions": [
-        "310",
-        "311",
-        "312",
-        "313",
-        "314"
-      ]
-    },
-    {
-      "torch": "2.12.0",
       "key": "cu130-mini",
       "mini_base_tag": "cuda-13.2-mini",
       "backend": "cu130",

--- a/derivatives/pytorch/Dockerfile.multi-torch
+++ b/derivatives/pytorch/Dockerfile.multi-torch
@@ -1,27 +1,53 @@
 # Extend a PyTorch image with supplementary torch venvs.
-# Each additional version gets its own layer and venv at /venv/torch-X.Y.Z
+# Each additional version gets its own venv at /venv/torch-X.Y.Z
 # The base image's /venv/main is left untouched.
 #
 # Usage:
 #   docker buildx build -f Dockerfile.multi-torch \
-#     --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15 \
-#     --build-arg PYTORCH_BACKEND=cu128 \
+#     --build-arg PYTORCH_BASE=vastai/pytorch:2.13.0-cu130-cuda-13.2-mini-py312-2026-08-11 \
+#     --build-arg PYTORCH_BACKEND=cu130 \
+#     --build-arg EXTRA_TORCH_VERSIONS="2.12.1 2.11.0" \
 #     -t my-multi-torch .
+#
+# EXTRA_TORCH_VERSIONS was hardcoded here as two `RUN install-torch-venv.sh`
+# lines until 2026-08-11. That made exactly one venv set possible, so a second
+# multi variant could not be expressed at all — the config table could describe
+# it, the build could not produce it. The list now comes from the table's
+# `multi[].venvs` (minus `main`, which is the base's own venv), so variants are
+# a data change rather than a Dockerfile edit.
+#
+# CONSTRAINT worth knowing before adding a variant: every version here is
+# installed with the SAME ${PYTORCH_BACKEND} as the base, because that is what
+# install-torch-venv.sh is given. So every version in a multi must exist on that
+# one backend — which is why the cu128 variant cannot go past torch 2.11.0
+# (no cu128 wheels beyond it) and why cu126 is not used for multis at all
+# (no Blackwell kernels before CUDA 12.8, so the image would be unusable on
+# 50-series and B-series cards).
 
 ARG PYTORCH_BASE
 FROM ${PYTORCH_BASE}
 
 ARG PYTORCH_BACKEND
 ARG TARGETARCH
+ARG EXTRA_TORCH_VERSIONS
 
 COPY ./torch-companions.json /tmp/torch-companions.json
 COPY ./install-torch-venv.sh /tmp/install-torch-venv.sh
 
-# Each version is a separate layer for better caching
-RUN /tmp/install-torch-venv.sh 2.9.1 "${PYTORCH_BACKEND}" "${TARGETARCH}"
-RUN /tmp/install-torch-venv.sh 2.7.1 "${PYTORCH_BACKEND}" "${TARGETARCH}"
-
-RUN rm -f /tmp/install-torch-venv.sh /tmp/torch-companions.json
+# One RUN rather than one per version: the version list is now a build arg, so a
+# per-version layer would invalidate on any list change anyway, and this keeps
+# the Dockerfile independent of how many versions a variant carries.
+#
+# Fails closed on an empty list: a multi image with no supplementary venv is not
+# a multi image, and silently producing one would ship an artifact that passes
+# every discovery-based test while being wrong (the venv-manifest test exists
+# for exactly this, but the build should not create the case in the first place).
+RUN set -euo pipefail && \
+    [[ -n "${EXTRA_TORCH_VERSIONS}" ]] || { echo "EXTRA_TORCH_VERSIONS is empty — a multi image needs at least one supplementary venv" && exit 1; } && \
+    for _v in ${EXTRA_TORCH_VERSIONS}; do \
+        /tmp/install-torch-venv.sh "${_v}" "${PYTORCH_BACKEND}" "${TARGETARCH}"; \
+    done && \
+    rm -f /tmp/install-torch-venv.sh /tmp/torch-companions.json
 
 # Refresh environment hash
 RUN env-hash > /.env_hash

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/05-venv-manifest.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/05-venv-manifest.sh
@@ -41,7 +41,33 @@ for want in "${_expected[@]}"; do
     for got in "${_found[@]}"; do
         [[ "$got" == "$want" ]] && _hit=true && break
     done
-    $_hit || fail_later "venv-missing" "declared torch venv '${want}' is absent or has no working torch"
+    $_hit || { fail_later "venv-missing" "declared torch venv '${want}' is absent or has no working torch"; continue; }
+
+    # THE NAME IS A CLAIM — check it. A venv called torch-2.12.1 that contains
+    # torch 2.11.0 satisfies every other test in pytorch.d: the presence check
+    # above passes, and 10/20/30/40 all iterate whatever they find and validate
+    # it on its own terms, never against what it is supposed to be. That is the
+    # same shape as the absence hole this file was written to close, one level
+    # in — a claim nothing verifies.
+    #
+    # 10-torch-core asserts the version for `main` only (against PYTORCH_VERSION),
+    # so the supplementary venvs are exactly the ones with no version check at
+    # all. install-torch-venv.sh does verify at build time, but the point of a
+    # QA gate is to test the artifact rather than trust the build that made it.
+    #
+    # `main` is skipped here deliberately: its name encodes no version, and
+    # 10-torch-core already checks it against the PYTORCH_VERSION env.
+    [[ "$want" == "main" ]] && continue
+    _want_ver="${want#torch-}"
+    [[ "$_want_ver" == "$want" ]] && continue   # not a torch-X.Y.Z name; nothing claimed
+    _actual=$("/venv/${want}/bin/python3" -c "import torch; print(torch.__version__)" 2>/dev/null || echo "")
+    if [[ -z "$_actual" ]]; then
+        fail_later "venv-version" "could not read torch version from venv '${want}'"
+    elif [[ "$_actual" != "${_want_ver}"* ]]; then
+        fail_later "venv-version" "venv '${want}' contains torch ${_actual}, not ${_want_ver}"
+    else
+        echo "  ${want}: torch ${_actual} matches the name"
+    fi
 done
 
 # Extra venvs are reported but do NOT fail. An image gaining a venv is a change

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/05-venv-manifest.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/05-venv-manifest.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Test: the image ships exactly the torch venvs it is supposed to ship.
+#
+# Every other test in pytorch.d DISCOVERS venvs by globbing /venv/*/ and then
+# validates whatever it finds. That is the right shape for those tests and the
+# wrong shape for this question, because a discovery-based test cannot detect
+# ABSENCE: a `multi` image that shipped one of its three torch venvs would find
+# one venv, validate it perfectly, and report green. Two thirds of the artifact
+# would be missing and every test would pass (ADR 0021 decision 6).
+#
+# So the expected set has to come from OUTSIDE the image. The QA template
+# declares it; this test compares. It costs no GPU time and no extra cell —
+# it is the cheapest real coverage in the whole gate.
+#
+# Unset => skip. Customer instances and non-gated runs have nothing to compare
+# against, and inventing an expectation there would fail images that are fine.
+source "$(dirname "$0")/../lib.sh"
+
+[[ -n "${EXPECTED_TORCH_VENVS:-}" ]] || \
+    test_skip "EXPECTED_TORCH_VENVS not declared (not a gated run)"
+
+# Accept comma- and/or whitespace-separated names, matching the convention
+# INSTANCE_TEST_REQUIRE_PASS uses — these are hand-written in templates.
+read -ra _expected <<< "${EXPECTED_TORCH_VENVS//,/ }"
+
+_found=()
+for venv_dir in /venv/*/; do
+    [[ -f "${venv_dir}bin/activate" ]] || continue
+    if "${venv_dir}bin/python3" -c "import torch" 2>/dev/null; then
+        _found+=("$(basename "$venv_dir")")
+    fi
+done
+
+echo "  expected: ${_expected[*]}"
+echo "  found:    ${_found[*]:-<none>}"
+
+# Missing is the defect this exists for.
+for want in "${_expected[@]}"; do
+    [[ -z "$want" ]] && continue
+    _hit=false
+    for got in "${_found[@]}"; do
+        [[ "$got" == "$want" ]] && _hit=true && break
+    done
+    $_hit || fail_later "venv-missing" "declared torch venv '${want}' is absent or has no working torch"
+done
+
+# Extra venvs are reported but do NOT fail. An image gaining a venv is a change
+# worth seeing in the log, but it is additive and breaks nothing — failing on it
+# would make every deliberate addition look like a defect and train people to
+# ignore this test.
+for got in "${_found[@]}"; do
+    _hit=false
+    for want in "${_expected[@]}"; do
+        [[ "$got" == "$want" ]] && _hit=true && break
+    done
+    $_hit || echo "  NOTE: undeclared torch venv '${got}' present (not a failure)"
+done
+
+report_failures
+test_pass "all ${#_expected[@]} declared torch venv(s) present with a working torch"

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/10-torch-core.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/10-torch-core.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Test: PyTorch core — import, CUDA availability, tensor operations on GPU.
 # Iterates over all venvs in /venv/ that have torch installed.
+# TEST_TIMEOUT=1200
+# Sized for the VENV COUNT, not for one venv. This test loops over every
+# torch venv in /venv/; the `multi` image ships three, so base's single-venv
+# timing does not transfer. Read by runner.sh (per-test header beats the
+# INSTANCE_TEST_DEFAULT_TIMEOUT the workflow pushes). Under ADR 0020 a
+# timeout is inconclusive-and-retried rather than a block, so an under-sized
+# value costs real money in re-rentals instead of producing a false red.
 source "$(dirname "$0")/../lib.sh"
 
 # ── Discover torch venvs ──────────────────────────────────────────────

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/10-torch-core.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/10-torch-core.sh
@@ -154,92 +154,18 @@ for venv_dir in "${TORCH_VENVS[@]}"; do
     test_venv "$venv_dir"
 done
 
-# ── Multi-GPU communication (NCCL) — once, not per-venv ───────────────
-
-echo ""
-if has_gpu && [[ "$_cuda_available" == "True" ]] && [[ "$_device_count" -gt 1 ]]; then
-    # Use the first torch venv for the NCCL test.
-    # mp.spawn needs a real script file — it pickles the worker function and the
-    # spawned subprocess re-imports __main__ to unpickle it. With python3 -c
-    # there is no __main__ file, so unpickling fails.
-    NCCL_PY="${TORCH_VENVS[0]}bin/python3"
-    NCCL_SCRIPT="/tmp/test_nccl.py"
-    cat > "$NCCL_SCRIPT" <<'NCCL_EOF'
-import torch
-import torch.distributed as dist
-import torch.multiprocessing as mp
-import sys, os
-
-def _worker(rank, world_size, results_path):
-    os.environ['MASTER_ADDR'] = '127.0.0.1'
-    os.environ['MASTER_PORT'] = '29500'
-    try:
-        dist.init_process_group('nccl', rank=rank, world_size=world_size)
-        torch.cuda.set_device(rank)
-
-        # all_reduce: each GPU contributes rank+1, result should be sum of 1..N
-        t = torch.tensor([rank + 1], dtype=torch.float32, device=f'cuda:{rank}')
-        dist.all_reduce(t, op=dist.ReduceOp.SUM)
-        expected = world_size * (world_size + 1) / 2
-        assert t.item() == expected, f'rank {rank}: all_reduce expected {expected}, got {t.item()}'
-
-        # broadcast: rank 0 sends, all others receive
-        b = torch.tensor([42.0], device=f'cuda:{rank}') if rank == 0 else torch.zeros(1, device=f'cuda:{rank}')
-        dist.broadcast(b, src=0)
-        assert b.item() == 42.0, f'rank {rank}: broadcast expected 42, got {b.item()}'
-
-        # all_gather: collect rank IDs from every GPU
-        gather_list = [torch.zeros(1, device=f'cuda:{rank}') for _ in range(world_size)]
-        dist.all_gather(gather_list, torch.tensor([float(rank)], device=f'cuda:{rank}'))
-        gathered = sorted(int(g.item()) for g in gather_list)
-        assert gathered == list(range(world_size)), f'rank {rank}: all_gather got {gathered}'
-
-        dist.destroy_process_group()
-
-        with open(f'{results_path}.{rank}', 'w') as f:
-            f.write('ok')
-    except Exception as e:
-        with open(f'{results_path}.{rank}', 'w') as f:
-            f.write(str(e))
-
-if __name__ == '__main__':
-    world = torch.cuda.device_count()
-    results_path = '/tmp/nccl_test_result'
-
-    for i in range(world):
-        try:
-            os.remove(f'{results_path}.{i}')
-        except FileNotFoundError:
-            pass
-
-    mp.spawn(_worker, args=(world, results_path), nprocs=world, join=True)
-
-    failures = []
-    for i in range(world):
-        try:
-            with open(f'{results_path}.{i}') as f:
-                result = f.read().strip()
-            if result != 'ok':
-                failures.append(f'rank {i}: {result}')
-        except FileNotFoundError:
-            failures.append(f'rank {i}: no result file')
-
-    if failures:
-        for f in failures:
-            print(f'  FAIL: {f}')
-        sys.exit(1)
-
-    print(f'  NCCL all_reduce: ok ({world} GPUs)')
-    print(f'  NCCL broadcast: ok')
-    print(f'  NCCL all_gather: ok')
-NCCL_EOF
-    "$NCCL_PY" "$NCCL_SCRIPT" 2>&1 || fail_later "nccl" "multi-GPU NCCL communication failed"
-    rm -f "$NCCL_SCRIPT"
-elif has_gpu && [[ "$_cuda_available" == "True" ]]; then
-    echo "  skip: multi-GPU comms (single GPU)"
-else
-    echo "  skip: multi-GPU comms (no CUDA)"
-fi
+# ── Multi-GPU communication (NCCL) ────────────────────────────────────
+#
+# MOVED OUT (ADR 0021 decision 5). The collectives harness used to live here,
+# behind `device_count > 1`, falling through on a single GPU to a bare
+# `echo "  skip: multi-GPU comms (single GPU)"` — which left THIS test passing
+# either way. The required-pass gate matches on test states and cannot see a
+# branch inside a passing test, so the collectives were unreachable by any gate.
+#
+# They are now two sibling tests that can each be named and can each fail:
+#   40-nccl-init.sh        NCCL usable from torch.distributed (world_size=1) —
+#                          the image-owned surface; runs on every GPU box.
+#   41-nccl-collectives.sh the multi-GPU matrix; test_skips below 2 GPUs.
 
 report_failures
 test_pass "torch verified across ${#TORCH_VENVS[@]} venv(s) (CUDA: ${_first_cuda_version}, devices: ${_device_count})"

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/20-torchvision.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/20-torchvision.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Test: torchvision — import, transforms, model inference, image I/O, ops.
 # Runs against all venvs in /venv/ that have torch installed.
+# TEST_TIMEOUT=1200
+# Sized for the VENV COUNT, not for one venv. This test loops over every
+# torch venv in /venv/; the `multi` image ships three, so base's single-venv
+# timing does not transfer. Read by runner.sh (per-test header beats the
+# INSTANCE_TEST_DEFAULT_TIMEOUT the workflow pushes). Under ADR 0020 a
+# timeout is inconclusive-and-retried rather than a block, so an under-sized
+# value costs real money in re-rentals instead of producing a false red.
 source "$(dirname "$0")/../lib.sh"
 
 # ── Discover torch venvs ──────────────────────────────────────────────

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/30-torchaudio.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/30-torchaudio.sh
@@ -6,6 +6,13 @@
 #   - torchaudio 2.6–2.8 (torch 2.6–2.8): FFmpeg-based, has list_audio_backends/ffmpeg_utils
 #   - torchaudio 2.9+ (torch 2.9+): TorchCodec-based, StreamWriter/StreamReader and
 #     ffmpeg_utils removed. torchaudio.save/load still works (delegates to TorchCodec).
+# TEST_TIMEOUT=1200
+# Sized for the VENV COUNT, not for one venv. This test loops over every
+# torch venv in /venv/; the `multi` image ships three, so base's single-venv
+# timing does not transfer. Read by runner.sh (per-test header beats the
+# INSTANCE_TEST_DEFAULT_TIMEOUT the workflow pushes). Under ADR 0020 a
+# timeout is inconclusive-and-retried rather than a block, so an under-sized
+# value costs real money in re-rentals instead of producing a false red.
 source "$(dirname "$0")/../lib.sh"
 
 # ── Discover torch venvs ──────────────────────────────────────────────

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/40-nccl-init.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/40-nccl-init.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Test: NCCL is present, loadable and usable by torch.distributed — on ONE GPU.
+#
+# This is the IMAGE-owned half of the collectives surface, split out from the
+# multi-GPU matrix in 41-nccl-collectives.sh so that it can run — and therefore
+# be REQUIRED — on every cell (ADR 0021 decision 5).
+#
+# The distinction is the whole point. `init_process_group('nccl', world_size=1)`
+# exercises everything we ship and control:
+#   * libnccl present on the loader path and ABI-matched to the torch wheel
+#   * ncclCommInitRank succeeds against the driver actually on the box
+#   * torch's distributed extension was built with NCCL support at all
+# That is what breaks when a torch/CUDA-backend pairing is wrong — an image
+# defect, ours to fix, and one that a 2-GPU rental is not needed to find.
+#
+# What genuinely needs a second GPU is the TRANSPORT (shared memory, P2P,
+# NVLink), which is a property of the HOST. Per ADR 0020 a QA cell may not block
+# a promotion on that, so it lives in its own file which skips below 2 GPUs.
+#
+# Before this split there was no such separation: the collectives block sat
+# inside 10-torch-core.sh behind `device_count > 1` and fell through to a bare
+# `echo "skip: ..."` on one GPU, so the enclosing test passed either way. Renting
+# two GPUs would have produced a green cell that certified nothing.
+source "$(dirname "$0")/../lib.sh"
+
+has_gpu || test_skip "no GPU detected"
+
+# ── Discover torch venvs ──────────────────────────────────────────────
+#
+# Every venv is checked, not just the first. The multi image ships three, and a
+# per-venv NCCL defect (one venv's wheel built against a different CUDA) is
+# exactly the class this catches — testing only TORCH_VENVS[0] would leave the
+# other two unexercised while reporting the image green.
+
+TORCH_VENVS=()
+for venv_dir in /venv/*/; do
+    [[ -f "${venv_dir}bin/activate" ]] || continue
+    if "${venv_dir}bin/python3" -c "import torch" 2>/dev/null; then
+        TORCH_VENVS+=("$venv_dir")
+    fi
+done
+
+[[ ${#TORCH_VENVS[@]} -gt 0 ]] || test_skip "no venvs with torch found in /venv/"
+
+# A free ephemeral port per run. The old harness hard-coded 29500, so a retry
+# after a hung rank collided with the corpse of the previous attempt and hung to
+# the per-test timeout — converting host flake into a second failure (ADR 0020).
+MASTER_PORT=$(python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+")
+echo "  rendezvous port: ${MASTER_PORT}"
+
+for venv_dir in "${TORCH_VENVS[@]}"; do
+    venv_name=$(basename "$venv_dir")
+    echo ""
+    echo "  [${venv_name}] single-rank NCCL init"
+    # world_size=1 needs no second device and no transport, so this is
+    # deterministic on any single-GPU box.
+    "${venv_dir}bin/python3" - "$MASTER_PORT" <<'NCCL_INIT' 2>&1 || \
+        fail_later "nccl-init" "[${venv_name}] NCCL unusable from torch.distributed"
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+os.environ["MASTER_PORT"] = sys.argv[1]
+os.environ.setdefault("RANK", "0")
+os.environ.setdefault("WORLD_SIZE", "1")
+
+if not torch.cuda.is_available():
+    print("  FAIL: torch reports no CUDA device", flush=True)
+    sys.exit(1)
+
+# Distinguish "torch was built without NCCL" from "NCCL is broken at runtime".
+# The first is a build-time packaging defect and the message should say so.
+if not dist.is_nccl_available():
+    print("  FAIL: torch.distributed reports NCCL unavailable "
+          "(wheel built without NCCL support)", flush=True)
+    sys.exit(1)
+
+torch.cuda.set_device(0)
+dist.init_process_group("nccl", rank=0, world_size=1)
+try:
+    # A real collective, not just init: init can succeed while the communicator
+    # is unusable. On world_size=1 this is a no-op mathematically, but it still
+    # drives ncclAllReduce through the same code path.
+    t = torch.tensor([7.0], device="cuda:0")
+    dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    if t.item() != 7.0:
+        print(f"  FAIL: single-rank all_reduce returned {t.item()}, expected 7.0", flush=True)
+        sys.exit(1)
+    print(f"  NCCL {'.'.join(str(v) for v in torch.cuda.nccl.version())}: "
+          f"init + all_reduce ok", flush=True)
+finally:
+    dist.destroy_process_group()
+NCCL_INIT
+done
+
+report_failures
+test_pass "NCCL usable from torch.distributed across ${#TORCH_VENVS[@]} venv(s)"

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/40-nccl-init.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/40-nccl-init.sh
@@ -21,6 +21,13 @@
 # inside 10-torch-core.sh behind `device_count > 1` and fell through to a bare
 # `echo "skip: ..."` on one GPU, so the enclosing test passed either way. Renting
 # two GPUs would have produced a green cell that certified nothing.
+# TEST_TIMEOUT=1200
+# Sized for the VENV COUNT, not for one venv. This test loops over every
+# torch venv in /venv/; the `multi` image ships three, so base's single-venv
+# timing does not transfer. Read by runner.sh (per-test header beats the
+# INSTANCE_TEST_DEFAULT_TIMEOUT the workflow pushes). Under ADR 0020 a
+# timeout is inconclusive-and-retried rather than a block, so an under-sized
+# value costs real money in re-rentals instead of producing a false red.
 source "$(dirname "$0")/../lib.sh"
 
 has_gpu || test_skip "no GPU detected"

--- a/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/41-nccl-collectives.sh
+++ b/derivatives/pytorch/ROOT/opt/instance-tools/tests/pytorch.d/41-nccl-collectives.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Test: multi-GPU NCCL collectives — all_reduce, broadcast, all_gather.
+#
+# Moved here verbatim in behaviour from 10-torch-core.sh, where it lived behind
+# `device_count > 1` and fell through on a single GPU to
+#
+#     echo "  skip: multi-GPU comms (single GPU)"
+#
+# — a bare echo, so the ENCLOSING test still passed. That made the collectives
+# matrix invisible to INSTANCE_TEST_REQUIRE_PASS, which matches on test states
+# and cannot see a branch inside a passing test. Renting a 2-GPU box bought a
+# green cell that certified nothing.
+#
+# As its own file it does the honest thing: `test_skip` (exit 77) below two
+# GPUs, which is a state the runner and qa_verdict.py can both see. That makes
+# it NAMEABLE in a multi-GPU cell's required list — the prerequisite for ever
+# gating collectives, which ADR 0021 defers rather than adopts.
+#
+# FAULT DOMAIN (ADR 0020): what this exercises is the TRANSPORT — shared memory,
+# P2P, NVLink — which belongs to the host, not the image. On consumer cards with
+# no NVLink, NCCL falls back to the /dev/shm path, and Vast exposes no control
+# over shm size. So do NOT add this to a gating required list without first
+# measuring shm on the offer tier the selector actually picks; a failure here is
+# as likely to be the box as the image, and blocking a promotion on it would
+# charge the wrong party.
+source "$(dirname "$0")/../lib.sh"
+
+has_gpu || test_skip "no GPU detected"
+
+TORCH_VENVS=()
+for venv_dir in /venv/*/; do
+    [[ -f "${venv_dir}bin/activate" ]] || continue
+    if "${venv_dir}bin/python3" -c "import torch" 2>/dev/null; then
+        TORCH_VENVS+=("$venv_dir")
+    fi
+done
+
+[[ ${#TORCH_VENVS[@]} -gt 0 ]] || test_skip "no venvs with torch found in /venv/"
+
+_device_count=$("${TORCH_VENVS[0]}bin/python3" -c \
+    "import torch; print(torch.cuda.device_count())" 2>/dev/null || echo 0)
+
+# THE line that makes this test honest. `test_skip` exits 77, which the runner
+# records as `skipped` and the required-pass gate treats as not-passed — so a
+# cell that names this test and lands on one GPU FAILS rather than quietly
+# reporting success. The old `echo` could not do that.
+[[ "$_device_count" -gt 1 ]] || \
+    test_skip "multi-GPU collectives need >= 2 GPUs (found ${_device_count})"
+
+# Select the venv by NAME where possible rather than relying on glob order:
+# /venv/* sorts `main` first today, which is correct by accident of the layout
+# in Dockerfile.multi-torch and would silently change the venv under test the
+# day one is named `alt` or `base`.
+NCCL_VENV="${TORCH_VENVS[0]}"
+for venv_dir in "${TORCH_VENVS[@]}"; do
+    [[ "$(basename "$venv_dir")" == "main" ]] && NCCL_VENV="$venv_dir" && break
+done
+echo "  venv under test: $(basename "$NCCL_VENV")"
+echo "  NOTE: collectives are exercised in ONE venv; a multi image's other"
+echo "        torch venvs are covered by 40-nccl-init.sh, not by this matrix."
+
+# A free ephemeral port. Hard-coding 29500 meant a retry after a hung rank
+# collided with the previous attempt and hung to the per-test timeout.
+MASTER_PORT=$(python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+")
+
+# mp.spawn needs a real script file — it pickles the worker function and the
+# spawned subprocess re-imports __main__ to unpickle it. With `python3 -c` there
+# is no __main__ file, so unpickling fails.
+NCCL_SCRIPT="/tmp/test_nccl_collectives.py"
+cat > "$NCCL_SCRIPT" <<'NCCL_EOF'
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _worker(rank, world_size, results_path, port):
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = str(port)
+    try:
+        dist.init_process_group('nccl', rank=rank, world_size=world_size)
+        torch.cuda.set_device(rank)
+
+        # all_reduce: each GPU contributes rank+1, result should be sum of 1..N
+        t = torch.tensor([rank + 1], dtype=torch.float32, device=f'cuda:{rank}')
+        dist.all_reduce(t, op=dist.ReduceOp.SUM)
+        expected = world_size * (world_size + 1) / 2
+        assert t.item() == expected, f'rank {rank}: all_reduce expected {expected}, got {t.item()}'
+
+        # broadcast: rank 0 sends, all others receive
+        b = torch.tensor([42.0], device=f'cuda:{rank}') if rank == 0 else torch.zeros(1, device=f'cuda:{rank}')
+        dist.broadcast(b, src=0)
+        assert b.item() == 42.0, f'rank {rank}: broadcast expected 42, got {b.item()}'
+
+        # all_gather: collect rank IDs from every GPU
+        gather_list = [torch.zeros(1, device=f'cuda:{rank}') for _ in range(world_size)]
+        dist.all_gather(gather_list, torch.tensor([float(rank)], device=f'cuda:{rank}'))
+        gathered = sorted(int(g.item()) for g in gather_list)
+        assert gathered == list(range(world_size)), f'rank {rank}: all_gather got {gathered}'
+
+        dist.destroy_process_group()
+
+        with open(f'{results_path}.{rank}', 'w') as f:
+            f.write('ok')
+    except Exception as e:
+        with open(f'{results_path}.{rank}', 'w') as f:
+            f.write(str(e))
+
+
+if __name__ == '__main__':
+    world = torch.cuda.device_count()
+    port = int(sys.argv[1])
+    results_path = '/tmp/nccl_test_result'
+
+    for i in range(world):
+        try:
+            os.remove(f'{results_path}.{i}')
+        except FileNotFoundError:
+            pass
+
+    mp.spawn(_worker, args=(world, results_path, port), nprocs=world, join=True)
+
+    failures = []
+    for i in range(world):
+        try:
+            with open(f'{results_path}.{i}') as f:
+                result = f.read().strip()
+            if result != 'ok':
+                failures.append(f'rank {i}: {result}')
+        except FileNotFoundError:
+            failures.append(f'rank {i}: no result file')
+
+    if failures:
+        for f in failures:
+            print(f'  FAIL: {f}')
+        sys.exit(1)
+
+    print(f'  NCCL all_reduce: ok ({world} GPUs)')
+    print('  NCCL broadcast: ok')
+    print('  NCCL all_gather: ok')
+NCCL_EOF
+
+"${NCCL_VENV}bin/python3" "$NCCL_SCRIPT" "$MASTER_PORT" 2>&1 \
+    || fail_later "nccl" "multi-GPU NCCL communication failed"
+rm -f "$NCCL_SCRIPT"
+
+report_failures
+test_pass "NCCL collectives verified across ${_device_count} GPUs"

--- a/derivatives/pytorch/torch-companions.json
+++ b/derivatives/pytorch/torch-companions.json
@@ -1,19 +1,13 @@
 {
-  "2.6.0": {
-    "packages": {
-      "torchvision": "0.21.0",
-      "torchaudio": "2.6.0",
-      "torchcodec": "0.2.1"
-    },
-    "amd64_only": ["torchcodec"]
-  },
   "2.7.1": {
     "packages": {
       "torchvision": "0.22.1",
       "torchaudio": "2.7.1",
       "torchcodec": "0.5"
     },
-    "amd64_only": ["torchcodec"]
+    "amd64_only": [
+      "torchcodec"
+    ]
   },
   "2.8.0": {
     "packages": {
@@ -21,7 +15,9 @@
       "torchaudio": "2.8.0",
       "torchcodec": "0.7.0"
     },
-    "amd64_only": ["torchcodec"]
+    "amd64_only": [
+      "torchcodec"
+    ]
   },
   "2.9.1": {
     "packages": {
@@ -29,7 +25,9 @@
       "torchaudio": "2.9.1",
       "torchcodec": "0.9.1"
     },
-    "amd64_only": ["torchcodec"]
+    "amd64_only": [
+      "torchcodec"
+    ]
   },
   "2.10.0": {
     "packages": {
@@ -37,7 +35,9 @@
       "torchaudio": "2.10.0",
       "torchcodec": "0.10.0"
     },
-    "amd64_only": ["torchcodec"]
+    "amd64_only": [
+      "torchcodec"
+    ]
   },
   "2.11.0": {
     "packages": {
@@ -47,10 +47,17 @@
     },
     "amd64_only": []
   },
-  "2.12.0": {
+  "2.12.1": {
     "packages": {
-      "torchvision": "0.27.0",
-      "torchcodec": "0.12.0"
+      "torchvision": "0.27.1",
+      "torchcodec": "0.15.0"
+    },
+    "amd64_only": []
+  },
+  "2.13.0": {
+    "packages": {
+      "torchvision": "0.28.0",
+      "torchcodec": "0.15.0"
     },
     "amd64_only": []
   }

--- a/docs/adr/0021-pytorch-promotion-qa-gate.md
+++ b/docs/adr/0021-pytorch-promotion-qa-gate.md
@@ -1,0 +1,309 @@
+# ADR 0021 — QA-gated pytorch promotion, with mini in scope and a whole-run block
+
+**Status:** Accepted
+**Date:** 2026-08-07
+**Extends:** [ADR 0005](0005-live-gpu-qa-gate.md) (live-GPU QA gate),
+[ADR 0019](0019-base-image-promotion-qa-gate.md) (base promotion QA gate)
+**Depends on:** [ADR 0020](0020-qa-verdicts-classify-by-fault-domain.md) — the hard
+block below is only affordable because a bad host can no longer produce a `block`.
+
+---
+
+## Context
+
+`promote-pytorch.yml` today has no QA reference at all: it resolves staging tags and
+writes production tags, including the `-auto` pointers that Vast's
+`@vastai-automatic-tag` backend serves to customers. ADR 0019 built exactly this
+gate for base-image and it is live; pytorch is the same shape with a different
+artifact set, so the question is what to copy and what to change.
+
+### What actually ships (measured 2026-08-07 from `configs/pytorch.json`)
+
+| family | entries | pointer surface |
+|---|---|---|
+| `configs` | 17 | 8 `cuda-*-auto` tags, mapped in `promote-pytorch.yml` |
+| `mini` | 11 | none |
+| `multi` | 1 | one floating alias, `pytorch:multi-210-291-271` |
+
+The auto surface is far smaller than the artifact count suggests. The 8 auto tags
+map onto **3 backends**, each resolving to the newest torch carrying it at
+`default_python: 312`:
+
+| backend | newest torch | auto tags pointing here |
+|---|---|---|
+| cu126 | 2.12.0 | `cuda-12.1.1`, `cuda-12.4.1`, `cuda-12.6.3` |
+| cu128 | 2.11.0 | `cuda-12.8.1`, `cuda-12.9.2` |
+| cu130 | 2.12.0 | `cuda-13.0.3`, `cuda-13.1.2`, `cuda-13.2.1` |
+
+So **three images cover 100% of the automatic blast radius.** An early framing of
+this work put it at "~100 artifacts, sampling required"; that was wrong by roughly
+thirty-fold and would have spent the budget certifying artifacts no pointer points
+at. It is recorded here because the error nearly drove the design.
+
+### Why mini is different here than it was for base
+
+ADR 0019 cond 5 declined mini QA for base-image on the reasoning that mini carries
+no `-auto` tag, so a bad mini has no *automatic* path to a customer — it reaches one
+only through a derivative build pinning an explicit dated tag, which is a reviewed
+act. That reasoning was sound for base, where mini has two consumers.
+
+It does not survive the pytorch numbers. Measured across
+`derivatives/pytorch/derivatives/*/Dockerfile`:
+
+- **15 derivative images pin a pytorch mini base. Zero pin a non-mini base.**
+- Every pin is `cu128-cuda-12.9-mini`, at py310/311/312, torch 2.7.1 / 2.9.1 / 2.10.0.
+
+Mini is not a side artifact in the pytorch family; it is the base layer for the
+entire derivative estate. "No automatic path to a customer" is technically true and
+practically irrelevant when the manual path is the one every derivative takes.
+
+A second measured fact points the same way: mini is the **cheapest** cell in the
+family (5.0–6.1 GB compressed, versus 8.4–12.2 GB for the auto configs and 14.8 GB
+for multi). It is the best coverage-per-dollar in the matrix, not a luxury.
+
+Note also that `multi` is built **on a mini base**, so a multi cell transitively
+exercises the runtime-subset CUDA userland as well.
+
+### Why multi is in scope where base's mini was not
+
+`pytorch:multi-210-291-271` is a **floating, mutable alias** — the only non-`-auto`
+mutable tag in the family. It moves on every promotion, untested. That is a pointer
+by any honest reading, so ADR 0019 cond 5's own criterion puts it in scope.
+
+---
+
+## Options considered
+
+### On what a failed cell does
+
+**A — Advisory cells.** Report mini/multi results; promote regardless.
+**Rejected.** A gate that cannot say no is decoration, and this repo has already
+decided that once. It would also make the mini cells pure cost.
+
+**B — Per-artifact hold.** Extend the flip/hold mechanism from auto tags to dated
+tags, so a failed mini cell withholds only the mini tags.
+**Rejected.** It adds conditional behaviour to the job that writes production tags —
+the highest-risk place in the system — and it produces partially-promoted releases
+where some artifacts of a build are public and others are not. That state is hard to
+reason about later and hard to reverse.
+
+**C — Any `block` stops the entire promotion.** **Chosen.**
+Mechanically the *simplest* of the three: a `needs:` edge and a failed job, with no
+new conditional logic inside the promote job at all. It is stricter than base-image,
+which promotes dated tags regardless and holds only auto tags.
+
+The objection to C is real and was raised before adoption: one flaky cell stops a
+whole release, and with mini in scope there are more cells and therefore more draws
+from a spot market per run. That objection is answered not by softening C but by
+ADR 0020 — a host-attributable outcome can no longer produce a `block`. C is only
+sound on top of that, which is why the dependency is declared rather than implied.
+
+### On hardware
+
+**D — Multi-GPU cells to exercise collectives.** **Rejected for now.**
+The decisive measured fact is that the NCCL tests **already exist** and are
+structurally unable to fail: `pytorch.d/10-torch-core.sh` runs a full `mp.spawn`
+harness (`all_reduce`, `broadcast`, `all_gather`) gated on `device_count > 1`, and
+falls through on a single GPU to a bare `echo` — not a skip — so the enclosing test
+passes either way. `base/61-cuda-compute.sh` similarly turns a peer-access failure
+into a `WARN` and then calls `test_pass`. Renting two GPUs today would produce a
+green cell that certifies nothing.
+
+Further, the image-owned half of that surface is reachable on **one** GPU:
+`init_process_group('nccl', world_size=1)` exercises whether `libnccl` is present,
+dlopen-able, ABI-matched to the wheel, and whether `ncclCommInitRank` succeeds —
+which is what breaks when a torch/CUDA backend pairing is wrong. What genuinely
+needs a second GPU is the *transport*, which is a property of the host, not the
+image, and therefore fails in the fault domain ADR 0020 excludes from blocking.
+
+**One GPU catches the defects we can fix; two catch the ones we cannot.**
+
+**E — Single GPU. Chosen.** Multi-GPU is revisitable, but only after the two
+existing tests are made capable of failing, and after `/dev/shm` on the offer tier
+the selector actually picks has been measured.
+
+---
+
+## Decision
+
+**1. `promote-pytorch.yml` gains the ADR 0019 gate topology**: `preflight` →
+`resolve-digests` (pin every artifact's digest, publish run-scoped `qa-<run_id>-<key>`
+aliases) → `qa` matrix → `qa-summary` → human approval (`environment: production`) →
+`promote`. Every promoted artifact is copied **by digest**, never by a mutable
+staging tag. There is no bypass input.
+
+**2. The gated set is 57 cells, all single-GPU:**
+
+| cells | what | python |
+|---|---|---|
+| 4 | one per config backend (cu126, cu128, cu129, cu130) | 312 |
+| 52 | **every mini artifact the build produces** | every python built (310–314) |
+| 1 | `multi` | 312 |
+
+*(Corrected 2026-08-10 from "3 cells / 56". The table builds **four** backends,
+not three: `cu129` (torch 2.8.0) exists but `AUTO_TAG_MAP` references only
+cu126, cu128 and cu130, so cu129 is promoted as dated tags with no pointer. The
+statement "3 images cover 100% of the automatic blast radius" remains true —
+cu129 is gated as ordinary coverage, on the same reasoning that put mini in
+scope: no auto tag is not the same as no consumer.)*
+
+The auto cells are derived from the config table's backends, but the thing that
+decides customer exposure is `AUTO_TAG_MAP`. Those agree today and nothing made
+them agree, so a test asserts every backend an auto tag points at has a cell.
+The reverse direction — a gated backend with no auto tag — is safe and allowed.
+
+**Mini is gated exhaustively, not sampled.** Every artifact the build emits is
+tested: 11 mini configs across 4–5 pythons each. The count is derived from the
+config table, so it tracks the build automatically rather than being a list that
+rots.
+
+The reasoning that makes exhaustive coverage the right call here rather than
+extravagant:
+
+- **Mini is the base layer for the whole derivative estate.** 15 of 15 derivative
+  Dockerfiles pin a pytorch mini base; zero pin a non-mini one.
+- **Sampling has a specific hole that matters for this artifact.** A
+  python-specific defect — a wheel built against the wrong ABI that still imports —
+  is invisible to a default-python sweep, and mini exists in 5 python flavours.
+- **Mini is the cheapest cell in the family** (5.0–6.1 GB compressed, versus
+  8.4–12.2 GB for auto configs and 14.8 GB for multi), so exhaustive mini coverage
+  is the cheapest coverage per artifact available.
+- **Pytorch promotions are infrequent.** Per-promotion cost is the cheap axis;
+  a bad base layer reaching 15 derivatives is the expensive one.
+
+**`multi` stays gated for the same reason, on its own evidence.** It carries the
+family's only non-`-auto` mutable alias (`pytorch:multi-210-291-271`, which moves
+untested on every promotion today), and it is the base for the AIO studio image —
+pinned at `derivatives/pytorch/derivatives/aio-studio/Dockerfile.base:1` and
+`build-aio-studio-base.yml:18`. It is also built **on** a mini base, so its cell
+exercises the runtime-subset CUDA userland transitively.
+
+**3. Any `block` verdict on any cell stops the whole promotion.** No tags are
+written — not auto, not dated. Per ADR 0020, `block` means the image is bad;
+host-attributable outcomes are `inconclusive` and are retried.
+
+**4. An exhausted `inconclusive` also stops the promotion**, with a reason line
+stating the image was never tested rather than that it failed. Re-dispatching draws
+fresh offers.
+
+**5. Before any of the above is trusted, the tests must be able to fail.** The
+required-pass gate matches on *test* states, so a conditional branch inside a
+passing test is invisible to it. Three source fixes are prerequisites, not
+follow-ups:
+   - split the multi-GPU collectives block out of `10-torch-core.sh` into its own
+     test file that `test_skip`s (exit 77) below 2 GPUs, so it can be *named* in
+     `INSTANCE_TEST_REQUIRE_PASS` on a multi-GPU cell if one is ever added;
+   - make a peer-access failure in `61-cuda-compute.sh` fail rather than warn;
+   - add a `world_size=1` NCCL init assertion to every cell.
+
+**6. `multi` asserts its venvs structurally.** A discovery-based test cannot detect
+absence: a multi image shipping one of its three venvs passes green today. The
+expected venv set is asserted explicitly. This costs nothing and needs no GPU.
+
+**7. `templates/pytorch-qa/template.yml` carries the base-qa offer floors**
+(`compute_cap gte 750`, `reliability2 gte 0.95`, `direct_port_count gte 64`,
+`disk_space gte 16`, per-config `cuda_max_good` lower bound) plus a per-test timeout
+sized for the venv count — the pytorch tests loop over every torch venv, and `multi`
+has three, so base's single-venv timing does not transfer.
+
+---
+
+## Binding conditions
+
+1. **The wiring is executed under test, not grepped.** The `wfexec.py` harness built
+   for the base gate is reused: workflow steps are extracted and run under bash
+   against a stubbed registry. String-matching a workflow file has produced false
+   green in this repo three times.
+2. **`block` cannot be bypassed or retried.** Asserted by test, as ADR 0020 cond 2.
+3. **The QA label uses the reaper's scope prefix.** `reap_orphans.py` matches
+   instance labels by `startswith`; a pytorch label outside that prefix would leave
+   orphans unreaped while the reaper reported success. Asserted by test.
+4. **GPU count is verified on the launched instance.** Disk is verified today and
+   GPU count is not. Any cell that specifies a GPU count and does not get it must be
+   treated as a bad box (`inconclusive`, retried), never as a pass.
+5. **Cost and wall-clock are measured after the first three promotions.** Estimated
+   at $18–20 per promotion (57 cells). If actual materially exceeds that, the mini
+   set is cut — first to one cell per config at default python (11), then to the
+   artifacts derivatives pin (7) — by ADR amendment, never by per-run exemption.
+6. **Coverage is stated, not implied.** See below, and it is restated in the
+   approval summary.
+7. **The gated set is DERIVED from the config table, never hand-maintained.** A test
+   asserts that the QA matrix covers **every** mini artifact the build produces —
+   equality, not containment, so a new mini config or a new python cannot be added
+   to the build without also entering the gate. A hand-written cell list is correct
+   the day it is written and silently wrong at the next table edit; that is the
+   exact drift the config-table extraction was done to remove. The test must fail
+   loudly on an uncovered artifact rather than skipping.
+8. **Matrix concurrency is bounded and the rate limit is respected.** 57 cells run
+   against a single QA API key with no semaphore (ADR 0005 cond 6, still open). The
+   client already backs off with jitter on 429/5xx, and ADR 0020 makes a genuine
+   rate-limit casualty `inconclusive`-and-retried rather than a block — but
+   `max-parallel` must be chosen deliberately and recorded, not left at a default,
+   and 429 incidence is reviewed after the first runs.
+
+---
+
+## What a pytorch promotion does and does not certify
+
+- **amd64 only.** arm64 children are promoted untested (ADR 0019 cond 5; parked on
+  market size).
+- **Mini: complete.** Every mini artifact the build produces is booted and tested,
+  across every python built. No sampling.
+- **Auto surface and `multi`: `default_python` (312) only** — which is the exact
+  pointer surface those tags expose, so this is scope rather than a gap. The
+  non-default-python `configs` artifacts promote untested via dated tags; they carry
+  no pointer and, unlike mini, no derivative pins them.
+- **Single GPU.** Collectives across devices are not exercised by any cell.
+- **One box, one moment.** Not a guarantee under load or over time.
+- **A pass after retries is still one box.** Retrying improves the odds of obtaining
+  a verdict; it does not broaden coverage.
+
+---
+
+## Consequences
+
+**Positive**
+
+- The mutable pointer surface — 8 auto tags plus the multi alias — can no longer
+  move to an untested digest.
+- The base layer of the derivative estate is tested **exhaustively** before it is
+  published — every mini artifact, every python — so a derivative can bump its pin
+  to any promoted mini tag and know that exact artifact was booted.
+- Python-specific defects in mini become detectable. A wheel built against the wrong
+  ABI that still imports is invisible to a default-python sweep; it is not invisible
+  to this one.
+- Whole-run blocking removes partially-promoted releases as a possible state.
+- Three source fixes convert two tests that could not fail into tests that can, which
+  is worth more than the cells that run them.
+
+**Accepted negative**
+
+- One genuinely bad artifact stops the release for everything, including healthy
+  artifacts. This is the deliberate trade: pytorch images are the base layer for the
+  derivative estate, so shipping a known-bad one is worse than shipping nothing.
+- ~57 instance rentals per promotion, plus retries — roughly $18–20 and a QA phase
+  measured in hours rather than minutes. Accepted on the grounds that pytorch
+  promotions are infrequent, so per-promotion cost and latency are the cheap axes
+  and coverage of the derivative estate's base layer is the expensive one.
+- The QA phase becomes the dominant cost and duration of a promotion, which makes
+  `max-parallel` and the single-key rate limit operational concerns rather than
+  incidental settings (cond 8).
+- Stricter semantics than base-image, so the two gates differ. Recorded here
+  deliberately; the difference is justified by mini's consumer count, not by taste.
+- Non-default-python mini artifacts that derivatives actually pin remain untested.
+
+---
+
+## What would reverse this
+
+- **Sustained whole-run blocks from single cells that turn out to be host artefacts.**
+  That would mean ADR 0020's classification is not sound, and the block should
+  narrow to per-artifact holds (option B) despite their cost.
+- **Derivatives moving off mini bases.** The mini decision here rests entirely on
+  15-of-15 consumption. If that ratio inverts, mini returns to base-image's
+  treatment.
+- **Cost materially above the estimate** with no defect ever caught by the mini
+  cells — that would make the mini set unearned, and cond 5 is the pre-committed
+  response.
+- **A pointer appearing on a non-default python.** That would make the
+  default-python-only scope indefensible rather than merely incomplete.

--- a/docs/adr/0021-pytorch-promotion-qa-gate.md
+++ b/docs/adr/0021-pytorch-promotion-qa-gate.md
@@ -132,20 +132,21 @@ aliases) → `qa` matrix → `qa-summary` → human approval (`environment: prod
 `promote`. Every promoted artifact is copied **by digest**, never by a mutable
 staging tag. There is no bypass input.
 
-**2. The gated set is 57 cells, all single-GPU:**
+**2. The gated set is 78 cells, all single-GPU:**
 
 | cells | what | python |
 |---|---|---|
-| 4 | one per config backend (cu126, cu128, cu129, cu130) | 312 |
-| 52 | **every mini artifact the build produces** | every python built (310–314) |
+| 5 | one per config backend (cu126, cu128, cu129, cu130, cu132) | 312 |
+| 72 | **every mini artifact the build produces** | every python built (310–314) |
 | 1 | `multi` | 312 |
 
-*(Corrected 2026-08-10 from "3 cells / 56". The table builds **four** backends,
-not three: `cu129` (torch 2.8.0) exists but `AUTO_TAG_MAP` references only
-cu126, cu128 and cu130, so cu129 is promoted as dated tags with no pointer. The
-statement "3 images cover 100% of the automatic blast radius" remains true —
-cu129 is gated as ordinary coverage, on the same reasoning that put mini in
-scope: no auto tag is not the same as no consumer.)*
+*(Restated 2026-08-10. The count moved twice: first from a wrong "3 backends /
+56 cells" — the table builds cu129 too, which `AUTO_TAG_MAP` does not reference,
+so it is promoted with no pointer and gated as ordinary coverage — and then
+again when the table was brought up to date with upstream (torch 2.12.1 and
+2.13.0 added, cu132 added as a new backend). Cell counts are DERIVED from the
+config table and asserted by test; treat any number written here as a snapshot
+and the test as the authority.)*
 
 The auto cells are derived from the config table's backends, but the thing that
 decides customer exposure is `AUTO_TAG_MAP`. Those agree today and nothing made
@@ -222,7 +223,7 @@ has three, so base's single-venv timing does not transfer.
    GPU count is not. Any cell that specifies a GPU count and does not get it must be
    treated as a bad box (`inconclusive`, retried), never as a pass.
 5. **Cost and wall-clock are measured after the first three promotions.** Estimated
-   at $18–20 per promotion (57 cells). If actual materially exceeds that, the mini
+   at $25–30 per promotion (78 cells). If actual materially exceeds that, the mini
    set is cut — first to one cell per config at default python (11), then to the
    artifacts derivatives pin (7) — by ADR amendment, never by per-run exemption.
 6. **Coverage is stated, not implied.** See below, and it is restated in the
@@ -234,7 +235,7 @@ has three, so base's single-venv timing does not transfer.
    the day it is written and silently wrong at the next table edit; that is the
    exact drift the config-table extraction was done to remove. The test must fail
    loudly on an uncovered artifact rather than skipping.
-8. **Matrix concurrency is bounded and the rate limit is respected.** 57 cells run
+8. **Matrix concurrency is bounded and the rate limit is respected.** 78 cells run
    against a single QA API key with no semaphore (ADR 0005 cond 6, still open). The
    client already backs off with jitter on 429/5xx, and ADR 0020 makes a genuine
    rate-limit casualty `inconclusive`-and-retried rather than a block — but
@@ -281,7 +282,7 @@ has three, so base's single-venv timing does not transfer.
 - One genuinely bad artifact stops the release for everything, including healthy
   artifacts. This is the deliberate trade: pytorch images are the base layer for the
   derivative estate, so shipping a known-bad one is worse than shipping nothing.
-- ~57 instance rentals per promotion, plus retries — roughly $18–20 and a QA phase
+- ~78 instance rentals per promotion, plus retries — roughly $25–30 and a QA phase
   measured in hours rather than minutes. Accepted on the grounds that pytorch
   promotions are infrequent, so per-promotion cost and latency are the cheap axes
   and coverage of the derivative estate's base layer is the expensive one.

--- a/docs/adr/0022-pytorch-version-lifecycle.md
+++ b/docs/adr/0022-pytorch-version-lifecycle.md
@@ -1,0 +1,179 @@
+# ADR 0022 — PyTorch version lifecycle: what we keep building, and when we stop
+
+**Status:** Accepted
+**Date:** 2026-08-10
+**Relates to:** [ADR 0021](0021-pytorch-promotion-qa-gate.md) (pytorch promotion
+QA gate), [ADR 0019](0019-base-image-promotion-qa-gate.md)
+
+---
+
+## Context
+
+Every pytorch promotion rebuilds **every** torch version in the table, back to
+2.6.0. The practice is long-standing and the stated reason is good: it keeps
+older torch versions shipping on a *current* base image, so a user on an old
+torch still gets current OS packages, portal releases and CVE fixes.
+
+Two things prompted a re-examination.
+
+**The mechanism does not do what the intent describes.** A user pinned to
+`2.6.0-cuda-12.6.3-py312-2026-06-15` gets nothing from a rebuild — the rebuild
+mints `…-2026-08-10`, a *different, immutable* tag. Their pin is unchanged. The
+benefit only reaches someone who **bumps**. That is a real use case (it is
+exactly what happens when a derivative's pin is moved forward), but it means the
+value is proportional to *bump activity*, not to how many people run old torch.
+The practice keeps a landing pad current for moves that may never happen.
+
+**ADR 0021 changed the risk.** Under the new gate, any blocked cell stops the
+whole promotion. Rebuilding a 2.6-era stack on a 2026 platform is the single
+most likely thing in the matrix to break — and there is direct precedent in this
+repo, where a base bump to `setuptools>=81` removed `pkg_resources` and broke
+dependencies that imported it, silently where the import sat behind a
+`try/except`. Under ADR 0021 that same event would now stop torch 2.13.0 from
+shipping. We would be coupling the release of the images people want to the
+survival of the images nothing points at.
+
+An attempt was made to settle this with evidence and **it failed to
+discriminate**, which is recorded here so nobody repeats it: DockerHub exposes
+`tag_last_pulled` but not per-tag pull counts, and all 812 dated tags showed a
+last pull within ~24 hours across 966 distinct timestamps. That is equally
+consistent with a mirror or scanner walking the repository daily and with broad
+genuine use. It cannot separate the two, so it was not used as evidence.
+
+Measured instead, from the repo itself: **85 of 177 images had neither an
+`-auto` tag nor a derivative pin.**
+
+---
+
+## Options considered
+
+### A — Keep rebuilding everything
+
+**Rejected.** Not on cost — on risk concentration. It puts the oldest, most
+fragile stacks on the blocking path for every release, in exchange for keeping a
+landing pad current for versions nothing in the repo consumes. It also gets
+worse over time: the tail only grows, so each new torch release makes the
+matrix slower, dearer and likelier to be blocked by something unrelated to it.
+
+### B — Keep the last N minor lines
+
+**Rejected, and it is instructive why.** With any N small enough to help, this
+retires **2.7 — which five derivative images pin** — while keeping 2.8, which
+nothing uses. Recency is a proxy for relevance and it is the wrong proxy here.
+This option is recorded because it is the obvious rule and it is actively
+harmful.
+
+### C — Tiered gating: rebuild everything, but let only "supported" versions block
+
+Build the long tail but make its QA failures non-blocking, with a pre-committed
+rule that repeated failure triggers retirement.
+
+**Rejected.** It reintroduces a red check nobody acts on, which this repo has
+already rejected twice (ADR 0019's `SKIP_QA` removal, and the advisory-cells
+option in the mini/arm64 review). It also keeps paying to build and QA artifacts
+whose failure has been declared not to matter, which is the worst of both.
+
+### D — Support floor derived from consumption
+
+**Chosen.** See below.
+
+---
+
+## Decision
+
+The pytorch build matrix carries a torch version if **both** hold.
+
+**1. It is the newest patch of its minor line.** A new patch SUPERSEDES the old
+one in place; two patches of one minor never coexist. This is not new — the
+table has always carried 2.7.1 and not 2.7.0, 2.9.1 and not 2.9.0. It was an
+implicit convention, noticed only when adding 2.12.1 alongside 2.12.0 broke it,
+and is now written down and enforced.
+
+**2. Its minor line is at or above the SUPPORT FLOOR**, where the floor is
+**the oldest torch minor that any derivative in this repo pins**.
+
+The floor is *derived*, never a hand-set number. That is the whole point: it
+tracks what is actually consumed, and it rises **on its own** as derivatives are
+bumped forward, with nobody having to remember to raise it. Today the floor is
+**2.7** (pinned by a1111, fluxgym, wan2gp, whisper, invokeai and others), so
+2.6 retires and everything from 2.7 up is built.
+
+**Retirement is not deletion.** Every dated tag already published stays pullable
+forever. Retiring a version only stops new ones being minted, so nothing anyone
+already runs can break. A retired version can be un-retired by adding it back
+with a reason.
+
+### Applied at adoption
+
+- **torch 2.6 retired** — below the floor, no derivative pin, no `-auto` tag.
+- **torch 2.12.0 retired** — superseded by 2.12.1 within the same minor.
+
+Effect: 178 images to 151, and the QA matrix from 78 cells to about 58.
+
+---
+
+## Binding conditions
+
+1. **A pinned version can never be retired.** Enforced by
+   `test_no_pinned_version_is_retired`, which reads the derivative Dockerfiles
+   and build workflows rather than a list. This is the direction that actually
+   causes harm — retiring something still in use breaks a derivative build with
+   no warning and no obvious cause — and it must never be weakened. The reverse
+   error (keeping something too long) is merely wasteful.
+2. **The floor is derived, and the derivation is guarded.** If the pin
+   extraction stops matching, the floor collapses and every rule passes
+   vacuously; `test_the_floor_is_derived_from_real_pins_not_a_constant` and
+   `test_the_floor_is_actually_load_bearing` exist for that.
+3. **Retirement is recorded, not silent.** The retired set is listed in the test
+   file, so a retired version reappearing fails rather than slipping back in as
+   a copy-paste of a neighbouring entry.
+4. **Bump before you retire.** The order is: move the derivative pins forward,
+   confirm the tests pass, then retire. Never the reverse.
+5. **This governs what is BUILT, not what exists.** No published tag is ever
+   deleted by this policy. Any proposal to actually delete tags is a different
+   decision with a different blast radius and needs its own ADR.
+
+---
+
+## Consequences
+
+**Positive**
+
+- The oldest, most fragile stacks leave the blocking path, so an unrelated
+  breakage in a 2.6-era build can no longer stop a current release.
+- The matrix stops growing monotonically; each release retires roughly as much
+  as it adds once the floor moves.
+- "What do we support?" has a checkable answer derived from real consumption,
+  rather than being whatever nobody got round to deleting.
+- Catching up to upstream while pruning takes the matrix from 123 images (today
+  on `main`) to 151, rather than to 178 — two new torch lines and a new CUDA
+  backend for a net +28 instead of +55.
+
+**Accepted negative**
+
+- A user who wants an old torch on a current base loses that option once the
+  version falls below the floor. Mitigated by retirement not being deletion, and
+  by the floor being consumption-driven — a version only falls below it once
+  nothing in the estate uses it.
+- The floor is only as good as the pins it reads. A consumer outside this repo
+  (a customer's Dockerfile, a Vast-side template) is invisible to it. This is
+  the known gap; see below.
+- Retiring 2.12.0 in the same change as adopting 2.12.1 means a version that
+  built on `main` yesterday does not build tomorrow. Deliberate, and the reason
+  is that they differ by a patch.
+
+---
+
+## What would reverse this
+
+- **Evidence of real external consumption below the floor.** The floor reads
+  only in-repo pins. If Vast has a support commitment to customers that old
+  torch stays patched, that is a product commitment and it outranks this ADR
+  entirely — the policy would become "the floor is the oldest supported
+  version", set by that commitment rather than by pins.
+- **Per-tag pull counts becoming available.** That would replace the structural
+  argument with a measured one, and could justify a lower floor.
+- **The gate becoming reliable enough that old builds no longer threaten a
+  release** — e.g. if ADR 0021's whole-run block were ever narrowed to
+  per-artifact holds, the risk argument weakens and rebuilding the tail becomes
+  cheap insurance again.

--- a/docs/adr/0022-pytorch-version-lifecycle.md
+++ b/docs/adr/0022-pytorch-version-lifecycle.md
@@ -103,12 +103,31 @@ forever. Retiring a version only stops new ones being minted, so nothing anyone
 already runs can break. A retired version can be un-retired by adding it back
 with a reason.
 
+**3. A CUDA BACKEND is retired when nothing points at it.** The two rules above
+govern torch *versions*; this covers the other axis. A backend earns its place by
+being reachable — an `-auto` tag in `AUTO_TAG_MAP`, a mini variant, or a
+derivative pin. A backend with none of those builds artifacts nobody can arrive
+at except by typing a dated tag by hand.
+
+*(Added 2026-08-12. The gap was found when cu129 failed QA on Blackwell hardware
+and the obvious question — "what does cu129 actually serve?" — turned out to be
+"nothing": no auto tag, no mini, no derivative pin. It had also just been brought
+current from torch 2.8.0 to 2.13.0 on the reasoning that it should not be an
+anomaly, which added 15 images nothing points at. Rule 3 is what stops that
+happening again by inattention.)*
+
 ### Applied at adoption
 
 - **torch 2.6 retired** — below the floor, no derivative pin, no `-auto` tag.
 - **torch 2.12.0 retired** — superseded by 2.12.1 within the same minor.
+- **backend cu129 retired (2026-08-12)** — no auto tag (`cuda-12.9.2-auto` has
+  always pointed at cu128), no mini, no derivative pin. Its three torch versions
+  (2.8.0, 2.12.1, 2.13.0) all remain on other backends, so nothing is lost.
+  Removing it also removes the only backend whose upstream torchvision has no
+  Blackwell kernels while its torch does — a split that would have needed a
+  per-backend workaround to keep testing something nobody used.
 
-Effect: 178 images to 151, and the QA matrix from 78 cells to about 58.
+Effect at adoption: 178 images to 151. With cu129 also retired, 144.
 
 ---
 

--- a/docs/adr/0023-agent-guide-effectiveness-eval.md
+++ b/docs/adr/0023-agent-guide-effectiveness-eval.md
@@ -1,0 +1,215 @@
+# ADR 0023 — Quantifying the in-image agent guides: an SSH-driven, arm-paired effectiveness eval
+
+**Status:** Accepted (conditional)
+**Pilot Zero status (2026-08-11):** PZ1 (banner reaches a one-shot SSH agent) and PZ2 (recycle = same host, fresh container, boot chain re-runs) both PASS on live boxes — see `docs/forge/2026-08-11-agents-guide-demo-eval/6-pilot-zero-results.md`. Added design rule: re-read the external port map after every recycle (recycle remaps ports); launch only from the template, never bare `--ssh`.
+**Date:** 2026-08-11
+**Decision owner:** Rob Ballantyne
+
+---
+
+## Context
+
+The base-image family ships an agent-enablement surface: per-image guides under
+`/etc/vast_agents/` assembled into `/etc/vast-agents-guide.md`, symlinked as
+`AGENTS.md`/`CLAUDE.md` into the landing directories, a pointer line appended to
+the SSH banner, and a machine-readable capabilities manifest (`vast-capabilities`,
+`/etc/vast_capabilities.json`, portal `GET /capabilities`). It accreted across
+~10 weeks (PR #165 merged 2026-06-04, then #175/#176/#180–#184/#192/#193/#194) —
+there is no single before/after release.
+
+We need to demonstrate to internal technical stakeholders that this surface does
+real work — that an AI agent operating a Vast instance succeeds and stays safe
+more often *because* the surface is present — and to answer, quantitatively,
+**"does it help, and how much?"** The audience can and will audit the method, so
+the result must survive hostile review; "it looks nice" is not evidence.
+
+This decision is the output of a full design review (idea gate → three blind
+competing designs → blind judging panel → synthesis → final adversarial gate);
+the raw material is preserved under
+`docs/forge/2026-08-11-agents-guide-demo-eval/`.
+
+Relevant prior art and invariants: the live-GPU QA machinery this eval reuses
+([ADR 0005](0005-live-gpu-qa-gate.md) — launch/teardown, ledger, reaper); the
+inadvertent-exposure gate ([ADR 0006](0006-inadvertent-exposure-gate.md)/`tests/base/28-inadvertent-exposure.sh`,
+which only runs under `INSTANCE_TEST=true` and which this eval must not trip); the
+public-repo redaction rule ([ADR 0012](0012-adr-location-and-content-guardrail.md), linter L060/L061 — no account
+IDs, keys, or tracker ticket IDs in any repo file, this ADR included).
+
+## Options considered
+
+Three genuinely different designs were built blind and judged by a blind panel
+(technical-feasibility / value / risk lenses). The panel did not converge — but
+**every judge ranked the chosen axis second**, and the two designs that beat it on
+some lens are the extremes this work is scoped to avoid.
+
+- **In-container agent, fresh instance per trial (Design A).** Runs headless
+  Claude Code *inside* the box. Highest internal validity and best blinding
+  analysis, but with cwd `= ${WORKSPACE}` the guide is auto-loaded into the prompt
+  before the agent acts — it measures *"does the pasted-in content help"*, not
+  *"does the shipped discovery machinery get the guide read"*, and never tests the
+  SSH banner. ~26.5 person-days, up to ~$1,900. **Rejected:** it answers the wrong
+  question for an ephemeral-instance product, and an agent harness living on a
+  throwaway box is the wrong deployment model.
+
+- **Lean batched battery (Design C).** Nine tasks batched onto each box with a
+  scripted revert between them; cheapest (~9 days, ~$250). **Rejected:** the panel
+  (risk lens) proved against the repo that its arm-delivery wrote the arm label
+  into `/etc/environment` and left the strip script in `/tmp` (unblinded on the
+  primary endpoint), and that its control arm kept a live `/capabilities` manifest.
+  Batching also introduces arm-correlated drift across the nine sequential tasks.
+  Its best ideas (boolean-verifier scoring, explicit supportable/not-supportable
+  claim wording, ADR-as-pre-registration) are grafted into the decision.
+
+- **SSH-driven agent, arms paired on a recycled rental (Design B) — chosen axis.**
+  The agent runs on the orchestrator and reaches the box only over SSH — the
+  realistic "user's laptop + remote GPU" pattern, and the honest test of whether
+  the guide is *discovered* over the wire. Arms T (shipped surface) / P (placebo
+  nudge) / C (stripped) run back-to-back on the **same physical host** via Vast
+  `recycle`, which removes host heterogeneity — the single strongest structural
+  idea in the panel — at near-zero cost. Its factual homework was the best of the
+  three (portal-patch payload verified byte-exact; two repo-tooling traps caught
+  that the others walked into).
+
+The user chose the SSH axis explicitly: *"I want to prove this over SSH only.
+Agent harnesses don't really belong on the instance due to the ephemeral nature.
+I also don't think we need to go absolutely nuts here — the question is 'does it
+help? how much?'"*
+
+## Decision
+
+Build **Design B, hardened by the panel and the final gate, and right-sized to the
+question.** Full plan: `docs/forge/2026-08-11-agents-guide-demo-eval/4-synthesis.md`
+as amended by `4-synthesis-resolution.md`.
+
+- **Three arms, current image, one frozen dated tag, identical template + port
+  map.** T = shipped surface; P = guide/manifest stripped and replaced by a
+  generic ~90-word "inspect before acting" nudge with zero Vast-specific content
+  (isolates "told to be careful" from "the content works"); C = fully stripped.
+  The genuine pre-#165 old build appears in the demo as **narrative only, no
+  numbers**, with the confound list (`git log --since 2026-06-05 -- ROOT/
+  portal-aio/`; #205 portal-crash fix, #214 thread caps, #204/#229 portal
+  responsiveness) disclosed by us first.
+
+- **Ports held identical across all arms** (a template property, not a per-arm
+  gift); the self-mapped port is **72300**, not 72299 (which syncthing owns —
+  verified against `ROOT/opt/supervisor-scripts/syncthing.sh:60`).
+
+- **The strip removes description/discovery, never capability.** The guide,
+  symlinks, banner line, `vast-capabilities` CLI/JSON and the `GET /capabilities`
+  routes are removed in C/P; the **`POST /capabilities/provision` action API stays
+  live in all three arms** and is asserted every trial. Stripping a capability, not
+  just information, would be the same category of rigging as disabling the
+  control's network.
+
+- **Arm applied at boot via a stage-15 `HOTFIX_SCRIPT` payload** (not post-boot —
+  see Binding conditions), from an **arm-symmetric fixed URL** (same string in
+  every arm) served with a per-recycle nonce and 404-after-first-fetch, that
+  self-scrubs its own residue and replaces the stage-80 assembler with an
+  identical-output shim so the boot log does not differ by arm. Residual leak is
+  arm-symmetric and **measured** by a blinded arm-guessing classifier
+  (AUC vs. 0.33 chance), reported as a pre-registered secondary.
+
+- **The agent runs containerised on the orchestrator**, reaching the box only over
+  SSH, with a per-trial task-scoped key and no mount of the eval repo, arm scripts,
+  or assignment file. Nothing of the harness lives on the instance.
+
+- **Task suite (frozen before tuning):** 3 primary ops tasks — expose a web app,
+  data persistence, the CUDA-driver trap — plus 1 context-tax control (debug a
+  script) and 1 over-trust probe (a guide-silent topic: container thread/pids
+  caps, ADR 0014). Truthfulness scored free on every trial from a required
+  handover report. Outcomes on a 4-level scale {correct-and-safe, correct-but-
+  unsafe, failed-safely, failed-dangerously} computed from **out-of-band, arm-
+  neutral verifiers** (external curl with/without token; control-plane state;
+  fresh-SSH inspection — never `vast-capabilities`).
+
+- **Primary endpoint (one):** proportion **correct-and-safe**, pooled over the 3
+  primary tasks, **T vs C**, as a matched (stratified-by-block) risk difference
+  with a 95% CI. **33 primary matched blocks** (11 per task). Everything else
+  (T vs P, the 4-level distribution, truthfulness, over-trust, context tax,
+  cost-per-success) is secondary/estimation-only, never called "significant".
+
+- **Pre-registration** = this ADR + a frozen protocol appendix merged to `main`
+  **before trial 1**, SHA printed on the results table. Null result is in scope:
+  the failure taxonomy feeds a guide-revision backlog. The number is stamped
+  point-in-time (one agent, one model, one date) and is **not a KPI**.
+
+## Binding conditions
+
+Non-negotiable; the final adversarial gate
+(`docs/forge/2026-08-11-agents-guide-demo-eval/5-redteam-gate.md`, verdict
+PROCEED-WITH-CONDITIONS) refused the plan without these. If any is later refused,
+this decision is void.
+
+1. **Arm application, including the `/capabilities` route strip and the
+   `/.first_boot_complete` freeze, MUST run at boot stage 15 — before the portal
+   starts (stage 65) and before first-boot (stage 25).** The portal runs
+   `fastapi run` with no hot-reload (verified: `portal-aio/launch.sh:44`,
+   `ROOT/opt/supervisor-scripts/instance_portal.sh:11`), so an on-disk edit to a
+   running portal does nothing; a post-boot strip would either discard every C/P
+   trial or leave the control serving a live capabilities manifest. Pre-flight
+   must re-validate, live, every trial: `GET /capabilities` → 404 in C/P and 200
+   in T, `POST /capabilities/provision` → 422 in all three, the auth edge back up.
+
+2. **The boot-time leak class MUST be closed to arm-symmetric residue, and the
+   residual MUST be measured.** Arm-symmetric fixed `HOTFIX_SCRIPT` URL; payload
+   self-scrubs `/tmp/hotfix.sh`, the hotfix log, and its `/etc/environment` line;
+   stage-80 replaced by an identical-output shim so the boot log does not differ
+   by arm; blinded arm-guessing classifier reported. If the classifier beats
+   chance, the result is reported as confounded by unblinding.
+
+3. **Power and CI stated honestly.** 33 matched blocks resolves ~30 pp at
+   discordance ψ≈0.40 (widening to ~34 pp at ψ=0.50) — stated verbatim in the
+   pre-registration and on the slide. No task-cluster bootstrap (degenerate at 3
+   tasks); the CI is a block-level bootstrap, and a leave-one-task-out sensitivity
+   shows whether one task carries the effect.
+
+4. **PZ1 gates all build spend:** verify live that sshd presents `/etc/banner` on a
+   one-shot `ssh host cmd` and that the text reaches the agent's transcript. The
+   repo does not configure this (control-plane owned). If it fails, **stop and
+   ship that as the finding** — "the one channel built to be unmissable misses the
+   SSH-agent pattern" — do not fake the result. PZ2 (recycle preserves host/ports,
+   wipes container) is the second hard blocker.
+
+5. **A self-destruct voids the whole block, not one arm.** An agent that stops or
+   destroys its own rental is scored failed-dangerously and the block is re-run
+   whole on a replacement rental; the partial block is dropped.
+
+6. **Safety / blast radius.** Operator-invoked only, never a CI gate; deliberate
+   exposure lasts only the trial window and is torn down; no real credential on
+   any box (dummy HF token only); layered teardown (ledger-on-create, per-trial
+   watchdog, hard per-rental deadline on a second machine); repo redaction rules
+   (ADR 0012, L060/L061) apply to the pre-registration and results.
+
+7. **The agent runs under bypassed permissions** (`--dangerously-skip-permissions`)
+   — inherent to autonomous-agent evaluation, accepted here because boxes are
+   disposable, hold no real credentials, and are destroyed within the trial
+   window. Recorded as an accepted risk, not hidden.
+
+## Consequences
+
+- **Positive:** a defensible, pre-registered answer to "does it help, how much?"
+  for the true ephemeral-SSH usage pattern, at ~2 weeks and ~$300–450, stamped
+  point-in-time. A near-null is a publishable finding, not a failure. The recycle
+  characterisation (PZ2) and the arm-symmetric boot-payload technique are reusable
+  by the repo's existing QA tooling. The failure taxonomy directly seeds guide
+  edits (each a separate vetted change).
+- **Accepted-negative:** measures the **SSH discovery channel only** — the
+  landing-dir auto-load path is out of scope, disclosed, not hidden. Powered for a
+  **large effect (~30 pp)** only; a modest effect returns a CI that includes small
+  values, pre-committed in the null wording. One agent, one model, one date; no
+  generalisation to "AI agents" and no KPI. P and C are synthetic builds that never
+  shipped. The volume-persistence branch of the persistence task is disclosed as
+  untested, not simulated.
+
+## What would reverse this
+
+- PZ1 fails (banner does not reach an SSH agent) → the SSH axis measures nothing;
+  pivot to reporting the banner-delivery gap as the finding, or re-scope to the
+  in-container axis (a different ADR).
+- PZ2 fails (recycle does not preserve host/ports or does not fully wipe) → the
+  matched-pairs design collapses to fresh-rental-per-trial at ~3× cost and loses
+  the matched analysis; re-decide scope before spending.
+- The arm-guessing classifier beats chance materially → blinding failed; the
+  primary result is confounded and must be reported as such, not as a clean effect.
+- A stakeholder withdraws the bypassed-permissions authorisation (condition 7) →
+  the autonomous eval cannot run as designed.

--- a/docs/runbooks/pytorch-version-lifecycle.md
+++ b/docs/runbooks/pytorch-version-lifecycle.md
@@ -22,6 +22,9 @@ QA gate).
 | Nothing below the support floor is still built | `test_nothing_below_the_support_floor_is_still_built` |
 | **A version a derivative pins can never be retired** | `test_no_pinned_version_is_retired` |
 | A retired version does not come back by accident | `test_a_retired_minor_does_not_come_back_by_accident` |
+| **Every built backend is reachable** (auto tag, mini, or derivative pin) | `test_every_built_backend_is_reachable` |
+| A retired backend does not come back by accident | `test_a_retired_backend_does_not_come_back_by_accident` |
+| A cu126 cell caps GPU architecture at sm_90 | `test_cu126_cells_cap_the_gpu_architecture` |
 | Every built mini artifact is QA-gated | `test_every_mini_artifact_the_build_produces_is_gated` |
 | Every backend an `-auto` tag points at has a QA cell | `test_every_backend_an_auto_tag_points_at_is_gated` |
 
@@ -158,7 +161,17 @@ Additionally:
   The base installs uv unpinned, so a build gets whatever is current.
 - **Confirm the CUDA base exists** in `configs/base-image.json`.
 - **Decide the `-auto` mapping deliberately** — see §4. Adding a backend does not
-  by itself change what customers are served; the `AUTO_TAG_MAP` does.
+  by itself change what customers are served; the `AUTO_TAG_MAP` does. A backend
+  with no auto tag, no mini and no derivative pin is unreachable and will fail
+  `test_every_built_backend_is_reachable` (ADR 0022 rule 3) — that is what
+  retired cu129.
+- **Know which GPU architectures its wheels cover, and cap QA accordingly.**
+  `cuda_max_good` bounds the host DRIVER from below; it says nothing about the
+  GPU. cu126 wheels stop at sm_90, so a cu126 cell renting a Blackwell card gets
+  `cudaErrorNoKernelImageForDevice` — which reads as a broken image and is not.
+  The per-cell `cap` in `resolve-digests` adds `compute_cap.lte` for such a
+  backend. Note the split can differ between torch and its companions: cu129's
+  torch had Blackwell kernels while its torchvision did not.
 
 ## 4. Repointing an `-auto` tag — read this before you do it
 

--- a/docs/runbooks/pytorch-version-lifecycle.md
+++ b/docs/runbooks/pytorch-version-lifecycle.md
@@ -1,0 +1,158 @@
+# Runbook — adding and retiring PyTorch versions
+
+**Audience:** whoever (human or agent) is told "add the new torch release" or
+"we're carrying too many old versions".
+**Authority:** this file is the procedure. Where it disagrees with a summary
+elsewhere, this file and the tests it names win.
+
+Governed by [ADR 0022](../adr/0022-pytorch-version-lifecycle.md) (version
+lifecycle) and [ADR 0021](../adr/0021-pytorch-promotion-qa-gate.md) (promotion
+QA gate).
+
+---
+
+## 0. The rules that are enforced, so you cannot get them wrong quietly
+
+| rule | enforced by |
+|---|---|
+| One patch per minor line — a new patch SUPERSEDES the old one | `test_each_minor_line_carries_exactly_one_patch` |
+| Mini and config agree on the patch | `test_mini_and_config_agree_on_the_patch` |
+| Nothing below the support floor is still built | `test_nothing_below_the_support_floor_is_still_built` |
+| **A version a derivative pins can never be retired** | `test_no_pinned_version_is_retired` |
+| A retired version does not come back by accident | `test_a_retired_minor_does_not_come_back_by_accident` |
+| Every built mini artifact is QA-gated | `test_every_mini_artifact_the_build_produces_is_gated` |
+| Every backend an `-auto` tag points at has a QA cell | `test_every_backend_an_auto_tag_points_at_is_gated` |
+
+```bash
+python -m pytest -q tools/imagegen tools/template_manager
+```
+
+If you change this area and these stay green, **assume you have not actually
+changed it.**
+
+---
+
+## 1. The support floor
+
+The floor is **the oldest torch minor any derivative in this repo pins**. It is
+derived from the derivative Dockerfiles and `build-*.yml` workflows, never
+hand-set, so it rises on its own as pins are bumped.
+
+To see it:
+
+```bash
+python - <<'PY'
+import re, pathlib
+from collections import defaultdict
+minor = lambda v: ".".join(v.split(".")[:2])
+pins = defaultdict(set)
+for pat in ("derivatives/pytorch/derivatives/*/Dockerfile", ".github/workflows/build-*.yml"):
+    for f in pathlib.Path(".").glob(pat):
+        for v, _ in re.findall(r"vastai/pytorch:([0-9.]+)-([a-z0-9]+)-cuda", f.read_text()):
+            pins[minor(v)].add(f.parent.name if f.name == "Dockerfile" else f.name)
+for m in sorted(pins, key=lambda s: [int(x) for x in s.split(".")]):
+    print(f"  {m}: {', '.join(sorted(pins[m]))}")
+PY
+```
+
+Retirement is **not** deletion. Every dated tag already published stays pullable
+forever; retiring only stops new ones being minted.
+
+---
+
+## 2. Adding a new torch version
+
+**Check upstream first, do not assume.** The wheel index is the ground truth,
+not a release note and not a comment in this repo:
+
+```bash
+# which CUDA backends exist at all
+for b in cu126 cu128 cu129 cu130 cu132; do
+  echo -n "$b -> "; curl -s -o /dev/null -w "%{http_code}\n" \
+    "https://download.pytorch.org/whl/$b/torch/"
+done
+
+# which torch versions, pythons and arches a backend carries
+curl -s "https://download.pytorch.org/whl/cu130/torch/" \
+ | grep -oE 'torch-[0-9.]+\+cu130-cp3[0-9]+-cp3[0-9]+-manylinux[^"<]*(x86_64|aarch64)\.whl' \
+ | sort -u
+```
+
+Things that bite:
+
+- **A backend can be frozen.** cu128 stops at torch 2.11.0 — there is no cu128
+  wheel for 2.12 or 2.13. Do NOT remap a cu128 entry onto cu126 to force a bump:
+  cu126 has no Blackwell kernels, so a Blackwell card on a 12.8/12.9 host would
+  get an unusable image.
+- **A patch replaces its predecessor**, it does not join it. Adding 2.12.1 means
+  removing 2.12.0 in the same change.
+- **Add the mini too, or no derivative can adopt it.** All 15 pytorch
+  derivatives pin a mini base; a config-only version is unreachable by the
+  estate.
+
+Then edit `configs/pytorch.json` — the only source of truth — and run the tests.
+
+## 3. Adding a new CUDA backend
+
+Additionally:
+
+- **Confirm `uv` supports it.** The build uses `uv pip install --torch-backend
+  <name>`, and uv only accepts backends it knows. cu132 was blocked on exactly
+  this until uv 0.12.0. Check the released version, not `main`:
+  ```bash
+  curl -s "https://raw.githubusercontent.com/astral-sh/uv/<tag>/crates/uv-torch/src/backend.rs" \
+    | grep -oE 'Cu[0-9]{3}' | sort -u
+  ```
+  The base installs uv unpinned, so a build gets whatever is current.
+- **Confirm the CUDA base exists** in `configs/base-image.json`.
+- **Decide the `-auto` mapping deliberately** — see §4. Adding a backend does not
+  by itself change what customers are served; the `AUTO_TAG_MAP` does.
+
+## 4. Repointing an `-auto` tag — read this before you do it
+
+`AUTO_TAG_MAP` in `promote-pytorch.yml` decides what real customers are served.
+It appears **twice** (promote and dry-run); both must move together.
+
+**The direction of CUDA minor-version compatibility is the thing to get right.**
+`cuda_max_good` is the NEWEST CUDA a host's driver supports. The safe direction
+is an **older-built image on a newer driver** — a cuda-11.8 image is fine on a
+13.x box, which is why every floor in the QA templates is a `gte`. The reverse —
+a 13.2-built image on a host whose driver tops out at 13.1 — leans on compat in
+the direction that can fail, across a whole host tier at once.
+
+This is why `cuda-13.2.1-auto` points at cu132 (native, strictly better) while
+`cuda-13.1.2-auto` deliberately stays on cu130. There is no cu131 wheel index
+upstream, so cu130 is the newest build every 13.1 driver can definitely run.
+
+If you repoint a tag onto a *newer-built* backend, **the QA floor must move with
+it**, or the gate tests the artifact only on hosts newer than the ones it will
+be served to.
+
+## 5. Retiring a version
+
+Order matters:
+
+1. **Bump any derivative pins off it first.** Retiring a pinned version breaks
+   that derivative's build with no warning. `test_no_pinned_version_is_retired`
+   stops you, but the fix is to bump, not to work around the test.
+2. Remove its `configs[]` and `mini[]` entries from `configs/pytorch.json`.
+3. Add the minor to `RETIRED` in `tools/imagegen/tests/test_pytorch_version_lifecycle.py`.
+4. Note it in ADR 0022's "applied" list, with the reason.
+5. Run the tests.
+
+Nothing is deleted from the registry. If you actually want to delete published
+tags, that is a different decision with a different blast radius and needs its
+own ADR.
+
+## 6. After changing the matrix
+
+- The QA matrix is **derived** from the table, so cells follow automatically —
+  but check the count is what you expect:
+  ```bash
+  python -m pytest -q tools/template_manager/tests/test_pytorch_qa_coverage.py
+  ```
+- Build before promoting: a version that has never been built has no staging tag
+  to promote, and `resolve-digests` will fail on the missing source.
+- Under ADR 0021 any blocked cell stops the whole promotion, so a newly added
+  version that fails QA holds everything. Adding several at once raises that
+  risk — consider one new backend per promotion.

--- a/docs/runbooks/pytorch-version-lifecycle.md
+++ b/docs/runbooks/pytorch-version-lifecycle.md
@@ -17,6 +17,8 @@ QA gate).
 |---|---|
 | One patch per minor line — a new patch SUPERSEDES the old one | `test_each_minor_line_carries_exactly_one_patch` |
 | Mini and config agree on the patch | `test_mini_and_config_agree_on_the_patch` |
+| **Every built version has a `torch-companions.json` entry** | `test_every_built_torch_version_has_a_companions_entry` |
+| No stale companions entry for a retired version | `test_companions_has_no_entries_for_versions_we_no_longer_build` |
 | Nothing below the support floor is still built | `test_nothing_below_the_support_floor_is_still_built` |
 | **A version a derivative pins can never be retired** | `test_no_pinned_version_is_retired` |
 | A retired version does not come back by accident | `test_a_retired_minor_does_not_come_back_by_accident` |
@@ -90,7 +92,57 @@ Things that bite:
   derivatives pin a mini base; a config-only version is unreachable by the
   estate.
 
-Then edit `configs/pytorch.json` — the only source of truth — and run the tests.
+### There are TWO files, not one
+
+`configs/pytorch.json` decides *which* images are built. **`derivatives/pytorch/torch-companions.json` decides what goes inside them** — the pinned
+torchvision/torchcodec/torchaudio for each torch version. Both need an entry.
+
+This is not optional and it fails late: the Dockerfile reads the companions file
+with
+
+```
+jq '... if .[$v] == null then error("version not found") ...'
+```
+
+so a missing entry kills the build with `jq: error: version not found` and exit
+code **5**, *after* pulling the base image, with nothing in the message naming
+the file that is actually wrong. It cost a full CI run to diagnose the first
+time. `test_every_built_torch_version_has_a_companions_entry` now catches it
+before dispatch.
+
+**Pick the companion versions by INTERSECTION, not by pattern.** The pin is per
+torch version but must resolve on *every backend that version builds on*, and
+availability is uneven:
+
+- **torchcodec is sparse on cu129** — it has 0.6, 0.7, 0.10, 0.11.x and 0.15,
+  with nothing in 0.12–0.14. When torch 2.13.0 was added on cu126/cu129/cu130/cu132,
+  **0.15.0 was the only version present on all four**.
+- The apparent "torchcodec minor tracks torch minor" pattern (2.11 → 0.11,
+  2.12 → 0.12) is coincidence. Upstream's own table says 0.12 through 0.15 all
+  require `torch>=2.11`, so there is no strict pairing to follow.
+- **torchaudio no longer exists past 2.11** — cu130 stops at 2.11.0 and cu132
+  has none at all. New entries simply omit it.
+
+Compute the intersection rather than guessing:
+
+```bash
+for pkg in torchvision torchcodec; do
+  for be in cu126 cu129 cu130 cu132; do
+    curl -s "https://download.pytorch.org/whl/$be/$pkg/" \
+      | grep -oE "$pkg-[0-9]+\.[0-9]+\.[0-9]+\+$be-cp312-cp312-manylinux[^\"<]*x86_64\.whl" \
+      | grep -oE "^$pkg-[0-9]+\.[0-9]+\.[0-9]+" | sed "s/$pkg-//" | sort -u > /tmp/${pkg}_${be}.txt
+  done
+  echo "$pkg on all four:"; comm -12 <(comm -12 /tmp/${pkg}_cu126.txt /tmp/${pkg}_cu129.txt) \
+    <(comm -12 /tmp/${pkg}_cu130.txt /tmp/${pkg}_cu132.txt) | tr '\n' ' '; echo
+done
+```
+
+Prefer a full `X.Y.Z` pin. The Dockerfile verifies the install with a PREFIX
+match (`[[ "${actual}" == "${ver}"* ]]`), so a two-component pin like `0.5`
+would also accept a hypothetical `0.50.0`. One such pin survives on 2.7.1 and is
+left alone because five derivatives depend on that image.
+
+Then edit both files and run the tests.
 
 ## 3. Adding a new CUDA backend
 
@@ -136,9 +188,11 @@ Order matters:
    that derivative's build with no warning. `test_no_pinned_version_is_retired`
    stops you, but the fix is to bump, not to work around the test.
 2. Remove its `configs[]` and `mini[]` entries from `configs/pytorch.json`.
-3. Add the minor to `RETIRED` in `tools/imagegen/tests/test_pytorch_version_lifecycle.py`.
-4. Note it in ADR 0022's "applied" list, with the reason.
-5. Run the tests.
+3. Remove its entry from `derivatives/pytorch/torch-companions.json` — both
+   files, always together.
+4. Add the minor to `RETIRED` in `tools/imagegen/tests/test_pytorch_version_lifecycle.py`.
+5. Note it in ADR 0022's "applied" list, with the reason.
+6. Run the tests.
 
 Nothing is deleted from the registry. If you actually want to delete published
 tags, that is a different decision with a different blast radius and needs its

--- a/templates/pytorch-qa/template.yml
+++ b/templates/pytorch-qa/template.yml
@@ -1,0 +1,140 @@
+# PyTorch image QA template (ADR 0021 live-GPU gate for pytorch promotion).
+#
+# WHAT THIS CERTIFIES. The pytorch family is a platform, not an app: the base
+# image's supervisor/portal/Caddy/CUDA layer plus a torch stack in one or more
+# venvs IS the product. So, as for base-image (ADR 0019), the shipped suite is a
+# real functional test rather than a boot-and-curl laundering "booted" into
+# "QA'd" (ADR 0005 option A, rejected).
+#
+# WHAT IT DOES NOT CERTIFY, stated rather than implied (ADR 0021):
+#   * amd64 only — the promoted index's arm64 child is never booted.
+#   * single GPU — no cell exercises collectives across devices. The multi-GPU
+#     matrix (pytorch.d/41-nccl-collectives) skips itself below 2 GPUs and is
+#     deliberately NOT required here.
+#   * one box, one moment — not a guarantee under load or over time.
+#
+# ADR 0010 EXEMPTION, same as base-qa: 0010 wants one template per image with
+# the gate booting the file a user launches. The pytorch customer launch
+# templates live on the Vast side, outside this repo, so this approximates a
+# customer launch and drift from the real Vast-side template is a risk no check
+# in here can detect. Keep them in step by hand when either moves.
+#
+# CI overrides image/tag with the freshly-built staging tag via create.py --tag,
+# raises cuda_max_good per config via create.py --set-filter (raise-only), and
+# passes EXPECTED_TORCH_VENVS per cell via the gate's extra_env.
+name: "PyTorch QA — platform + torch/CUDA suite"
+image: vastai/pytorch
+tag: latest                       # CI overrides with the staging tag
+private: true
+readme_visible: false
+onstart: entrypoint.sh
+runtype: jupyter                  # production launch mode
+jup_direct: true
+ssh_direct: true
+use_ssh: true
+use_jupyter_lab: false
+ports:
+  - "1111:1111"                   # Instance Portal
+  - "8080:8080"                   # Jupyter
+  - "6006:6006"                   # Tensorboard
+  - "8384:8384"                   # Syncthing
+env:
+  OPEN_BUTTON_PORT: "1111"
+  OPEN_BUTTON_TOKEN: "1"
+  JUPYTER_DIR: "/"
+  DATA_DIRECTORY: "/workspace/"
+  # Only entries whose port actually binds: the harness's port check fails an
+  # entry pointing at a dead port. Inherited unchanged from base — the pytorch
+  # images add a torch stack, not a different platform.
+  PORTAL_CONFIG: "localhost:1111:11111:/:Instance Portal|localhost:6006:16006:/:Tensorboard|localhost:8384:18384:/:Syncthing|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+
+  # A skip is not a pass (ADR 0019), and a test that cannot fail is not a test
+  # (ADR 0020, gated by L059). Every name below resolves to a file with a real
+  # failure path.
+  #
+  # NAMING: derivative tests are named by their DIRECTORY, so it is
+  # `pytorch.d/10-torch-core`, NOT `pytorch/10-torch-core`. runner.sh derives the
+  # name as the path relative to the tests dir minus `.sh`, and the directory on
+  # disk is `pytorch.d/`. Getting this wrong fails CLOSED — the runner reports
+  # "missing from this image" and the cell blocks — so the error is safe but it
+  # would be a systematic false red on all 56 cells. Pinned by
+  # test_required_test_names.py, which derives the names from the runner's own
+  # rule rather than restating them.
+  #
+  # NOT required, deliberately: pytorch.d/41-nccl-collectives. It skips below 2
+  # GPUs and every cell here is single-GPU, so requiring it would fail every
+  # cell. The image-owned half of that surface — libnccl present, ABI-matched,
+  # ncclCommInitRank works — is 40-nccl-init, which runs on one GPU and IS
+  # required. That split is the point of ADR 0021 decision 5.
+  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries pytorch.d/05-venv-manifest pytorch.d/10-torch-core pytorch.d/20-torchvision pytorch.d/30-torchaudio pytorch.d/40-nccl-init"
+
+  # Overridden per cell by the workflow. Declared here so the template is
+  # self-describing and so a single-venv cell still asserts SOMETHING about
+  # completeness rather than trusting discovery (ADR 0021 decision 6).
+  EXPECTED_TORCH_VENVS: "main"
+
+# QA gate floors (ADR 0005). Identical in shape to base-qa: these were derived
+# from measured offer data during the base rollout and the reasoning does not
+# change for pytorch. Each is reproduced with its direction, because getting a
+# direction backwards is the failure mode that keeps recurring.
+extra_filters:
+  # sm_75 (Turing). The pytorch images ship prebuilt wheels rather than
+  # compiling kernels at test time, so the real target is "a GPU generation this
+  # torch/CUDA pairing still supports". CUDA 13 dropped pre-sm_75 anyway.
+  compute_cap:
+    gte: 750
+  # MAJOR-baseline, raised per config at rent time via --set-filter.
+  #
+  # DIRECTION: a LOWER bound, and it must stay one. cuda_max_good is the NEWEST
+  # CUDA a host's driver supports, so `gte: 12.0` matches a 12.0 host and every
+  # newer one — a cu126 image on a 13.x-driver box is correct, because newer
+  # drivers run older CUDA. An `lte` here would select FOR the oldest hosts,
+  # which is the opposite of the intent and would brick the newer backends.
+  #
+  # The floor of the floor: the oldest CUDA any pytorch config targets is 12.x
+  # (there is no cu118 in the table), so 12.0 rather than base's 11.8.
+  cuda_max_good:
+    gte: 12.0
+  # PER-GPU, not the sum. gpu_total_ram lets a multi-GPU box of small cards
+  # clear the floor and behave nothing like the target — observed live on the
+  # vLLM cu13.0 cell, where GPU 0 was 9.64 GiB against a 16 GB *total* floor.
+  #
+  # These tests allocate small tensors and load no model, so 8 GB is ample.
+  gpu_ram:
+    gte: 8192
+  # Cheap unreliable hosts fail in host-specific ways the image cannot fix: a
+  # truncated pull ("unexpected eof") and a host with no outbound egress, both
+  # observed live. Good hosts sit ~0.92-0.99.
+  reliability2:
+    gte: 0.95
+  # A host that forwards very few ports is usually proxied/VPN-fronted, and
+  # those pull images pathologically slowly even when they ADVERTISE fast links.
+  # That is why this is a port floor and not an inet_down floor: measured across
+  # 930 live offers at these same floors, hosts with <8 forwardable ports still
+  # advertised a median 253 Mbps, so a bandwidth floor would not have excluded
+  # them. Reported bandwidth is a claim; port count is structural.
+  #
+  # DIRECTION: a LOWER bound. An `lte` would select FOR the hosts this avoids.
+  direct_port_count:
+    gte: 64
+  # THE DISK FLOOR THAT ACTUALLY FILTERS, and it is NOT about image size.
+  #
+  # On Vast the container image is stored separately and is not charged to the
+  # instance; the disk requested is the additional (overlayfs) space for what
+  # the instance WRITES. So a 15 GB multi image does not need a bigger disk than
+  # a 5 GB mini one, and an offer with less disk than the image is not thereby
+  # unable to run it.
+  #
+  # What this prevents is mechanical: the client REQUESTS recommended_disk_space
+  # at create time and rejects any instance that comes up with less than the
+  # full request (DISK_TOLERANCE). Without a matching search floor, offers are
+  # never filtered on disk, so the client rents a box that cannot satisfy the
+  # request and only learns after launch — burning a bounded launch attempt.
+  #
+  # Keep this >= recommended_disk_space. L058 enforces that relationship.
+  disk_space:
+    gte: 16
+# Overlayfs space for what the instance WRITES — not for the image, which Vast
+# stores separately. This suite downloads no models and no test carries a
+# download step; it writes little beyond logs and provisioning scratch.
+recommended_disk_space: 16.0

--- a/templates/pytorch-qa/template.yml
+++ b/templates/pytorch-qa/template.yml
@@ -66,7 +66,19 @@ env:
   # cell. The image-owned half of that surface — libnccl present, ABI-matched,
   # ncclCommInitRank works — is 40-nccl-init, which runs on one GPU and IS
   # required. That split is the point of ADR 0021 decision 5.
-  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries pytorch.d/05-venv-manifest pytorch.d/10-torch-core pytorch.d/20-torchvision pytorch.d/30-torchaudio pytorch.d/40-nccl-init"
+  # OVERRIDDEN PER CELL by the workflow (via --env, which wins over a template
+  # env). What is declared here is the SAFE SUPERSET minus the one test that is
+  # conditional on what the image ships: torchaudio does not exist upstream past
+  # torch 2.11, so 2.12+ images correctly do not carry it and
+  # pytorch.d/30-torchaudio correctly self-skips. Requiring it unconditionally
+  # blocked 20 healthy artifacts on the first real gate run — the gate was right
+  # and the list was wrong.
+  #
+  # The workflow ADDS 30-torchaudio for cells whose image does ship it, derived
+  # from torch-companions.json. Keeping the conditional test OUT of the default
+  # means a template used without that override under-claims rather than
+  # producing false blocks; L057 still enforces the GPU trio.
+  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries pytorch.d/05-venv-manifest pytorch.d/10-torch-core pytorch.d/20-torchvision pytorch.d/40-nccl-init"
 
   # Overridden per cell by the workflow. Declared here so the template is
   # self-describing and so a single-venv cell still asserts SOMETHING about

--- a/tools/imagegen/tests/test_pytorch_config_table.py
+++ b/tools/imagegen/tests/test_pytorch_config_table.py
@@ -112,17 +112,139 @@ def test_round_trip_promote_configs(table):
     assert have == want
 
 
+def _minor(c):
+    """cuda_minor, as extend/promote spell it for mini: cuda-12.9-mini -> 12.9."""
+    return c["mini_base_tag"].removeprefix("cuda-").removesuffix("-mini")
+
+
+def test_round_trip_extend_mini(table):
+    have = _entries((W / "extend-pytorch.yml").read_text(), "ALL_MINI_CONFIGS")
+    if have is None:
+        pytest.skip("extend-pytorch.yml now reads the table")
+    want = [f"{c['torch']}|{c['key']}|{c['backend']}|{_minor(c)}|"
+            f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in table["mini"]]
+    assert have == want
+
+
+def test_round_trip_promote_mini(table):
+    have = _entries((W / "promote-pytorch.yml").read_text(), "ALL_MINI_CONFIGS")
+    if have is None:
+        pytest.skip("promote-pytorch.yml now reads the table")
+    want = [f"{c['torch']}|{c['key']}|{c['backend']}|{_minor(c)}|"
+            f"{' '.join(c['python_versions'])}" for c in table["mini"]]
+    assert have == want
+
+
+def test_round_trip_extend_multi(table):
+    have = _entries((W / "extend-pytorch.yml").read_text(), "ALL_MULTI_CONFIGS")
+    if have is None:
+        pytest.skip("extend-pytorch.yml now reads the table")
+    want = [f"{c['key']}|{c['primary_torch']}|{c['primary_backend']}|{c['cuda_minor']}|"
+            f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in table["multi"]]
+    assert have == want
+
+
+def test_round_trip_promote_multi(table):
+    have = _entries((W / "promote-pytorch.yml").read_text(), "ALL_MULTI_CONFIGS")
+    if have is None:
+        pytest.skip("promote-pytorch.yml now reads the table")
+    want = [f"{c['key']}|{c['primary_torch']}|{c['primary_backend']}|{c['cuda_minor']}|"
+            f"{' '.join(c['python_versions'])}" for c in table["multi"]]
+    assert have == want
+
+
+def test_every_mini_base_tag_yields_a_cuda_minor(table):
+    """extend/promote derive cuda_minor from mini_base_tag by stripping the affixes.
+    A mini_base_tag that does not fit that shape would silently yield a garbage
+    minor rather than failing."""
+    import re as _re
+    for c in table["mini"]:
+        assert _re.fullmatch(r"cuda-\d+\.\d+-mini", c["mini_base_tag"]), (
+            f"{c['key']}: mini_base_tag {c['mini_base_tag']!r} does not fit "
+            f"cuda-<major>.<minor>-mini, so cuda_minor cannot be derived")
+
+
 # --- the end state ---------------------------------------------------------
 
-@pytest.mark.xfail(reason="migration in progress: workflows still carry inline arrays",
-                   strict=False)
 def test_no_workflow_still_hardcodes_the_lists():
-    """The goal. Flips to passing as each workflow is wired to the table; drop the
-    xfail once all three are done, and delete the round-trip tests above with the
-    arrays they check."""
+    """Met 2026-08-07: all nine arrays across the three workflows now read the
+    table. The round-trip tests above skip themselves now that the arrays are gone;
+    test_wired_jq_reproduces_the_table below is what guards the wiring instead."""
     stale = []
     for name in ("build-pytorch.yml", "extend-pytorch.yml", "promote-pytorch.yml"):
         t = (W / name).read_text()
         if re.search(r"^\s*ALL_(CONFIGS|MINI_CONFIGS|MULTI_CONFIGS)=\(", t, re.M):
             stale.append(name)
     assert not stale, f"still hardcoding the pytorch matrices: {stale}"
+
+
+# --- the wiring itself ------------------------------------------------------
+
+def _minor2(c):
+    return c["mini_base_tag"].removeprefix("cuda-").removesuffix("-mini")
+
+
+def _short2(c):
+    return c["cuda_ver"].split("-")[0]
+
+
+EXPECTED = {
+    ("build-pytorch.yml", "ALL_CONFIGS"): lambda T: [
+        f"{c['torch']}|{c['key']}|{c['cuda_ver']}|{c['backend']}|"
+        f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in T["configs"]],
+    ("build-pytorch.yml", "ALL_MINI_CONFIGS"): lambda T: [
+        f"{c['torch']}|{c['key']}|{c['mini_base_tag']}|{c['backend']}|"
+        f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in T["mini"]],
+    ("build-pytorch.yml", "ALL_MULTI_CONFIGS"): lambda T: [
+        f"{c['key']}|{c['primary_torch']}|{c['primary_backend']}|{c['cuda_minor']}|"
+        f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in T["multi"]],
+    ("extend-pytorch.yml", "ALL_CONFIGS"): lambda T: [
+        f"{c['torch']}|{c['key']}|{_short2(c)}|{','.join(c['arches'])}|"
+        f"{' '.join(c['python_versions'])}" for c in T["configs"]],
+    ("extend-pytorch.yml", "ALL_MINI_CONFIGS"): lambda T: [
+        f"{c['torch']}|{c['key']}|{c['backend']}|{_minor2(c)}|{','.join(c['arches'])}|"
+        f"{' '.join(c['python_versions'])}" for c in T["mini"]],
+    ("extend-pytorch.yml", "ALL_MULTI_CONFIGS"): lambda T: [
+        f"{c['key']}|{c['primary_torch']}|{c['primary_backend']}|{c['cuda_minor']}|"
+        f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in T["multi"]],
+    ("promote-pytorch.yml", "ALL_CONFIGS"): lambda T: [
+        f"{c['torch']}|{c['key']}|{_short2(c)}|{' '.join(c['python_versions'])}"
+        for c in T["configs"]],
+    ("promote-pytorch.yml", "ALL_MINI_CONFIGS"): lambda T: [
+        f"{c['torch']}|{c['key']}|{c['backend']}|{_minor2(c)}|"
+        f"{' '.join(c['python_versions'])}" for c in T["mini"]],
+    ("promote-pytorch.yml", "ALL_MULTI_CONFIGS"): lambda T: [
+        f"{c['key']}|{c['primary_torch']}|{c['primary_backend']}|{c['cuda_minor']}|"
+        f"{' '.join(c['python_versions'])}" for c in T["multi"]],
+}
+
+
+@pytest.mark.parametrize("fname,arr", sorted(EXPECTED))
+def test_wired_jq_reproduces_the_table(table, fname, arr):
+    """RUN the committed jq and compare its output to the table.
+
+    The extraction was verified once against the arrays it replaced; this keeps it
+    verified. A jq expression is easy to edit into something that still parses and
+    silently drops a field — e.g. losing the arch join, which would build one arch
+    instead of two with no error anywhere.
+    """
+    import shutil
+    import subprocess
+    if not shutil.which("jq"):
+        pytest.skip("jq not available")
+    text = (W / fname).read_text()
+    m = re.search(rf"""mapfile -t {arr} < <\(jq -r '(.*?)' "\$GITHUB_WORKSPACE/configs/pytorch\.json"\)""", text)
+    assert m, f"{fname}:{arr} is not wired to the table"
+    got = subprocess.run(["jq", "-r", m.group(1), str(CONFIG)],
+                         capture_output=True, text=True, check=True).stdout.splitlines()
+    assert got == EXPECTED[(fname, arr)](table)
+
+
+@pytest.mark.parametrize("fname,arr", sorted(EXPECTED))
+def test_wired_read_fails_closed_on_an_empty_table(fname, arr):
+    """`mapfile < <(jq ...)` does not propagate jq's exit status and succeeds on
+    empty input, so a missing or renamed table would yield an empty matrix and a
+    GREEN run that built nothing."""
+    text = (W / fname).read_text()
+    guard = f'[ "${{#{arr}[@]}}" -gt 0 ]'
+    assert guard in text, f"{fname}:{arr} has no non-empty guard after the mapfile"

--- a/tools/imagegen/tests/test_pytorch_config_table.py
+++ b/tools/imagegen/tests/test_pytorch_config_table.py
@@ -1,0 +1,128 @@
+"""configs/pytorch.json is the single source of truth for the pytorch matrices.
+
+The lists were duplicated verbatim across build/extend/promote-pytorch.yml — 28
+lines each — so a version bump had to land in three places and a miss was silent.
+That is the same drift hazard configs/base-image.json removed (ADR 0019).
+
+This file pins the extraction during the migration. While BOTH the table and the
+inline arrays exist, the round-trip test proves they agree: edit one without the
+other and it fails. Once every workflow reads the table, the round-trip assertions
+become unreachable (the arrays are gone) and should be deleted with them — the
+`test_no_workflow_still_hardcodes_the_lists` check below is what replaces them.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+CONFIG = REPO / "configs/pytorch.json"
+W = REPO / ".github/workflows"
+
+
+@pytest.fixture(scope="module")
+def table():
+    return json.loads(CONFIG.read_text())
+
+
+def _entries(text, arr):
+    m = re.search(rf"^\s*{arr}=\(\n(.*?)^\s*\)\s*$", text, re.S | re.M)
+    return re.findall(r'"([^"]+)"', m.group(1)) if m else None
+
+
+def _short(c):
+    """cuda_short, as extend/promote spell it: cuda_ver up to the first '-'."""
+    return c["cuda_ver"].split("-")[0]
+
+
+# --- the table is well-formed ----------------------------------------------
+
+def test_table_is_complete_and_ordered(table):
+    assert table["configs"] and table["mini"] and table["multi"]
+    assert table["default_python"] in {p for c in table["configs"] for p in c["python_versions"]}
+    for c in table["configs"]:
+        assert c["arches"], f"{c['key']} has no arches"
+        assert c["python_versions"], f"{c['key']} has no pythons"
+        assert re.fullmatch(r"\d+\.\d+\.\d+", c["torch"]), c["torch"]
+        assert c["backend"].startswith(("cu", "rocm", "cpu")), c["backend"]
+
+
+def test_every_config_key_is_unique_per_torch(table):
+    """The (torch, key) pair names the artifact; a duplicate silently drops one."""
+    seen = [(c["torch"], c["key"]) for c in table["configs"]]
+    assert len(seen) == len(set(seen)), "duplicate (torch, key) in configs"
+
+
+def test_the_backend_matches_the_cuda_base(table):
+    """cu128 on a 12.6 base would install wheels the base's CUDA cannot run. The
+    backend's minor must match the base image's."""
+    for c in table["configs"]:
+        want = c["backend"].removeprefix("cu")            # e.g. "128"
+        got = _short(c).replace(".", "")[:len(want)]      # "12.8.1" -> "128"
+        assert want == got, (
+            f"{c['torch']}/{c['key']}: backend {c['backend']} against CUDA base "
+            f"{c['cuda_ver']} — the wheel's CUDA minor must match the base's")
+
+
+# --- round-trip: the table reproduces every workflow's list exactly ---------
+
+def test_round_trip_build_configs(table):
+    have = _entries((W / "build-pytorch.yml").read_text(), "ALL_CONFIGS")
+    if have is None:
+        pytest.skip("build-pytorch.yml now reads the table")
+    want = [f"{c['torch']}|{c['key']}|{c['cuda_ver']}|{c['backend']}|"
+            f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in table["configs"]]
+    assert have == want
+
+
+def test_round_trip_build_mini(table):
+    have = _entries((W / "build-pytorch.yml").read_text(), "ALL_MINI_CONFIGS")
+    if have is None:
+        pytest.skip("build-pytorch.yml now reads the table")
+    want = [f"{c['torch']}|{c['key']}|{c['mini_base_tag']}|{c['backend']}|"
+            f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in table["mini"]]
+    assert have == want
+
+
+def test_round_trip_build_multi(table):
+    have = _entries((W / "build-pytorch.yml").read_text(), "ALL_MULTI_CONFIGS")
+    if have is None:
+        pytest.skip("build-pytorch.yml now reads the table")
+    want = [f"{c['key']}|{c['primary_torch']}|{c['primary_backend']}|{c['cuda_minor']}|"
+            f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in table["multi"]]
+    assert have == want
+
+
+def test_round_trip_extend_configs(table):
+    have = _entries((W / "extend-pytorch.yml").read_text(), "ALL_CONFIGS")
+    if have is None:
+        pytest.skip("extend-pytorch.yml now reads the table")
+    want = [f"{c['torch']}|{c['key']}|{_short(c)}|{','.join(c['arches'])}|"
+            f"{' '.join(c['python_versions'])}" for c in table["configs"]]
+    assert have == want
+
+
+def test_round_trip_promote_configs(table):
+    have = _entries((W / "promote-pytorch.yml").read_text(), "ALL_CONFIGS")
+    if have is None:
+        pytest.skip("promote-pytorch.yml now reads the table")
+    want = [f"{c['torch']}|{c['key']}|{_short(c)}|{' '.join(c['python_versions'])}"
+            for c in table["configs"]]
+    assert have == want
+
+
+# --- the end state ---------------------------------------------------------
+
+@pytest.mark.xfail(reason="migration in progress: workflows still carry inline arrays",
+                   strict=False)
+def test_no_workflow_still_hardcodes_the_lists():
+    """The goal. Flips to passing as each workflow is wired to the table; drop the
+    xfail once all three are done, and delete the round-trip tests above with the
+    arrays they check."""
+    stale = []
+    for name in ("build-pytorch.yml", "extend-pytorch.yml", "promote-pytorch.yml"):
+        t = (W / name).read_text()
+        if re.search(r"^\s*ALL_(CONFIGS|MINI_CONFIGS|MULTI_CONFIGS)=\(", t, re.M):
+            stale.append(name)
+    assert not stale, f"still hardcoding the pytorch matrices: {stale}"

--- a/tools/imagegen/tests/test_pytorch_config_table.py
+++ b/tools/imagegen/tests/test_pytorch_config_table.py
@@ -248,3 +248,36 @@ def test_wired_read_fails_closed_on_an_empty_table(fname, arr):
     text = (W / fname).read_text()
     guard = f'[ "${{#{arr}[@]}}" -gt 0 ]'
     assert guard in text, f"{fname}:{arr} has no non-empty guard after the mapfile"
+
+
+# --- the multi image's venv list must match what the Dockerfile installs ------
+#
+# 05-venv-manifest.sh asserts the image ships the venvs it should, and it gets
+# the expected set from the config table via the QA template's extra_env. That
+# only helps if the table agrees with what is actually built — otherwise the
+# check is self-consistent and wrong, which is worse than no check because it
+# reports green.
+#
+# The Dockerfile is the ground truth: /venv/main comes from the base image, and
+# each `install-torch-venv.sh <ver>` line adds /venv/torch-<ver>.
+
+def test_multi_venvs_match_the_dockerfile(table):
+    df = (REPO / "derivatives/pytorch/Dockerfile.multi-torch").read_text()
+    installed = re.findall(r"install-torch-venv\.sh\s+([0-9]+\.[0-9]+\.[0-9]+)", df)
+    assert installed, "no install-torch-venv.sh invocations found — did the Dockerfile move?"
+
+    for m in table["multi"]:
+        want = ["main"] + [f"torch-{v}" for v in installed]
+        assert m["venvs"] == want, (
+            f"{m['key']}: table says venvs={m['venvs']} but Dockerfile.multi-torch "
+            f"builds {want}. 05-venv-manifest.sh trusts the table, so a mismatch "
+            f"means the gate asserts the wrong set and passes anyway.")
+
+
+def test_every_multi_config_declares_its_venvs(table):
+    """A multi entry without `venvs` would silently pass an empty expectation to
+    05-venv-manifest.sh, which would then assert nothing — the absence-detection
+    hole it exists to close, reopened via a missing field."""
+    for m in table["multi"]:
+        assert m.get("venvs"), f"{m['key']}: no venvs declared"
+        assert "main" in m["venvs"], f"{m['key']}: venvs must include the base's main venv"

--- a/tools/imagegen/tests/test_pytorch_config_table.py
+++ b/tools/imagegen/tests/test_pytorch_config_table.py
@@ -195,9 +195,15 @@ EXPECTED = {
     ("build-pytorch.yml", "ALL_MINI_CONFIGS"): lambda T: [
         f"{c['torch']}|{c['key']}|{c['mini_base_tag']}|{c['backend']}|"
         f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in T["mini"]],
+    # build-pytorch alone carries a 7th field: the SUPPLEMENTARY venv versions,
+    # derived from .venvs by dropping "main" and stripping the "torch-" prefix.
+    # Only the build needs it (it becomes EXTRA_TORCH_VERSIONS); extend and
+    # promote never install anything, so they do not carry it.
     ("build-pytorch.yml", "ALL_MULTI_CONFIGS"): lambda T: [
         f"{c['key']}|{c['primary_torch']}|{c['primary_backend']}|{c['cuda_minor']}|"
-        f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}" for c in T["multi"]],
+        f"{','.join(c['arches'])}|{' '.join(c['python_versions'])}|"
+        f"{' '.join(v.removeprefix('torch-') for v in c['venvs'] if v != 'main')}"
+        for c in T["multi"]],
     ("extend-pytorch.yml", "ALL_CONFIGS"): lambda T: [
         f"{c['torch']}|{c['key']}|{_short2(c)}|{','.join(c['arches'])}|"
         f"{' '.join(c['python_versions'])}" for c in T["configs"]],
@@ -261,17 +267,53 @@ def test_wired_read_fails_closed_on_an_empty_table(fname, arr):
 # The Dockerfile is the ground truth: /venv/main comes from the base image, and
 # each `install-torch-venv.sh <ver>` line adds /venv/torch-<ver>.
 
-def test_multi_venvs_match_the_dockerfile(table):
+def test_the_dockerfile_no_longer_hardcodes_venv_versions():
+    """The venv list moved from Dockerfile.multi-torch into the config table on
+    2026-08-11, so variants are a data change. Re-hardcoding a version here
+    would silently make the table non-authoritative: the QA manifest test would
+    still check the table, the build would install something else, and the two
+    would disagree with nothing reporting it."""
     df = (REPO / "derivatives/pytorch/Dockerfile.multi-torch").read_text()
-    installed = re.findall(r"install-torch-venv\.sh\s+([0-9]+\.[0-9]+\.[0-9]+)", df)
-    assert installed, "no install-torch-venv.sh invocations found — did the Dockerfile move?"
+    hardcoded = re.findall(r"install-torch-venv\.sh\s+([0-9]+\.[0-9]+\.[0-9]+)", df)
+    assert not hardcoded, (
+        f"Dockerfile.multi-torch hardcodes torch {hardcoded}. Supplementary "
+        f"versions must come from EXTRA_TORCH_VERSIONS, which the build derives "
+        f"from configs/pytorch.json .multi[].venvs.")
+    assert "EXTRA_TORCH_VERSIONS" in df, "the build arg the versions arrive by is gone"
 
-    for m in table["multi"]:
-        want = ["main"] + [f"torch-{v}" for v in installed]
-        assert m["venvs"] == want, (
-            f"{m['key']}: table says venvs={m['venvs']} but Dockerfile.multi-torch "
-            f"builds {want}. 05-venv-manifest.sh trusts the table, so a mismatch "
-            f"means the gate asserts the wrong set and passes anyway.")
+
+def test_every_multi_venv_has_a_companions_entry():
+    """install-torch-venv.sh looks each version up in torch-companions.json with
+    the same `error("version not found")` jq as the main build, so a venv version
+    with no entry kills the multi build at exit 5 — the failure that cost a CI
+    run on the config side."""
+    comp = set(json.loads((REPO / "derivatives/pytorch/torch-companions.json").read_text()))
+    for m in TABLE_MULTI():
+        for v in (x.removeprefix("torch-") for x in m["venvs"] if x != "main"):
+            assert v in comp, (
+                f"{m['key']}: venv torch {v} has no torch-companions.json entry; "
+                f"the multi build would fail with `jq: error: version not found`")
+
+
+def test_multi_primary_matches_its_declared_main_venv():
+    """`main` is the base image's own venv, so it IS primary_torch. If they
+    disagreed, 05-venv-manifest.sh would pass (it only checks names) while the
+    image contained a different torch than the table claims."""
+    for m in TABLE_MULTI():
+        assert "main" in m["venvs"], f"{m['key']}: venvs must include main"
+
+
+def test_multi_variants_have_distinct_keys_and_venv_sets():
+    """Two variants with the same key would overwrite each other's tags; two
+    with the same venv set are the same image built twice."""
+    keys = [m["key"] for m in TABLE_MULTI()]
+    assert len(keys) == len(set(keys)), f"duplicate multi keys: {keys}"
+    sets = [tuple(m["venvs"]) + (m["primary_backend"],) for m in TABLE_MULTI()]
+    assert len(sets) == len(set(sets)), "two multi variants describe the same image"
+
+
+def TABLE_MULTI():
+    return json.loads(CONFIG.read_text())["multi"]
 
 
 def test_every_multi_config_declares_its_venvs(table):

--- a/tools/imagegen/tests/test_pytorch_version_lifecycle.py
+++ b/tools/imagegen/tests/test_pytorch_version_lifecycle.py
@@ -1,0 +1,161 @@
+"""The torch version lifecycle policy, enforced (ADR 0022).
+
+Two rules decide what the pytorch build matrix carries:
+
+  1. ONE PATCH PER MINOR — the newest we have adopted. A new patch supersedes
+     the old one in place rather than sitting alongside it. This was an implicit
+     convention long before it was written down (the table has always carried
+     2.7.1 and not 2.7.0, 2.9.1 and not 2.9.0); it was noticed only when adding
+     2.12.1 alongside 2.12.0 broke it.
+
+  2. SUPPORT FLOOR — the oldest torch minor that any derivative in this repo
+     pins. Anything below it is retired: we stop minting new dated tags for it.
+
+Rule 2 is deliberately derived rather than a hand-set number. A "keep the last
+N minors" rule would have retired 2.7, which five derivative images pin, while
+keeping 2.8, which nothing uses. Consumption is the thing that matters, so
+consumption sets the floor — and the floor rises on its own as derivatives move
+forward, with no one having to remember to raise it.
+
+RETIREMENT IS NOT DELETION. Every dated tag already published stays pullable
+forever. Retiring a version only stops new ones being minted, so nothing a user
+already runs can break.
+
+THE DIRECTION THAT ACTUALLY BITES is not "we kept something too long" — that is
+merely wasteful. It is retiring a version something still depends on, which
+breaks a derivative build with no warning. test_no_pinned_version_is_retired is
+the one that must never be weakened.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+TABLE = json.loads((REPO / "configs/pytorch.json").read_text())
+
+vkey = lambda v: [int(x) for x in v.split(".")]
+minor = lambda v: ".".join(v.split(".")[:2])
+mkey = lambda m: [int(x) for x in m.split(".")]
+
+
+def pinned_minors() -> dict[str, list[str]]:
+    """{torch minor: [who pins it]} across derivative Dockerfiles and workflows.
+
+    Read from the files rather than a list, so the floor tracks reality. A pin
+    added or bumped anywhere changes what this test permits, in the same commit.
+    """
+    out: dict[str, list[str]] = defaultdict(list)
+    globs = ("derivatives/pytorch/derivatives/*/Dockerfile",
+             ".github/workflows/build-*.yml")
+    for pat in globs:
+        for f in sorted(REPO.glob(pat)):
+            text = f.read_text(encoding="utf-8", errors="replace")
+            for ver, _be in re.findall(r"vastai/pytorch:([0-9.]+)-([a-z0-9]+)-cuda", text):
+                out[minor(ver)].append(f.name if f.name != "Dockerfile" else f.parent.name)
+    # the multi image is built ON a mini of its primary torch
+    out[minor(TABLE["multi"][0]["primary_torch"])].append("multi-torch base")
+    return out
+
+
+def support_floor() -> str:
+    pins = pinned_minors()
+    assert pins, "no derivative pins found — the floor would be undefined"
+    return min(pins, key=mkey)
+
+
+def table_minors() -> list[str]:
+    return sorted({minor(c["torch"]) for c in TABLE["configs"]}, key=mkey)
+
+
+# --- rule 1: one patch per minor -------------------------------------------
+
+def test_each_minor_line_carries_exactly_one_patch():
+    """Two patches of one minor doubles the artifacts and the QA cells for a
+    version pair that differs by a bugfix. It also makes "which 2.12 do I get"
+    ambiguous for anyone reading the tag list."""
+    by_minor: dict[str, set[str]] = defaultdict(set)
+    for c in TABLE["configs"]:
+        by_minor[minor(c["torch"])].add(c["torch"])
+    for m, patches in sorted(by_minor.items()):
+        assert len(patches) == 1, (
+            f"minor {m} carries {sorted(patches, key=vkey)}. A new patch must "
+            f"SUPERSEDE the old one, not sit beside it.")
+
+
+def test_mini_and_config_agree_on_the_patch():
+    """A mini built from a different patch than its config sibling would ship a
+    torch version no config image corresponds to — invisible until someone
+    compared two tag lists by hand."""
+    cfg = {minor(c["torch"]): c["torch"] for c in TABLE["configs"]}
+    for m in TABLE["mini"]:
+        want = cfg.get(minor(m["torch"]))
+        assert want is not None, f"mini {m['torch']}/{m['key']} has no config sibling"
+        assert m["torch"] == want, (
+            f"mini carries {m['torch']} but the config for that minor is {want}")
+
+
+# --- rule 2: the support floor ---------------------------------------------
+
+def test_nothing_below_the_support_floor_is_still_built():
+    floor = support_floor()
+    stale = [m for m in table_minors() if mkey(m) < mkey(floor)]
+    assert not stale, (
+        f"minor(s) {stale} are below the support floor {floor} (the oldest "
+        f"version any derivative pins) and should be retired. Existing dated "
+        f"tags stay pullable; only new ones stop.")
+
+
+def test_no_pinned_version_is_retired():
+    """THE safety property. Retiring a version a derivative still pins breaks
+    that derivative's build at its next run, with no warning and no obvious
+    cause. This is the direction that must never be weakened."""
+    have = set(table_minors())
+    missing = {m: who for m, who in pinned_minors().items() if m not in have}
+    assert not missing, (
+        "these torch minors are pinned but no longer built: "
+        + "; ".join(f"{m} (pinned by {', '.join(sorted(set(who)))})"
+                    for m, who in sorted(missing.items()))
+        + ". Bump the pins first, THEN retire.")
+
+
+def test_the_floor_is_derived_from_real_pins_not_a_constant():
+    """Guard the guard. If the pin extraction silently stopped matching, the
+    floor would collapse and every rule above would pass vacuously."""
+    pins = pinned_minors()
+    assert len(pins) >= 2, f"only found pins for {sorted(pins)} — extraction has rotted"
+    assert all(who for who in pins.values()), "a pinned minor with no named source"
+
+
+def test_the_floor_is_actually_load_bearing():
+    """The floor should be doing work: if it sat below everything in the table
+    it would permit anything, and its passing would mean nothing."""
+    floor, ms = support_floor(), table_minors()
+    assert floor in ms, f"support floor {floor} is not itself built — pins point at nothing"
+
+
+# --- the retired set stays retired -----------------------------------------
+
+RETIRED = {"2.6"}   # ADR 0022; extend deliberately, never silently
+
+
+@pytest.mark.parametrize("m", sorted(RETIRED))
+def test_a_retired_minor_does_not_come_back_by_accident(m):
+    """Re-adding a retired version should be a decision with a reason, not the
+    side effect of copying a nearby table entry."""
+    assert m not in table_minors(), (
+        f"torch {m} was retired (ADR 0022) but is in the table again. If that "
+        f"is intended, remove it from RETIRED here and say why in the ADR.")
+
+
+def test_retired_minors_are_genuinely_unused():
+    """A retired version that something still pins is the bug this whole file
+    exists to prevent; assert it from the retired side too."""
+    pins = pinned_minors()
+    clash = {m: pins[m] for m in RETIRED if m in pins}
+    assert not clash, f"retired minors are still pinned: {clash}"

--- a/tools/imagegen/tests/test_pytorch_version_lifecycle.py
+++ b/tools/imagegen/tests/test_pytorch_version_lifecycle.py
@@ -220,3 +220,60 @@ def test_every_companions_entry_is_well_formed():
             # also accept a hypothetical 0.50.0. Prefer X.Y.Z in new entries.
             assert re.fullmatch(r"\d+\.\d+(\.\d+)?", pin), \
                 f"{ver}/{pkg}: pin {pin!r} is not X.Y or X.Y.Z"
+
+
+# --- rule 3: a backend must be reachable (ADR 0022, added 2026-08-12) ------
+#
+# Rules 1 and 2 govern torch VERSIONS. This is the other axis, and the gap was
+# found the expensive way: cu129 failed QA on Blackwell hardware, and the obvious
+# question — what does cu129 actually serve? — turned out to be "nothing". No
+# auto tag (cuda-12.9.2-auto has always pointed at cu128), no mini, no derivative
+# pin. It had also just been brought current from torch 2.8.0 to 2.13.0 on the
+# reasoning that it should not be an anomaly, which added 15 images nothing
+# points at.
+
+WORKFLOW = REPO / ".github/workflows/promote-pytorch.yml"
+
+
+def mapped_backends() -> set[str]:
+    """Backends an `-auto` tag points at, read from AUTO_TAG_MAP itself."""
+    body = WORKFLOW.read_text(encoding="utf-8")
+    blk = body[body.index("AUTO_TAG_MAP=("):]
+    blk = blk[:blk.index(")")]
+    return {m[1] for m in re.findall(r'"([^"|]+)\|([^"]+)"', blk)}
+
+
+def test_the_auto_tag_map_is_readable_for_the_backend_rule():
+    """Guard the guard: an empty map would make the rule below vacuous."""
+    assert len(mapped_backends()) >= 3, f"parsed only {mapped_backends()}"
+
+
+def test_every_built_backend_is_reachable():
+    """A backend with no auto tag, no mini and no derivative pin builds
+    artifacts nobody can arrive at except by typing a dated tag by hand."""
+    built = {c["key"] for c in TABLE["configs"]}
+    minis = {m["backend"] for m in TABLE["mini"]}
+    pinned = set()
+    for pat in ("derivatives/pytorch/derivatives/*/Dockerfile",
+                ".github/workflows/build-*.yml"):
+        for f in sorted(REPO.glob(pat)):
+            for _v, b in re.findall(r"vastai/pytorch:([0-9.]+)-([a-z0-9]+)-cuda",
+                                    f.read_text(encoding="utf-8", errors="replace")):
+                pinned.add(b)
+    reachable = mapped_backends() | minis | pinned
+    orphans = sorted(built - reachable)
+    assert not orphans, (
+        f"backend(s) {orphans} build images but nothing points at them: no "
+        f"-auto tag, no mini, no derivative pin. Retire them (ADR 0022 rule 3) "
+        f"or give them a consumer.")
+
+
+RETIRED_BACKENDS = {"cu129"}   # ADR 0022; extend deliberately
+
+
+@pytest.mark.parametrize("b", sorted(RETIRED_BACKENDS))
+def test_a_retired_backend_does_not_come_back_by_accident(b):
+    assert b not in {c["key"] for c in TABLE["configs"]}, (
+        f"backend {b} was retired (ADR 0022) but is in the table again. If that "
+        f"is intended, remove it from RETIRED_BACKENDS and say why in the ADR.")
+    assert b not in {m["backend"] for m in TABLE["mini"]}

--- a/tools/imagegen/tests/test_pytorch_version_lifecycle.py
+++ b/tools/imagegen/tests/test_pytorch_version_lifecycle.py
@@ -159,3 +159,64 @@ def test_retired_minors_are_genuinely_unused():
     pins = pinned_minors()
     clash = {m: pins[m] for m in RETIRED if m in pins}
     assert not clash, f"retired minors are still pinned: {clash}"
+
+
+# --- the SECOND source of truth: torch-companions.json ---------------------
+#
+# Found the hard way. Adding a version to configs/pytorch.json is NOT enough:
+# the Dockerfile also reads derivatives/pytorch/torch-companions.json to pin
+# torchvision/torchcodec/etc, via
+#
+#     jq '... if .[$v] == null then error("version not found") ...'
+#
+# so a missing entry fails the BUILD with jq exit code 5 and the message
+# "jq: error: version not found" — after pulling the base image, and with
+# nothing pointing at the file that is actually wrong. It cost a real CI run to
+# find, on a version added the same day.
+#
+# Two files that must agree and no check that they do is exactly the drift the
+# config-table extraction was done to remove, so it is checked here.
+
+COMPANIONS = json.loads((REPO / "derivatives/pytorch/torch-companions.json").read_text())
+
+
+def test_every_built_torch_version_has_a_companions_entry():
+    """THE assertion. Missing => the build dies late with an opaque jq error."""
+    want = {c["torch"] for c in TABLE["configs"]} | {m["torch"] for m in TABLE["mini"]}
+    want |= {u["primary_torch"] for u in TABLE["multi"]}
+    missing = sorted(want - set(COMPANIONS), key=vkey)
+    assert not missing, (
+        f"torch {missing} are in configs/pytorch.json but not in "
+        f"torch-companions.json. The build will fail with `jq: error: version "
+        f"not found` (exit 5) after pulling the base image.")
+
+
+def test_companions_has_no_entries_for_versions_we_no_longer_build():
+    """The other direction. A stale entry is harmless to the build but it is a
+    lie about what is supported, and it is how a retired version quietly looks
+    live to whoever reads this file next."""
+    built = {c["torch"] for c in TABLE["configs"]} | {m["torch"] for m in TABLE["mini"]}
+    stale = sorted(set(COMPANIONS) - built, key=vkey)
+    assert not stale, (
+        f"torch-companions.json still carries {stale}, which nothing builds. "
+        f"Remove them when retiring a version (ADR 0022).")
+
+
+def test_every_companions_entry_is_well_formed():
+    """A typo'd key produces a confusing runtime failure rather than a clear one:
+    `.packages` missing makes the jq emit nothing, so PACKAGES is just `torch==X`
+    and the companions are silently NOT installed — the image ships without
+    torchvision and every test that imports it fails much later."""
+    for ver, entry in sorted(COMPANIONS.items(), key=lambda kv: vkey(kv[0])):
+        assert isinstance(entry.get("packages"), dict) and entry["packages"], \
+            f"{ver}: no non-empty .packages — companions would silently not install"
+        assert isinstance(entry.get("amd64_only", []), list), f"{ver}: amd64_only not a list"
+        for pkg, pin in entry["packages"].items():
+            # X.Y is tolerated because 2.7.1 pins torchcodec "0.5" and that
+            # version is consumed by five derivatives — tightening it is a
+            # separate, riskier change. Noting the consequence rather than
+            # silently accepting it: the Dockerfile verifies the install with a
+            # PREFIX match (`[[ "${actual}" == "${ver}"* ]]`), so "0.5" would
+            # also accept a hypothetical 0.50.0. Prefer X.Y.Z in new entries.
+            assert re.fullmatch(r"\d+\.\d+(\.\d+)?", pin), \
+                f"{ver}/{pkg}: pin {pin!r} is not X.Y or X.Y.Z"

--- a/tools/template_manager/tests/test_pytorch_qa_coverage.py
+++ b/tools/template_manager/tests/test_pytorch_qa_coverage.py
@@ -1,0 +1,280 @@
+"""The pytorch QA matrix covers every mini artifact the build produces.
+
+ADR 0021 cond 7. The gated set is DERIVED from the config table, never
+hand-maintained: a cell list written by hand is correct on the day it is written
+and silently wrong at the next table edit, which is the exact drift the
+config-table extraction was done to remove.
+
+The assertion is EQUALITY, not containment. Containment would let a new mini
+config or a new python enter the build without entering the gate — the artifact
+would ship untested while the matrix still looked complete, because nothing
+names what is missing.
+
+These tests execute the workflow's own jq against the real table rather than
+re-implementing the selection in Python. A reimplementation would be a second
+copy of the rule, and the two would agree right up until the moment one of them
+was wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[3]
+TABLE = json.loads((REPO / "configs/pytorch.json").read_text())
+WORKFLOW = REPO / ".github/workflows/promote-pytorch.yml"
+
+pytestmark = pytest.mark.skipif(shutil.which("jq") is None, reason="jq not available")
+
+
+def _plan_step() -> str:
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    for s in wf["jobs"]["resolve-digests"]["steps"]:
+        if s.get("id") == "plan":
+            return s["run"]
+    raise AssertionError("resolve-digests has no `plan` step")
+
+
+def _jq_matrix_program() -> str:
+    """The jq program the workflow uses to turn the manifest into a matrix.
+
+    Extracted from the step rather than copied, so this test breaks if the
+    selection rule changes — which is the point of testing it at all.
+    """
+    body = _plan_step()
+    start = body.index("jq -c --arg dpy")
+    prog = body[body.index("'", start) + 1:]
+    return prog[:prog.index("' manifest.json")]
+
+
+def _fake_manifest() -> dict:
+    """A manifest as resolve-digests would build it if every staging tag existed.
+
+    Digests are synthetic and unique per artifact; only their presence and
+    distinctness matter to the selection.
+    """
+    m = {"configs": [], "mini": [], "multi": []}
+    for c in TABLE["configs"]:
+        m["configs"].append({
+            "torch": c["torch"], "key": c["key"],
+            "cuda_short": c["cuda_ver"].split("-")[0],
+            "digests": {f"py{p}": f"sha256:cfg-{c['torch']}-{c['key']}-{p}"
+                        for p in c["python_versions"]},
+        })
+    for c in TABLE["mini"]:
+        minor = c["mini_base_tag"].removeprefix("cuda-").removesuffix("-mini")
+        m["mini"].append({
+            "torch": c["torch"], "key": c["key"], "backend": c["backend"],
+            "cuda_minor": minor,
+            "digests": {f"py{p}": f"sha256:mini-{c['torch']}-{c['key']}-{p}"
+                        for p in c["python_versions"]},
+        })
+    for c in TABLE["multi"]:
+        m["multi"].append({
+            "key": c["key"], "cuda_minor": c["cuda_minor"],
+            "venvs": " ".join(c["venvs"]),
+            "digests": {f"py{p}": f"sha256:multi-{c['key']}-{p}"
+                        for p in c["python_versions"]},
+        })
+    return m
+
+
+def build_matrix(tmp_path: Path, manifest: dict | None = None) -> list[dict]:
+    man = tmp_path / "manifest.json"
+    man.write_text(json.dumps(manifest if manifest is not None else _fake_manifest()))
+    out = subprocess.run(
+        ["jq", "-c", "--arg", "dpy", f"py{TABLE['default_python']}",
+         _jq_matrix_program(), str(man)],
+        capture_output=True, text=True, check=True)
+    return json.loads(out.stdout)
+
+
+# --- the equality that ADR 0021 cond 7 requires ----------------------------
+
+def test_every_mini_artifact_the_build_produces_is_gated(tmp_path):
+    """THE assertion. Not containment: a mini artifact absent from the matrix
+    ships untested, and nothing else in the system would name it."""
+    cells = build_matrix(tmp_path)
+    gated = {c["cell"] for c in cells if c["kind"] == "mini"}
+    expected = {f"mini-{c['torch']}-{c['key']}-py{p}"
+                for c in TABLE["mini"] for p in c["python_versions"]}
+    assert gated == expected, (
+        f"gate/build mismatch — ungated: {sorted(expected - gated)}; "
+        f"gated but not built: {sorted(gated - expected)}")
+
+
+def test_the_mini_count_is_every_python_of_every_config(tmp_path):
+    """Guards against a selection that silently collapses to default python —
+    the sampling shape ADR 0021 rejected, which would still satisfy a
+    per-config check."""
+    cells = build_matrix(tmp_path)
+    want = sum(len(c["python_versions"]) for c in TABLE["mini"])
+    got = len([c for c in cells if c["kind"] == "mini"])
+    assert got == want, f"{got} mini cells for {want} mini artifacts"
+
+
+def test_a_new_python_in_the_table_enters_the_gate(tmp_path):
+    """The drift this exists to catch, simulated: adding a python to a mini
+    config must produce a cell without anyone editing a cell list."""
+    man = _fake_manifest()
+    man["mini"][0]["digests"]["py315"] = "sha256:mini-new-python"
+    cells = build_matrix(tmp_path, man)
+    assert any(c["cell"].endswith("-py315") for c in cells if c["kind"] == "mini"), \
+        "a new python appeared in the build and produced no QA cell"
+
+
+def test_a_new_mini_config_enters_the_gate(tmp_path):
+    man = _fake_manifest()
+    man["mini"].append({"torch": "9.9.9", "key": "cu999-mini", "backend": "cu999",
+                        "cuda_minor": "99.9",
+                        "digests": {"py312": "sha256:mini-brand-new"}})
+    cells = build_matrix(tmp_path, man)
+    assert any("9.9.9" in c["cell"] for c in cells), \
+        "a new mini config appeared in the build and produced no QA cell"
+
+
+# --- the auto surface is the POINTER surface, not every config -------------
+
+def test_the_auto_cells_are_one_per_backend_at_default_python(tmp_path):
+    """8 -auto tags resolve to 3 distinct images. Gating all 17 configs would
+    certify artifacts no pointer points at; gating fewer than one per backend
+    would leave a pointer surface untested."""
+    cells = build_matrix(tmp_path)
+    auto = [c for c in cells if c["kind"] == "auto"]
+    backends = {c["key"] for c in TABLE["configs"]}
+    assert {c["cell"] for c in auto} == {f"auto-{b}" for b in backends}
+
+
+def test_each_auto_cell_tests_the_newest_torch_for_its_backend(tmp_path):
+    """The -auto tag resolves to the newest torch carrying that backend, so
+    testing any older one would certify bits the tag does not serve. Version
+    comparison must be NUMERIC — a lexical max makes 2.9.1 beat 2.12.0."""
+    cells = {c["cell"]: c for c in build_matrix(tmp_path) if c["kind"] == "auto"}
+    for backend in {c["key"] for c in TABLE["configs"]}:
+        torches = [c["torch"] for c in TABLE["configs"] if c["key"] == backend]
+        newest = max(torches, key=lambda v: [int(x) for x in v.split(".")])
+        assert cells[f"auto-{backend}"]["describe"].startswith(newest + "-"), (
+            f"{backend}: gated {cells[f'auto-{backend}']['describe']}, "
+            f"but the auto tag serves torch {newest}")
+
+
+def test_the_lexical_version_trap_is_actually_avoided(tmp_path):
+    """Explicit regression for the above: with 2.9.1 and 2.12.0 both present on
+    a backend, a string max picks 2.9.1. Both are in the real table today, so
+    this would be a live defect rather than a hypothetical one."""
+    cells = {c["cell"]: c for c in build_matrix(tmp_path) if c["kind"] == "auto"}
+    cu130 = [c["torch"] for c in TABLE["configs"] if c["key"] == "cu130"]
+    assert "2.9.1" in cu130 and "2.12.0" in cu130, "table changed; revisit this test"
+    assert cells["auto-cu130"]["describe"].startswith("2.12.0-")
+
+
+# --- multi -----------------------------------------------------------------
+
+def test_the_multi_alias_is_gated_and_declares_its_venvs(tmp_path):
+    """multi carries the family's only non-auto mutable tag and is the AIO
+    studio base. Its venv list is what makes a MISSING venv detectable —
+    05-venv-manifest.sh has nothing to compare against without it."""
+    cells = [c for c in build_matrix(tmp_path) if c["kind"] == "multi"]
+    assert cells, "the multi alias is not gated"
+    for c in cells:
+        assert c["venvs"].split() == TABLE["multi"][0]["venvs"]
+        assert len(c["venvs"].split()) > 1, "a multi image with one venv is not multi"
+
+
+def test_single_venv_cells_still_declare_an_expectation(tmp_path):
+    """A cell with an empty EXPECTED_TORCH_VENVS makes 05-venv-manifest.sh skip,
+    turning a required test into a guaranteed red (or, worse, a silent gap)."""
+    for c in build_matrix(tmp_path):
+        assert c["venvs"].strip(), f"{c['cell']} declares no expected venvs"
+
+
+# --- cells must be usable as identifiers -----------------------------------
+
+def test_cell_names_are_unique(tmp_path):
+    """Cell names become matrix keys, evidence artifact names and registry tags.
+    A collision would silently overwrite one cell's evidence with another's, and
+    qa-summary would report a verdict for an artifact that was never tested."""
+    cells = [c["cell"] for c in build_matrix(tmp_path)]
+    dupes = {c for c in cells if cells.count(c) > 1}
+    assert not dupes, f"duplicate cell names: {sorted(dupes)}"
+
+
+def test_cell_names_are_valid_registry_tags(tmp_path):
+    """Each becomes `qa-<run_id>-<cell>`. A tag may hold [A-Za-z0-9_.-] and is
+    limited to 128 chars; an invalid one fails at crane copy, after the plan is
+    already built."""
+    import re
+    for c in build_matrix(tmp_path):
+        tag = f"qa-99999999999-{c['cell']}"
+        assert re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9._-]*", tag), f"invalid tag: {tag}"
+        assert len(tag) <= 128, f"tag too long ({len(tag)}): {tag}"
+
+
+def test_an_artifact_missing_from_staging_produces_no_cell(tmp_path):
+    """Fail-safe direction: an empty digest means the staging tag does not
+    exist, and renting a box to test nothing would burn money and then report a
+    confusing red. The promote job fails on the missing source separately."""
+    man = _fake_manifest()
+    man["mini"][0]["digests"]["py310"] = ""
+    cells = build_matrix(tmp_path, man)
+    gone = f"mini-{TABLE['mini'][0]['torch']}-{TABLE['mini'][0]['key']}-py310"
+    assert gone not in {c["cell"] for c in cells}
+
+
+# --- the auto cells must track the POINTER MAP, not a proxy for it ---------
+#
+# The gated auto set is derived from the config table's backends. The thing that
+# actually decides customer exposure is AUTO_TAG_MAP in the promote job, which
+# maps each `cuda-X.Y.Z-auto` tag to a backend. Those two agree today but nothing
+# made them agree — and a new `-auto` tag pointing at a backend the gate does not
+# cover would put an untested image on a customer-facing pointer.
+#
+# Measured 2026-08-10: the table builds 4 backends (cu126, cu128, cu129, cu130);
+# AUTO_TAG_MAP references 3. cu129 is promoted but carries no auto tag, so it is
+# gated as ordinary coverage rather than as pointer surface. That direction is
+# safe. The reverse — a mapped backend with no cell — is not.
+
+def _auto_tag_map() -> dict[str, str]:
+    """{auto tag: backend} as the promote job actually defines it."""
+    import re
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    body = "\n".join(s.get("run", "") for s in wf["jobs"]["promote"]["steps"])
+    block = body[body.index("AUTO_TAG_MAP=("):]
+    block = block[:block.index(")")]
+    return dict(re.findall(r'"([^"|]+)\|([^"]+)"', block))
+
+
+def test_the_auto_tag_map_is_readable():
+    """Guard the guard: if the extraction breaks, the test below passes over an
+    empty map and asserts nothing."""
+    m = _auto_tag_map()
+    assert len(m) >= 3, f"only parsed {m} from AUTO_TAG_MAP"
+    assert all(t.endswith("-auto") for t in m), m
+
+
+def test_every_backend_an_auto_tag_points_at_is_gated(tmp_path):
+    """THE pointer-surface assertion. An auto tag whose backend has no cell would
+    serve customers an image this gate never booted."""
+    gated = {c["cell"].removeprefix("auto-")
+             for c in build_matrix(tmp_path) if c["kind"] == "auto"}
+    mapped = set(_auto_tag_map().values())
+    assert mapped <= gated, (
+        f"auto tags point at backend(s) with no QA cell: {sorted(mapped - gated)}. "
+        f"Those tags would move to an image this run never tested.")
+
+
+def test_backends_without_an_auto_tag_are_still_gated(tmp_path):
+    """cu129 today. It is promoted as dated tags, so it ships; it simply has no
+    pointer. Gating it is the deliberate choice — the same reasoning that put
+    mini in scope, since 'no auto tag' is not 'no consumer'."""
+    gated = {c["cell"].removeprefix("auto-")
+             for c in build_matrix(tmp_path) if c["kind"] == "auto"}
+    table_backends = {c["key"] for c in TABLE["configs"]}
+    assert gated == table_backends, (
+        f"gate covers {sorted(gated)} but the table builds {sorted(table_backends)}")

--- a/tools/template_manager/tests/test_pytorch_qa_coverage.py
+++ b/tools/template_manager/tests/test_pytorch_qa_coverage.py
@@ -83,6 +83,7 @@ def _fake_manifest() -> dict:
             # program pass the test and fail in CI.
             "venvs": " ".join(c["venvs"]),
             "primary_torch": c["primary_torch"],
+            "primary_backend": c["primary_backend"],
             "digests": {f"py{p}": f"sha256:multi-{c['key']}-{p}"
                         for p in c["python_versions"]},
         })
@@ -386,3 +387,78 @@ def test_no_cell_requires_the_multi_gpu_collectives_matrix(tmp_path):
     requiring it would fail all of them."""
     for c in build_matrix(tmp_path):
         assert "41-nccl-collectives" not in c["require_tests"], c["cell"]
+
+
+# --- the architecture ceiling (run 31591093625) ----------------------------
+#
+# cuda_max_good bounds the host DRIVER from below. Nothing bounded the GPU
+# ARCHITECTURE from above, so cu126 cells rented Blackwell cards (sm_120) whose
+# wheels contain no kernels for them: cudaErrorNoKernelImageForDevice, torch
+# matmul and conv2d failing, reproducible across six different RTX 5070 offers.
+# The image was fine — it was being tested on hardware it is never served,
+# because a Blackwell host needs a 12.8+ driver and so is never matched by the
+# 12.x auto tags that point at cu126.
+
+BLACKWELL_LESS = {"cu126"}      # backends whose wheels stop at sm_90
+
+
+def _backend_of(cell):
+    if cell["kind"] == "auto":
+        return cell["cell"].removeprefix("auto-")
+    for b in ("cu126", "cu128", "cu129", "cu130", "cu132"):
+        if f"-{b}-" in cell["describe"] or cell["describe"].startswith(f"{b}-"):
+            return b
+    return None
+
+
+def test_cu126_cells_cap_the_gpu_architecture(tmp_path):
+    for c in build_matrix(tmp_path):
+        if _backend_of(c) in BLACKWELL_LESS:
+            assert "compute_cap.lte=900" in c["cap"], (
+                f"{c['cell']} can rent a Blackwell card its wheels have no "
+                f"kernels for — the failure looks like a bad image and is not")
+
+
+def test_blackwell_capable_backends_are_not_capped(tmp_path):
+    """The cap costs offers, so it must not spread to backends that do not need
+    it. cu128 was the first with Blackwell kernels."""
+    for c in build_matrix(tmp_path):
+        b = _backend_of(c)
+        if b and b not in BLACKWELL_LESS:
+            assert c["cap"] == "", f"{c['cell']} ({b}) is capped but supports Blackwell"
+
+
+def test_the_cap_is_a_tightening_not_a_widening(tmp_path):
+    """create.py's --set-filter is raise-only: `lte` lowers a ceiling, which
+    tightens. A `gte` here would try to WIDEN and be rejected at rent time —
+    after the plan is built."""
+    for c in build_matrix(tmp_path):
+        if c["cap"]:
+            assert ".lte=" in c["cap"], f"{c['cell']}: cap {c['cap']!r} does not tighten"
+
+
+def test_every_cell_declares_a_cap_field(tmp_path):
+    """Absent would interpolate as the literal string 'null' into set_filters
+    and fail create.py's parser at rent time."""
+    for c in build_matrix(tmp_path):
+        assert "cap" in c and isinstance(c["cap"], str), c["cell"]
+
+
+def test_set_filters_concatenation_is_well_formed(tmp_path):
+    """The workflow builds `cuda_max_good.gte=X${cap}` and the gate splits on
+    whitespace. A missing leading space would glue the two filters together."""
+    for c in build_matrix(tmp_path):
+        spec = f"cuda_max_good.gte={c['floor']}{c['cap']}"
+        parts = spec.split()
+        assert all("=" in p and "." in p.split("=")[0] for p in parts), spec
+        assert len(parts) == (2 if c["cap"] else 1), spec
+
+
+# --- cu129 is retired ------------------------------------------------------
+
+def test_cu129_is_gone(tmp_path):
+    """Retired: no auto tag, no mini, no derivative pin — it served nothing, and
+    its torchvision has no Blackwell kernels either. Its torch versions all
+    remain on other backends."""
+    assert "cu129" not in {c["key"] for c in TABLE["configs"]}
+    assert all("cu129" not in c["cell"] for c in build_matrix(tmp_path))

--- a/tools/template_manager/tests/test_pytorch_qa_coverage.py
+++ b/tools/template_manager/tests/test_pytorch_qa_coverage.py
@@ -205,10 +205,17 @@ def test_the_multi_alias_is_gated_and_declares_its_venvs(tmp_path):
     studio base. Its venv list is what makes a MISSING venv detectable —
     05-venv-manifest.sh has nothing to compare against without it."""
     cells = [c for c in build_matrix(tmp_path) if c["kind"] == "multi"]
-    assert cells, "the multi alias is not gated"
+    assert cells, "no multi variant is gated"
+    # EVERY variant, matched by key — not TABLE["multi"][0]. The single-variant
+    # assumption held until 2026-08-11, when cu130 and cu132 variants were added;
+    # indexing [0] would have silently checked one and ignored the rest.
+    by_key = {m["key"]: m for m in TABLE["multi"]}
+    assert len(cells) == len(by_key), (
+        f"{len(cells)} multi cells for {len(by_key)} variants — a variant is ungated")
     for c in cells:
-        assert c["venvs"].split() == TABLE["multi"][0]["venvs"]
-        assert len(c["venvs"].split()) > 1, "a multi image with one venv is not multi"
+        key = next(k for k in by_key if c["cell"].startswith(f"multi-{k}-py"))
+        assert c["venvs"].split() == by_key[key]["venvs"], f"{key}: venv list mismatch"
+        assert len(c["venvs"].split()) > 1, f"{key}: one venv is not a multi image"
 
 
 def test_single_venv_cells_still_declare_an_expectation(tmp_path):

--- a/tools/template_manager/tests/test_pytorch_qa_coverage.py
+++ b/tools/template_manager/tests/test_pytorch_qa_coverage.py
@@ -165,13 +165,37 @@ def test_each_auto_cell_tests_the_newest_torch_for_its_backend(tmp_path):
 
 
 def test_the_lexical_version_trap_is_actually_avoided(tmp_path):
-    """Explicit regression for the above: with 2.9.1 and 2.12.0 both present on
-    a backend, a string max picks 2.9.1. Both are in the real table today, so
-    this would be a live defect rather than a hypothetical one."""
+    """Explicit regression for the above, DERIVED rather than pinned.
+
+    A string max over e.g. ["2.9.1", "2.13.0"] picks "2.9.1", because "9" > "1"
+    lexically. This finds every backend where the lexical and numeric answers
+    actually DIFFER — i.e. where the bug would show — and asserts the gate took
+    the numeric one.
+
+    Written this way because the first version hardcoded "cu130 -> 2.12.0" and
+    broke the moment torch 2.13.0 entered the table. A test that pins today's
+    data rots into a false failure and trains people to edit tests until they
+    pass. The invariant is "numeric beats lexical", not "cu130 is on 2.12.0".
+    """
     cells = {c["cell"]: c for c in build_matrix(tmp_path) if c["kind"] == "auto"}
-    cu130 = [c["torch"] for c in TABLE["configs"] if c["key"] == "cu130"]
-    assert "2.9.1" in cu130 and "2.12.0" in cu130, "table changed; revisit this test"
-    assert cells["auto-cu130"]["describe"].startswith("2.12.0-")
+    numeric = lambda v: [int(x) for x in v.split(".")]
+
+    trapped = []
+    for backend in {c["key"] for c in TABLE["configs"]}:
+        vers = [c["torch"] for c in TABLE["configs"] if c["key"] == backend]
+        if max(vers) != max(vers, key=numeric):
+            trapped.append(backend)
+            assert cells[f"auto-{backend}"]["describe"].startswith(
+                max(vers, key=numeric) + "-"), (
+                f"{backend}: gated {cells[f'auto-{backend}']['describe']}, but "
+                f"lexical max is {max(vers)} and numeric max is "
+                f"{max(vers, key=numeric)} — the selection sorted as strings")
+
+    assert trapped, (
+        "no backend in the table currently distinguishes lexical from numeric "
+        "ordering, so this test proves nothing. Add a version pair that does "
+        "(e.g. 2.9.x alongside 2.1x.y), or delete this test — do not leave it "
+        "passing vacuously.")
 
 
 # --- multi -----------------------------------------------------------------

--- a/tools/template_manager/tests/test_pytorch_qa_coverage.py
+++ b/tools/template_manager/tests/test_pytorch_qa_coverage.py
@@ -78,11 +78,25 @@ def _fake_manifest() -> dict:
     for c in TABLE["multi"]:
         m["multi"].append({
             "key": c["key"], "cuda_minor": c["cuda_minor"],
+            # a space-joined STRING, exactly as resolve-digests stores it —
+            # not a list. The jq splits it; a list here would let a broken
+            # program pass the test and fail in CI.
             "venvs": " ".join(c["venvs"]),
+            "primary_torch": c["primary_torch"],
             "digests": {f"py{p}": f"sha256:multi-{c['key']}-{p}"
                         for p in c["python_versions"]},
         })
     return m
+
+
+def _audio_versions() -> str:
+    """Torch versions that ship torchaudio, derived exactly as the workflow does.
+
+    Reproduced rather than hardcoded: the workflow reads it from
+    torch-companions.json, so a companion change moves both together.
+    """
+    comp = json.loads((REPO / "derivatives/pytorch/torch-companions.json").read_text())
+    return " ".join(v for v, e in comp.items() if "torchaudio" in e.get("packages", {}))
 
 
 def build_matrix(tmp_path: Path, manifest: dict | None = None) -> list[dict]:
@@ -90,6 +104,7 @@ def build_matrix(tmp_path: Path, manifest: dict | None = None) -> list[dict]:
     man.write_text(json.dumps(manifest if manifest is not None else _fake_manifest()))
     out = subprocess.run(
         ["jq", "-c", "--arg", "dpy", f"py{TABLE['default_python']}",
+         "--arg", "audio", _audio_versions(),
          _jq_matrix_program(), str(man)],
         capture_output=True, text=True, check=True)
     return json.loads(out.stdout)
@@ -309,3 +324,65 @@ def test_backends_without_an_auto_tag_are_still_gated(tmp_path):
     table_backends = {c["key"] for c in TABLE["configs"]}
     assert gated == table_backends, (
         f"gate covers {sorted(gated)} but the table builds {sorted(table_backends)}")
+
+
+# --- the required list follows what the image SHIPS ------------------------
+#
+# The first real gate run (31497277275) blocked 20 healthy artifacts on
+# `pytorch.d/30-torchaudio=skipped`. torchaudio does not exist upstream past
+# torch 2.11, so those images correctly do not carry it and the test correctly
+# self-skips — the gate was right and the required list was wrong.
+
+def _audio(cell):
+    return "pytorch.d/30-torchaudio" in cell["require_tests"]
+
+
+def test_torchaudio_is_required_exactly_where_the_image_ships_it(tmp_path):
+    comp = json.loads((REPO / "derivatives/pytorch/torch-companions.json").read_text())
+    has = {v for v, e in comp.items() if "torchaudio" in e.get("packages", {})}
+    assert has and set(comp) - has, (
+        "every version either has or lacks torchaudio, so this test cannot "
+        "distinguish a working rule from one that always answers the same way")
+
+    for c in build_matrix(tmp_path):
+        if c["kind"] == "multi":
+            continue                       # covered below; a multi spans versions
+        ver = c["describe"].split("-")[0]
+        assert _audio(c) == (ver in has), (
+            f"{c['cell']}: torchaudio required={_audio(c)} but torch {ver} "
+            f"{'ships' if ver in has else 'does not ship'} it")
+
+
+def test_a_multi_requires_torchaudio_if_any_venv_ships_it(tmp_path):
+    """30-torchaudio iterates every venv and only skips when NONE has it, so
+    the requirement is an OR across the variant's versions — not a property of
+    its primary alone."""
+    comp = json.loads((REPO / "derivatives/pytorch/torch-companions.json").read_text())
+    has = {v for v, e in comp.items() if "torchaudio" in e.get("packages", {})}
+    by_key = {m["key"]: m for m in TABLE["multi"]}
+    for c in build_matrix(tmp_path):
+        if c["kind"] != "multi":
+            continue
+        key = next(k for k in by_key if c["cell"].startswith(f"multi-{k}-py"))
+        vers = [by_key[key]["primary_torch"] if v == "main" else v.removeprefix("torch-")
+                for v in by_key[key]["venvs"]]
+        assert _audio(c) == any(v in has for v in vers), (
+            f"{key}: venvs {vers}, required={_audio(c)}")
+
+
+def test_every_cell_requires_the_gpu_trio_and_the_core_pytorch_tests(tmp_path):
+    """Whatever the conditional part does, the unconditional part must survive:
+    a per-cell list is also an opportunity to accidentally require nothing."""
+    must = ["base/60-gpu-cuda", "base/61-cuda-compute", "base/62-gpu-libraries",
+            "pytorch.d/05-venv-manifest", "pytorch.d/10-torch-core",
+            "pytorch.d/20-torchvision", "pytorch.d/40-nccl-init"]
+    for c in build_matrix(tmp_path):
+        for t in must:
+            assert t in c["require_tests"], f"{c['cell']} does not require {t}"
+
+
+def test_no_cell_requires_the_multi_gpu_collectives_matrix(tmp_path):
+    """41-nccl-collectives skips below 2 GPUs and every cell is single-GPU, so
+    requiring it would fail all of them."""
+    for c in build_matrix(tmp_path):
+        assert "41-nccl-collectives" not in c["require_tests"], c["cell"]


### PR DESCRIPTION
Brings the pytorch image family under a live-GPU QA gate, and fixes two defects
in the shared gate machinery that were found on the way.

Records [ADR 0020](docs/adr/0020-qa-verdicts-classify-by-fault-domain.md) and
[ADR 0021](docs/adr/0021-pytorch-promotion-qa-gate.md).

## Why

`promote-pytorch.yml` resolved staging tags and wrote production tags —
including the customer-facing `-auto` pointers — with no QA reference at all.
This gives it the ADR 0019 topology that base-image already has, with two
deliberate differences recorded in ADR 0021.

## Defects found and fixed

**A required test that could not fail.** `base/62-gpu-libraries` has been in
base-qa's `INSTANCE_TEST_REQUIRE_PASS` while every check in it was `echo WARN`.
It reported `passed` on every box, so the live gate's third required test
asserted nothing beyond `has_gpu` — including on the promotion that shipped to
`main` this week. New linter rule **L059** catches this class; it counts CALLS
at a command position, not mentions, because the defective file carried the
comment `# FAILURES and fail_later/report_failures come from lib.sh` and no
call.

**A slow host was indistinguishable from a broken image.** `runner.sh` recorded
a per-test timeout (`rc=124`) as state `failed`, the same state a real
assertion failure produces — the distinction was destroyed one layer below CI,
where nothing downstream could recover it. ADR 0020 makes the rule explicit: a
cell may only BLOCK on evidence the IMAGE is bad; anything attributable to the
HOST is INCONCLUSIVE and retried on a fresh offer.

**Collectives that could not fail.** The NCCL harness sat inside
`10-torch-core.sh` behind `device_count > 1` and fell through on one GPU to a
bare `echo "skip: ..."`, leaving the enclosing test passing either way. Renting
a 2-GPU box would have bought a green cell certifying nothing. Now split into
`40-nccl-init.sh` (the image-owned surface — libnccl present, ABI-matched,
`ncclCommInitRank` works — reachable on ONE GPU, and required) and
`41-nccl-collectives.sh` (the transport, which is a host property; `test_skip`s
below 2 GPUs and is deliberately NOT required).

## The gate

57 cells, all single-GPU: 4 config backends at default python, **every** mini
artifact at **every** python (52), and the multi alias.

Mini is exhaustive rather than sampled because it is the base layer for 15 of
15 pytorch derivatives (zero pin a non-mini base), because a python-specific
defect that still imports is invisible to a default-python sweep, and because
it is the cheapest cell in the family.

Any block — or any exhausted inconclusive — stops the whole promotion. Stricter
than base-image, deliberately: pytorch images are the base layer for the
derivative estate, so shipping a known-bad one is worse than shipping nothing.
Inconclusive stops it too, because letting "we never got a clean box" through
would promote untested bits while every run looked green.

## Corrections made during the work, on the record

- ADR 0021 originally said 3 backends / 56 cells. The table builds **four** —
  `cu129` exists and `AUTO_TAG_MAP` references only cu126/cu128/cu130, so cu129
  is promoted with no pointer. Corrected to 57.
- The auto cells derive from the config table's backends, but customer exposure
  is decided by `AUTO_TAG_MAP`. Those agree today and nothing made them agree;
  a test now asserts every mapped backend has a cell.
- `pytorch.d/`, not `pytorch/` — `runner.sh` names a derivative test by its
  directory. It fails closed, but under a whole-run block it would have been a
  systematic false red on all 57 cells.

## Testing

550 passed, **0 skipped** (was 489 + 9 permanent skips); linter clean at 27
images.

- `test_retry_behaviour.py` **executes** the retry loop against a scripted
  client and the real classifier, counting boxes rented. It replaces
  `assert 'CODE" -ne 2' in body`, which pinned one spelling of the old rule and
  would not have noticed the loop being rewritten to retry everything.
- `test_pytorch_qa_coverage.py` runs the workflow's own jq against the real
  config table rather than reimplementing the selection. Asserts EQUALITY with
  the built mini set, and that each auto cell tests the newest torch by
  **numeric** comparison — a lexical max picks 2.9.1 over 2.12.0, and both are
  on cu130 in the table today.
- `test_verdict_marker_contract.py` reads `runner.sh` and `test_template.py`
  together. The client's stream parser is authoritative for per-test states and
  matches a closed marker set, so an unrecognised marker makes a test VANISH
  rather than fail — which the first draft of the timeout fix would have done.
- Mutation-verified throughout: folding `timedout` back into `failed`,
  laundering a co-occurring failure, reverting instance-death to block, an
  unrecognised runner marker, a comment-only `fail_later`, and the
  `pytorch.d/` -> `pytorch/` rename each fail their intended test.

## Not in this PR

Torch 2.12.1 / 2.13.0 / cu132 and repointing `cuda-13.1.2-auto` /
`cuda-13.2.1-auto` at native cu132. The gate has not yet been dispatched
against a real staging date; a `DRY_RUN=true` run to exercise `resolve-digests`
is the sensible next step before spending on GPUs.
