### PR TITLE
fix(qa): redraw on any failure, and name the machine that failed (ADR 0029)

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -249,43 +249,41 @@ jobs:
             set -e
             echo "---- attempt ${attempt} verdict ----"; cat /tmp/qa-raw.json || echo "(no --raw output)"
 
-            # DRAW ANOTHER HOST when the red is attributable to the BOX, not the
-            # image. On 2026-08-14 a cell rented a machine that presented no GPU:
-            # 60/61/62 skipped, `skip != pass` turned that into a block, and one
-            # bad draw held a tag on an image that was fine.
+            # DRAW ANOTHER HOST ON ANY FAILURE, AND NAME THE HOST.
             #
-            # The discriminator is whether any test actually FAILED. A host that
-            # cannot run the GPU tests makes them SKIP; a defective image makes
-            # them FAIL. So `failed == 0` with a non-zero exit means the required
-            # -pass gate fired on skips — nothing was tested, exactly like the
-            # no_offers case, and a fresh draw is the right answer.
+            # Reproducibility is the discriminator, not the symptom. A defect in
+            # the IMAGE reproduces on every box we draw, so it still blocks once
+            # the attempts are exhausted. A defect in the HOST does not survive a
+            # fresh draw. Deciding from a single run cannot tell them apart, and
+            # the 2026-08-18 pytorch gate proved it: six cells blocked, and every
+            # one that was investigated passed on other hardware — an NCCL
+            # segfault inside libcuda on machine 35974 (two controls on the
+            # identical driver build passed), two multi-GPU collectives timeouts
+            # (the same test then passed 10/10 on the same GPU model, driver and
+            # image digest), and three supervisord boot races.
             #
-            # 5 (instance_error) is included for the same reason, against its own
-            # comment in test_template.py ("treated as the image's problem"). That
-            # holds for an instance that crashes PART WAY THROUGH — but the same
-            # code covers an instance that came up and was then unreachable, which
-            # is the host's problem and produces zero test results. `failed == 0`
-            # separates them: something that ran and failed is the image, nothing
-            # having run at all is the box. Observed live 2026-08-14 on a cell
-            # whose machine had connectivity issues after a successful launch.
+            # This supersedes the narrower rule that only redrew when NO test had
+            # failed. That rule was written for a GPU-less box, where the required
+            # -pass gate fires on skips; it could not help when a host makes a
+            # real test fail, which is most of what actually happened.
             #
-            # NOT 3 (bad_instance): the client already walked MAX_LAUNCH_ATTEMPTS
-            # offers internally, so redrawing repeats work it has done. NOT 4
-            # (config_error): that is our bug, and retrying it hides it.
+            # The cost is real and accepted: retrying a red risks passing by luck.
+            # Two things bound it — the attempt count, and the fact that a genuine
+            # image defect has to pass EVERY redraw to escape, not just one.
             #
-            # A genuinely broken image that kills every instance it touches still
-            # blocks — it redraws at most `retries` times and then reports, since
-            # the attempt count bounds the loop.
-            #
-            # A single genuine failure still breaks immediately: retrying a real
-            # red until it passes by luck is how a gate becomes decoration, and
-            # that rule is unchanged.
-            if { [ "$CODE" -eq 1 ] || [ "$CODE" -eq 5 ]; } && [ -s /tmp/qa-raw.json ]; then
-              _failed=$(jq -r '.stream_counts.failed // empty' /tmp/qa-raw.json 2>/dev/null || echo "")
-              if [ "${_failed:-x}" = "0" ]; then
-                echo "::warning::cell blocked with 0 failed tests — the host did not provide what the required tests need (e.g. no GPU); drawing another host"
-                CODE=2      # treat as inconclusive: retry on a fresh offer
-              fi
+            # NOT 4 (config_error): that is our bug, and retrying hides it.
+            if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 4 ] && [ "$CODE" -ne 2 ]; then
+              # Name the box before redrawing. A machine that fails a test the
+              # image passes elsewhere is a de-verification candidate, and that is
+              # only actionable if the machine id is recorded at the moment it
+              # failed — the instance is destroyed immediately afterwards.
+              _mid=$(jq -r '.machine_id // empty' /tmp/qa-raw.json 2>/dev/null || echo "")
+              _iid=$(jq -r '.instance_id // empty' /tmp/qa-raw.json 2>/dev/null || echo "")
+              _failed_names=$(jq -r '[.tests[]? | select(.state=="failed") | .name] | join(",")' /tmp/qa-raw.json 2>/dev/null || echo "")
+              echo "SUSPECT-HOST machine=${_mid:-unknown} instance=${_iid:-unknown} exit=${CODE} failed=${_failed_names:-none}"
+              echo "${_mid:-unknown}|${_iid:-unknown}|${CODE}|${_failed_names:-none}" >> /tmp/qa-suspect-hosts.txt
+              echo "::warning::cell failed on machine ${_mid:-unknown} (exit ${CODE}, failed: ${_failed_names:-none}) — drawing another host; if a redraw passes, this machine is a de-verification candidate"
+              CODE=2      # treat as inconclusive: retry on a fresh offer
             fi
 
             [ "$CODE" -ne 2 ] && break
@@ -301,6 +299,44 @@ jobs:
           done
           echo "exit_code=${CODE}" >> "$GITHUB_OUTPUT"
           echo "attempts=${attempt}" >> "$GITHUB_OUTPUT"
+          if [ -s /tmp/qa-suspect-hosts.txt ]; then
+            echo "suspect-hosts<<SUSPECT_EOF" >> "$GITHUB_OUTPUT"
+            cat /tmp/qa-suspect-hosts.txt >> "$GITHUB_OUTPUT"
+            echo "SUSPECT_EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      # A machine that failed a cell which then PASSED on another box is the
+      # actionable case: the image is exonerated by the redraw, so the fault is
+      # the host and it should be de-verified. If the cell never passed, the same
+      # machine list is NOT evidence against those hosts — the image is still a
+      # live suspect — so the two are reported differently rather than as one
+      # undifferentiated list.
+      - name: Report suspect hosts
+        if: always() && steps.test.outputs.suspect-hosts != ''
+        env:
+          SUSPECTS: ${{ steps.test.outputs.suspect-hosts }}
+          FINAL_CODE: ${{ steps.test.outputs.exit_code }}
+        run: |
+          {
+            if [ "${FINAL_CODE}" = "0" ]; then
+              echo "### De-verification candidates — ${{ inputs.repo }} \`${{ inputs.tag }}\`"
+              echo ""
+              echo "These machines failed, then the SAME image passed on a fresh draw."
+              echo "The redraw exonerates the image, so the host is the fault:"
+            else
+              echo "### Failed hosts (image NOT exonerated) — ${{ inputs.repo }} \`${{ inputs.tag }}\`"
+              echo ""
+              echo "The cell never passed, so these are NOT de-verification"
+              echo "candidates — the image is still a live suspect:"
+            fi
+            echo ""
+            echo "| machine | instance | exit | failed tests |"
+            echo "|---|---|---|---|"
+            while IFS='|' read -r m i c f; do
+              [ -n "$m" ] && echo "| \`$m\` | $i | $c | $f |"
+            done <<< "${SUSPECTS}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "${SUSPECTS}"
 
       - name: Delete the throwaway template (always)
         if: always() && steps.create.outputs.id != ''

--- a/docs/adr/0019-base-image-promotion-qa-gate.md
+++ b/docs/adr/0019-base-image-promotion-qa-gate.md
@@ -453,7 +453,17 @@ The first promote to run under this ADR held exactly one tag, and the cause was 
 rented host that presented **no GPU**: `60/61/62` skipped, `skip != pass` blocked
 the cell. Nothing about the image was tested or faulty. That is a *bad draw*, and
 the answer to a bad draw is another draw — not a partial promotion. The gate now
-distinguishes the two by whether any test actually **failed**: a host that cannot
+distinguishes the two by whether any test actually **failed**:
+
+> **SUPERSEDED 2026-08-19 by ADR 0029.** The zero-failure rule below — and its
+> 2026-08-14 extension to exit 5 — no longer describes the gate. On 2026-08-18
+> the pytorch gate ran 70 cells and blocked six; every one investigated passed on
+> other hardware, and all six had FAILED tests, so this rule could not redraw any
+> of them. It was built for a host that makes tests SKIP; a bad host mostly makes
+> tests FAIL. A cell now redraws on any non-zero exit except `config_error`, and
+> records the machine it failed on. The paragraph below is kept as the reasoning
+> that was current at the time, not as the rule.
+ a host that cannot
 run the GPU tests makes them SKIP, a defective image makes them FAIL. Zero
 failures with a non-zero exit means nothing was tested, which is the same class as
 `no_offers`, and it is retried on a fresh offer. A single genuine failure still
@@ -489,7 +499,7 @@ notification that reports the intended outcome rather than the actual one invert
 the safety signal in the one place most people read. Guarded by
 `test_promote_notification_truth.py`.
 
-**Extended 2026-08-14 (observed live):** the redraw also covers exit 5
+**Extended 2026-08-14 (observed live; SUPERSEDED by ADR 0029):** the redraw also covers exit 5
 (`instance_error`). `test_template.py` classifies anything that is not a clean
 pass/fail as `instance_error` and its comment calls that "the image's problem".
 True for an instance that crashes part way through a run — false for one that

--- a/docs/adr/0029-qa-redraws-on-any-failure-and-names-the-host.md
+++ b/docs/adr/0029-qa-redraws-on-any-failure-and-names-the-host.md
@@ -1,0 +1,169 @@
+# ADR 0029 — A QA cell redraws on any failure, and names the machine it failed on
+
+## Status
+
+Accepted. **Supersedes the redraw clause of ADR 0019** (the "zero failures with a
+non-zero exit" rule, and its 2026-08-14 extension to exit 5). Built and merged as
+`fix/qa-redraw-and-suspect-hosts`.
+
+## Date
+
+2026-08-19
+
+## Context
+
+`qa-gate.yml` is the one live-GPU gate. `promote-base-image.yml`,
+`promote-pytorch.yml`, `build-comfyui.yml` and `build-vllm.yml` all call it, and
+none of them carries retry logic of its own. **Base-image is the source of truth
+for how tests behave**, so a rule established here is the rule everywhere, and a
+change here needs recording rather than discovering.
+
+ADR 0019 established: a cell redraws when the run produced **zero failed tests**
+with a non-zero exit. The reasoning was sound for the case that prompted it — a
+rented host presenting no GPU, where `60/61/62` SKIP and the required-pass gate
+turns those skips into a block. Nothing was tested, so another draw is the right
+answer. A test that actually FAILED was treated as evidence about the image, and
+never retried: *"retrying a real red until it passes by luck remains the thing
+this gate must never do."*
+
+That rule met its first large sample on 2026-08-18, when the pytorch gate ran 70
+cells for the first time. **Six blocked. Every one investigated passed on other
+hardware.**
+
+- **NCCL segfault, machine 35974.** `ncclCuMemHostEnable` crashed inside
+  `libcuda.so.1` during `ncclCudaLibraryInit`. Two controls on the *identical*
+  driver build (570.133.07) — one of them the same Ampere generation — ran the
+  same image digest clean. No NCCL environment variable avoided it; the crash is
+  in the init-time probe.
+- **Two multi-GPU collectives timeouts.** The same test then passed **10/10** on
+  the same GPU model, driver build, torch version and image digest — standalone,
+  and in real suite order after `40-nccl-init`.
+- **Three supervisord boot races.** `supervisorctl cannot communicate with
+  supervisord (exit 4)`, with `20-portal` and `26-caddy-auth` failing as
+  collateral of that one root cause.
+
+None was an image defect. All six produced **failed tests**, so the zero-failure
+rule could not redraw any of them. That is the flaw: it was built for a host that
+makes tests SKIP, and a bad host mostly makes tests FAIL.
+
+An earlier attempt at this — the fault-domain model of ADR 0020, on the pytorch
+config-table branch — was dropped on 2026-08-18 during a rebase, to keep main's
+conventions while that branch landed. This ADR reaches the same conclusion from
+the opposite direction, with the evidence the first run produced, and adds the
+part ADR 0020 did not have: naming the host.
+
+## Options considered
+
+### A. Keep the zero-failure rule (rejected)
+
+Cheapest, and it preserves the strong "never retry a red" property.
+
+Rejected on measurement: it did not redraw a single one of the six cells it
+should have. Under all-or-nothing promotion (ADR 0019) each of those blocked
+every tag in the batch, so the rule's real cost was two full dispatch cycles for
+faults that were not ours.
+
+### B. Raise the QA offer floors so bad hosts are never drawn (rejected)
+
+`set_filters` already carries `cuda_max_good`; a driver floor looked plausible
+when the first failure appeared on driver 570.133.07.
+
+Rejected because it is **positively contraindicated by the evidence**. The two
+collectives failures were on driver 595.71.05, and the same combination passes
+10/10 elsewhere; the segfault host's driver build passes on two other machines.
+There is no filterable property that separates these hosts — the fault is the
+individual machine, not any attribute we can express in a search query. A floor
+would have excluded healthy capacity and still drawn the bad boxes.
+
+### C. Fault-domain classification in `qa_verdict.py` (rejected for now)
+
+ADR 0020's model: classify each outcome into HOST or IMAGE, retry the former.
+Cleaner in principle, and it moves the decision into tested Python.
+
+Rejected as the immediate step because it is a larger change to a shared verdict
+path, and because the discriminator it needs — *does this reproduce?* — is
+exactly what a redraw already measures. Reconsider if the redraw proves too
+coarse; the two are compatible.
+
+### D. Redraw on any failure, and record the host (chosen)
+
+Reproducibility becomes the discriminator rather than the symptom.
+
+## Decision
+
+**A cell redraws on any non-zero exit except `config_error` (4), and every failed
+attempt names the machine it ran on.**
+
+1. **Redraw on any failure.** `config_error` stays excluded: it is our own bug,
+   and retrying it makes a broken gate look healthy. `bad_instance` (3) is no
+   longer excluded — the client's `MAX_LAUNCH_ATTEMPTS` are about reaching a
+   *running* box, which says nothing about whether that box can pass the suite.
+
+2. **The machine id is captured at the moment of failure.** `test_template.py`
+   carries `machine_id` out of the launch loop into `--raw`. The gate appends
+   every failed attempt to `/tmp/qa-suspect-hosts.txt`, prints a `SUSPECT-HOST`
+   line, and renders a job-summary table. Capture must happen there: the instance
+   is destroyed immediately afterwards and the offer is gone.
+
+3. **The report distinguishes exoneration from suspicion**, because the same list
+   means opposite things:
+   - *passed after redraw* → the image is exonerated by the redraw, so the fault
+     is the host: a **de-verification candidate**.
+   - *never passed* → the image is still a live suspect, and these hosts are
+     **not** evidence. De-verifying them on this basis would be wrong.
+
+4. **A deterministic image defect still blocks.** It fails every draw, and the
+   attempt count bounds the loop.
+
+## Binding conditions
+
+1. **The accepted cost is stated, not hidden.** A FLAKY image defect — failing on
+   some boxes, passing on others — can now escape, because one passing redraw
+   ends the loop. ADR 0019's warning was not wrong; it is being traded
+   deliberately against six cells lost to bad hosts. What makes it survivable is
+   the record: an image failing across many DIFFERENT machines is a pattern, not
+   a green tick.
+2. **The suspect record is what makes redrawing a red defensible.** If the
+   machine capture is ever removed, this decision no longer holds and the
+   zero-failure rule should come back. Guarded by
+   `test_a_flaky_image_defect_can_now_pass_by_luck_AND_IS_RECORDED`.
+3. **De-verification requires the exonerating pass.** A machine may only be
+   de-verified on the strength of a later PASS of the same image. Without it the
+   image is unexonerated and the host is not proven guilty.
+4. **`config_error` is never retried.**
+5. **Base-image is the reference.** Any future change to retry or verdict
+   semantics lands in `qa-gate.yml` and is recorded here, not forked per image.
+
+## Consequences
+
+**Positive.** A bad draw costs one extra cell instead of a whole dispatch cycle.
+Bad machines become actionable — previously the evidence was destroyed with the
+instance. The gate stops reporting host faults as image faults, which is the
+failure mode most likely to erode trust in it.
+
+**Accepted negative.** A flaky image defect can pass by luck (condition 1). Cells
+that fail take longer, since a failure now costs a redraw. Money: each redraw is
+another rental.
+
+**Accepted negative.** The de-verification signal needs a human. Nothing
+automatically reports a machine to Vast; the gate produces the list.
+
+**Known gap.** Suspects are reported per cell in that job's summary. There is no
+aggregate across a whole promote, so a machine failing several cells appears
+several times rather than once with a count. Cheap to add once there is real data
+to shape it.
+
+**Known gap.** No threshold on distinct machines. Failing across N different
+hosts is the signal that an image is at fault, and nothing computes it yet — the
+pattern is visible but not enforced.
+
+## What would reverse this
+
+- A flaky image defect reaching production through a lucky redraw. That is the
+  scenario ADR 0019 guarded against, and it would justify either the zero-failure
+  rule returning or a distinct-machine threshold (the better answer).
+- Redraws becoming common enough that QA cost or the single-key QA account (ADR
+  0005 condition 6) becomes the binding constraint.
+- Evidence that the failures were a property of the images after all — for
+  instance the same machines passing other images at the same time. The
+  investigation on 2026-08-18 found the opposite, but it was six cells.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -591,6 +591,27 @@ invariant:
 > An auto tag may only move to a digest that PASSED live-GPU QA in this run, on
 > that exact digest. Anything else HOLDS the tag at its current digest.
 
+**A failing cell redraws before it blocks (ADR 0029).** `qa-gate.yml` is shared by
+base, pytorch, comfyui and vllm, and none of them carries retry logic of its own —
+so base-image is the reference for how a QA cell behaves everywhere. A cell now
+redraws on any non-zero exit except `config_error`, because reproducibility rather
+than symptom is what separates a bad host from a bad image: measured on 2026-08-18,
+six of seventy pytorch cells blocked and every one investigated passed on other
+hardware, all of them with FAILED tests that the previous zero-failure rule could
+not redraw.
+
+Every failed attempt records the `machine_id` it ran on (`SUSPECT-HOST`, and a
+job-summary table), because the instance is destroyed immediately afterwards and
+the evidence is otherwise lost. The table separates the two readings deliberately:
+a cell that PASSED after a redraw exonerates the image and makes that host a
+de-verification candidate; a cell that never passed does not, and de-verifying
+those hosts would be wrong.
+
+Accepted cost, stated: a FLAKY image defect can now pass by luck, where the old
+rule would have blocked it. A deterministic one still fails every draw and blocks.
+The suspect record is what makes the trade defensible — an image failing across
+many DIFFERENT machines shows as a pattern rather than a green tick.
+
 Not statically checkable — it is a property of ~420 lines of bash inside
 `promote-base-image.yml`, and a linter cannot see a working gate versus a copy of
 one. It has been disarmed three times, each time with the whole suite green:

--- a/tools/template_manager/test_template.py
+++ b/tools/template_manager/test_template.py
@@ -1291,7 +1291,11 @@ def launch_with_retry(api, candidate_offers, payload_factory, requested_disk,
             on_instance_created(None)
             continue
 
-        return instance_id, test_url, auth_token
+        # machine_id travels with the instance so a FAILING cell can name the
+        # box it ran on. A host that fails a test the image passes elsewhere is
+        # a de-verification candidate, and that is only actionable if the
+        # machine is in the record rather than only the instance.
+        return instance_id, test_url, auth_token, offer.get("machine_id")
 
     log(f"Exhausted offers ({attempts} attempts, last error: {last_error or 'none'})")
     return None
@@ -1566,7 +1570,7 @@ def main():
         log("Could not launch a usable instance on any candidate offer")
         emit_outcome("bad_instance", EXIT_BAD_INSTANCE, reason="exhausted launch attempts")
 
-    instance_id, test_url, auth_token = launch
+    instance_id, test_url, auth_token, machine_id = launch
 
     # 6. Monitor instance health in background.
     # Detects if instance goes non-running, disappears, or enters a terminal state.
@@ -1750,6 +1754,8 @@ def main():
         raw_output["stream_had_gap"] = stream_had_gap
         # Address the held box for the QA-fix loop: instance id + SSH coords (only when the
         # box persists, i.e. --keep). The loop SSHes in to diagnose against a live workbench.
+        if machine_id is not None:
+            raw_output["machine_id"] = machine_id
         if instance_id:
             raw_output["instance_id"] = instance_id
             if args.keep:

--- a/tools/template_manager/tests/test_promote_all_or_nothing.py
+++ b/tools/template_manager/tests/test_promote_all_or_nothing.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import yaml
 
-_REDRAW_GUARD = re.compile(r'if \{? ?\[ "\$CODE" -eq 1 \].*?\n            fi', re.S)
+_REDRAW_GUARD = re.compile(r'if \[ "\$CODE" -ne 0 \].*?\n            fi', re.S)
 
 REPO = Path(__file__).resolve().parents[3]
 PROMOTE = REPO / ".github" / "workflows" / "promote-base-image.yml"
@@ -92,51 +92,54 @@ def test_an_all_clear_batch_is_untouched():
     assert _apply(clear) == clear, "the rewrite must be a no-op when nothing holds"
 
 
-def test_the_gate_redraws_on_a_zero_failure_block():
-    """A cell that blocks with no failed tests was never really tested."""
-    body = QA_GATE.read_text()          # raw: a json dump escapes the shell quoting
-    assert "stream_counts.failed" in body, (
-        "qa-gate must inspect the failed-test count to tell a bad host from a bad image")
-    assert "drawing another host" in body
+def test_the_gate_redraws_on_ANY_failure_not_just_a_zero_failure_block():
+    """SUPERSEDES the zero-failure redraw rule (2026-08-19).
 
+    The old rule redrew only when NO test had failed — written for a GPU-less
+    box, where the required-pass gate fires on skips. It could not help when a
+    bad HOST makes a real test FAIL, which is what actually happened: the
+    2026-08-18 pytorch gate blocked six cells, and every one investigated passed
+    on other hardware — an NCCL segfault inside libcuda on machine 35974 (two
+    controls on the identical driver build passed), two multi-GPU collectives
+    timeouts whose test then passed 10/10 on the same GPU model, driver and image
+    digest, and three supervisord boot races.
 
-def test_an_unreachable_instance_is_also_redrawn():
-    """A host that comes up and is then unreachable exits 5 (instance_error) with
-    no test results. test_template.py's own comment calls 5 "the image's problem",
-    which is true for a crash PART WAY THROUGH and false for a box that was never
-    reachable — `failed == 0` separates them. Observed live 2026-08-14."""
+    Reproducibility is the discriminator, not the symptom.
+    """
     body = QA_GATE.read_text()
-    assert re.search(r'\[ "\$CODE" -eq 5 \]', body), (
-        "instance_error must be eligible for a redraw when nothing was tested")
-    guard = _REDRAW_GUARD.search(body)
-    assert guard, "the redraw guard no longer matches"
-    assert re.search(r'\[\s*"\$\{_failed:?-?[^}]*\}"\s*=\s*"0"\s*\]', guard.group(0)), (
-        "the exit-5 redraw must be gated on zero failed tests, exactly like exit 1")
+    assert '[ "$CODE" -ne 0 ] && [ "$CODE" -ne 4 ]' in body, (
+        "the redraw must fire on any non-zero exit except config_error")
+    assert _REDRAW_GUARD.search(body), "no redraw guard block found"
 
 
-def test_config_error_and_bad_instance_are_NOT_redrawn():
-    """4 is our bug — retrying hides it. 3 already walked MAX_LAUNCH_ATTEMPTS
-    offers internally, so redrawing repeats work the client has done."""
-    guard = _REDRAW_GUARD.search(QA_GATE.read_text())
-    assert guard, "the redraw guard no longer matches"
-    block = guard.group(0)
-    assert '-eq 4' not in block and '-eq 3' not in block, (
-        "config_error/bad_instance must not be redrawn")
+def test_config_error_is_the_one_exit_never_redrawn():
+    """config_error is OUR bug; retrying it hides it.
 
-
-def test_a_genuine_failure_is_still_never_retried():
-    """The redraw must key on zero failed tests, never on exit 1 alone —
-    retrying a real red until it passes by luck is how a gate becomes
-    decoration, and that rule is unchanged."""
+    bad_instance is no longer excluded. The client's own launch attempts are
+    about reaching a RUNNING box, which says nothing about whether that box can
+    pass the suite — so exhausting them is not a reason to stop drawing.
+    """
     body = QA_GATE.read_text()
-    assert 'CODE" -eq 1' in body and "_failed" in body, (
-        "the redraw must be conditional on the failed-test count")
-    guard = _REDRAW_GUARD.search(body)
-    assert guard, "no exit-1 guard block found"
-    block = guard.group(0)
-    # Not "does _failed appear" — that survives replacing the condition with
-    # `if true`, because the assignment is still in the block. The redraw must be
-    # CONDITIONAL on the count being zero.
-    assert re.search(r'\[\s*"\$\{_failed:?-?[^}]*\}"\s*=\s*"0"\s*\]', block), (
-        "the redraw must be gated on the failed-test count being exactly 0; as "
-        "written it would retry a genuine red until it passed by luck")
+    assert '"$CODE" -ne 4' in body, "config_error must never be redrawn"
+
+
+def test_a_flaky_image_defect_can_now_pass_by_luck_AND_IS_RECORDED():
+    """The accepted cost of redrawing a red, stated rather than hidden.
+
+    A DETERMINISTIC image defect still blocks: it fails every draw, and the
+    attempt count bounds the loop. A FLAKY one — failing on some boxes, passing
+    on others — can now escape, because one passing redraw ends the loop. That is
+    a genuine weakening of the previous rule, taken deliberately: the alternative
+    cost six blocked cells on hosts that were simply bad.
+
+    What makes it survivable is that every failed attempt is RECORDED with the
+    machine it ran on, so an image failing across many DIFFERENT machines shows
+    as a pattern instead of being laundered into a green tick.
+    """
+    body = QA_GATE.read_text()
+    assert "SUSPECT-HOST" in body and ".machine_id" in body, (
+        "redrawing a red is only defensible if each failed attempt names the "
+        "host it failed on; without that a flaky image defect is invisible")
+    assert "qa-suspect-hosts.txt" in body, (
+        "every failed attempt must be kept, not just the last — one machine "
+        "failing is a bad host, five different machines failing is the image")

--- a/tools/template_manager/tests/test_promote_notification_truth.py
+++ b/tools/template_manager/tests/test_promote_notification_truth.py
@@ -404,3 +404,77 @@ def test_the_dockerfile_still_builds_without_the_arg():
         "an empty ARG must fall back to resolving the version in-build")
     assert "${SYNCTHING_VERSION#v}" in df, (
         "the tag_name carries a leading 'v' that the download URL adds back")
+
+
+# ---- redraw on any failure, and name the host (2026-08-19) -------------------
+
+QA_GATE = REPO / ".github" / "workflows" / "qa-gate.yml"
+
+
+def _qa_gate_run() -> str:
+    d = yaml.safe_load(QA_GATE.read_text())
+    steps = d["jobs"]["qa"]["steps"]
+    return " ".join(str(s.get("run", "")) for s in steps)
+
+
+def test_a_failing_cell_redraws_instead_of_blocking_on_one_host():
+    """Reproducibility is the discriminator, not the symptom.
+
+    The 2026-08-18 pytorch gate blocked six cells; every one investigated passed
+    on other hardware — an NCCL segfault inside libcuda on one machine (two
+    controls on the identical driver build passed), two collectives timeouts (the
+    same test then passed 10/10 on the same GPU model, driver and image digest),
+    and three supervisord boot races. A rule that only redrew when NO test failed
+    could not help with any of them, because a bad host makes real tests fail.
+    """
+    run = _qa_gate_run()
+    assert '[ "$CODE" -ne 0 ] && [ "$CODE" -ne 4 ]' in run, (
+        "a failing cell must redraw on any non-zero exit except config_error; "
+        "keying on 'no test failed' misses every host fault that breaks a test")
+    assert 'CODE=2' in run, "the redraw path must mark the attempt inconclusive"
+
+
+def test_config_error_is_never_retried():
+    """config_error is OUR bug. Retrying it hides it."""
+    run = _qa_gate_run()
+    assert '"$CODE" -ne 4' in run, (
+        "config_error (4) must be excluded from the redraw, or a broken gate "
+        "retries itself into looking healthy")
+
+
+def test_the_failing_machine_is_NAMED_before_the_instance_is_destroyed():
+    """A de-verification candidate is only actionable if the machine id is
+    captured at the moment it failed — the instance is destroyed immediately
+    after, and the offer is gone."""
+    run = _qa_gate_run()
+    assert ".machine_id" in run, (
+        "the gate never reads machine_id, so a bad host cannot be identified")
+    assert "SUSPECT-HOST" in run, "the failing host is not announced in the log"
+    assert "qa-suspect-hosts.txt" in run, (
+        "suspects must accumulate across attempts, not just the last one")
+
+
+def test_the_client_reports_the_machine_it_ran_on():
+    """qa-gate can only name the host if test_template.py puts it in --raw."""
+    src = (REPO / "tools" / "template_manager" / "test_template.py").read_text()
+    assert 'raw_output["machine_id"] = machine_id' in src, (
+        "the client does not surface machine_id, so the gate has nothing to read")
+    assert 'return instance_id, test_url, auth_token, offer.get("machine_id")' in src, (
+        "machine_id must travel out of the launch loop with the instance")
+
+
+def test_exoneration_is_distinguished_from_a_still_suspect_image():
+    """A machine list means opposite things depending on whether a redraw passed.
+
+    Passed after redraw -> the image is exonerated, the host is at fault, de-verify.
+    Never passed        -> the image is still a live suspect; those hosts are NOT
+                           evidence and must not be de-verified on this basis.
+    """
+    d = yaml.safe_load(QA_GATE.read_text())
+    step = [s for s in d["jobs"]["qa"]["steps"] if s.get("name") == "Report suspect hosts"]
+    assert step, "no step reports the suspect hosts"
+    body = str(step[0].get("run", ""))
+    assert "De-verification candidates" in body and "NOT exonerated" in body, (
+        "the report must distinguish a redraw-exonerated image from one that "
+        "never passed; otherwise good hosts get de-verified for an image bug")
+    assert 'FINAL_CODE' in body, "the distinction must key on the cell's final outcome"


### PR DESCRIPTION
The 2026-08-18 pytorch gate blocked six of seventy cells. Every one investigated
passed on other hardware:

- an **NCCL segfault** inside `libcuda` on machine 35974 — two controls on the
  identical driver build (570.133.07), one the same Ampere generation, passed the
  same image digest
- **two multi-GPU collectives timeouts** — the same test then passed **10/10** on
  the same GPU model, driver build, torch version and image digest, standalone and
  in real suite order
- **three supervisord boot races**, with portal and caddy-auth as collateral

None was an image defect. All six produced *failed tests*, so the previous
zero-failure redraw rule could not redraw any of them: it was built for a host
that makes tests SKIP, and a bad host mostly makes tests FAIL.

## What changes

Reproducibility becomes the discriminator rather than the symptom. A cell redraws
on any non-zero exit except `config_error` (our own bug — retrying it would make a
broken gate look healthy). `bad_instance` is no longer excluded: the client's
launch attempts are about reaching a *running* box, which says nothing about
whether that box can pass the suite.

**Every failed attempt names its machine.** `test_template.py` carries
`machine_id` into `--raw`; the gate records each failure, prints `SUSPECT-HOST`,
and renders a job-summary table. Capture happens at failure time because the
instance is destroyed immediately afterwards and the offer is gone.

The table distinguishes two readings that must not be conflated:

- **passed after redraw** → the image is exonerated, the host is at fault: a
  de-verification candidate
- **never passed** → the image is still a live suspect; those hosts are *not*
  evidence

## The accepted cost, stated

A **deterministic** image defect still blocks — it fails every draw and the
attempt count bounds the loop. A **flaky** one can now escape, because one passing
redraw ends the loop. ADR 0019's warning ("retrying a real red until it passes by
luck is how a gate becomes decoration") was not wrong; it is traded deliberately
against six cells lost to bad hosts. The suspect record is what makes it
defensible — an image failing across many *different* machines shows as a pattern
rather than a green tick. ADR 0029 binding condition 2: if the machine capture is
removed, this decision no longer holds and the zero-failure rule should return.

## Scope

`qa-gate.yml` is shared by **base, pytorch, comfyui and vllm**, none of which
carries retry logic of its own — so base-image is the reference and this applies
everywhere at once.

ADR 0019 is marked superseded **at the clause** (redraw paragraph and its
2026-08-14 exit-5 extension), reasoning kept as what was current at the time.
`docs/invariants.md` gains the rule and the same stated cost.

## Known gaps, recorded not implied

- suspects are reported per cell; no aggregate across a whole promote
- nothing counts *distinct* machines yet — that is the signal that would catch a
  flaky image rather than a bad host

## Evidence

Four superseded guards rewritten in place, each carrying the evidence. Six
mutations checked (revert the condition, make `config_error` retryable, stop
capturing the machine id, drop the announcement, stop surfacing `machine_id` in
the client, collapse the two exoneration messages) — each reddens.

lint clean (27 images); 353 template_manager.