### PR TITLE
fix(qa): panel remediation — the loop flag was auto-promoting broken images (ADR 0029 follow-up)

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Notify Slack
         if: steps.slack-check.outputs.available == 'true'
         env:
+          TRIGGER: ${{ inputs.trigger }}
+          IMAGE_REF: ${{ inputs.image-ref }}
+          RUN_URL: ${{ inputs.run-url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           IMAGE_TAGS: ${{ inputs.image-tags }}
           STATUS: ${{ inputs.status }}
@@ -135,8 +138,8 @@ jobs:
           # Build base blocks
           BLOCKS=$(jq -n \
             --arg header "$HEADER_TEXT" \
-            --arg trigger "${{ inputs.trigger }}" \
-            --arg ref "${{ inputs.image-ref }}" \
+            --arg trigger "$TRIGGER" \
+            --arg ref "$IMAGE_REF" \
             '[
               {
                 "type": "header",
@@ -216,7 +219,7 @@ jobs:
           
           # Add context block
           CONTEXT_BLOCK=$(jq -n \
-            --arg url "${{ inputs.run-url }}" \
+            --arg url "$RUN_URL" \
             '[{
               "type": "context",
               "elements": [{
@@ -226,7 +229,7 @@ jobs:
             }]')
           BLOCKS=$(echo "$BLOCKS" | jq --argjson ctx "$CONTEXT_BLOCK" '. + $ctx')
           
-          FALLBACK="${HEADER_TEXT} (${{ inputs.image-ref }})"
+          FALLBACK="${HEADER_TEXT} (${IMAGE_REF})"
 
           PAYLOAD=$(jq -n \
             --arg color "$COLOR" \

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -111,10 +111,16 @@ jobs:
             # 147 + the ellipsis. Cut on a word boundary when one is near the end,
             # so the header does not stop mid-token.
             _cut="${HEADER_TEXT:0:147}"
-            case "${_cut##*[[:space:]]}" in
-              "$_cut") ;;                       # no space at all: hard cut
-              *) [[ ${#_cut} -gt 120 ]] && _cut="${_cut% *}" ;;
-            esac
+            # Cut on a word boundary ONLY when that does not cost most of the
+            # budget. The length test must be on the TRIMMED string: the first
+            # version tested ${#_cut}, which is always 147 here, so it was
+            # vacuously true — and a headline whose tail is a space-free list
+            # (a comma-joined tag list, say) trimmed back to the last space in
+            # the prose prefix. Measured: 194 chars in, 27 out.
+            _trim="${_cut% *}"
+            if [[ "$_trim" != "$_cut" && ${#_trim} -gt 120 ]]; then
+              _cut="$_trim"
+            fi
             HEADER_TEXT="${_cut}…"
             echo "::notice::headline was ${#HEADER_OVERFLOW} chars; clamped to Slack's 150 char header limit (full text moved into the message body)"
           fi

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -107,7 +107,7 @@ jobs:
           # This file already truncates the tags section for its 3000 char limit.
           # The header was never clamped, so any caller could break the shared
           # notifier. Clamp here rather than only fixing the caller: this is the
-          # component that knows Slack's limits, and there are five callers.
+          # component that knows Slack's limits, and 29 workflows call it.
           HEADER_OVERFLOW=""
           if [[ ${#HEADER_TEXT} -gt 150 ]]; then
             HEADER_OVERFLOW="$HEADER_TEXT"

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -91,6 +91,34 @@ jobs:
             HEADER_TEXT="${STATUS_EMOJI} ${IMAGE_NAME} Image Build ${STATUS_TEXT}"
           fi
 
+          # CLAMP THE HEADER. Slack's header block is plain_text with a hard 150
+          # character limit, and the whole POST is rejected with HTTP 400 if it is
+          # exceeded — the notification is lost entirely, including the part that
+          # says whether anything shipped.
+          #
+          # Observed 2026-08-19 (run 32239585814): promote-pytorch built a 527
+          # character headline enumerating the QA'd artifacts. The promotion had
+          # fully SUCCEEDED — every tag pushed — and the run still reported failure,
+          # because the only thing that broke was the announcement of the success.
+          #
+          # This file already truncates the tags section for its 3000 char limit.
+          # The header was never clamped, so any caller could break the shared
+          # notifier. Clamp here rather than only fixing the caller: this is the
+          # component that knows Slack's limits, and there are five callers.
+          HEADER_OVERFLOW=""
+          if [[ ${#HEADER_TEXT} -gt 150 ]]; then
+            HEADER_OVERFLOW="$HEADER_TEXT"
+            # 147 + the ellipsis. Cut on a word boundary when one is near the end,
+            # so the header does not stop mid-token.
+            _cut="${HEADER_TEXT:0:147}"
+            case "${_cut##*[[:space:]]}" in
+              "$_cut") ;;                       # no space at all: hard cut
+              *) [[ ${#_cut} -gt 120 ]] && _cut="${_cut% *}" ;;
+            esac
+            HEADER_TEXT="${_cut}…"
+            echo "::notice::headline was ${#HEADER_OVERFLOW} chars; clamped to Slack's 150 char header limit (full text moved into the message body)"
+          fi
+
           # Show the promoted-tags block when something was promoted: a normal
           # success, OR a soft-pass warning (ungated promotion — show the tags).
           SHOW_TAGS="false"
@@ -126,6 +154,14 @@ jobs:
                 ]
               }
             ]')
+
+          # The clamped-away text is information, not decoration — put it back in
+          # the body, where the limit is 3000 rather than 150.
+          if [[ -n "$HEADER_OVERFLOW" ]]; then
+            BLOCKS=$(jq --arg full "${HEADER_OVERFLOW:0:2900}" \
+              '. + [{"type": "section",
+                     "text": {"type": "mrkdwn", "text": $full}}]' <<<"$BLOCKS")
+          fi
           
           # Add image tags when something was promoted (success or soft-pass warning)
           if [[ "$SHOW_TAGS" == "true" ]]; then

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -243,6 +243,20 @@ jobs:
               }]
             }')
           
-          curl -sfS -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-type: application/json' \
-            --data "$PAYLOAD"
+          # A FAILED ANNOUNCEMENT MUST NOT FAIL THE THING IT ANNOUNCES.
+          # On 2026-08-19 a fully successful pytorch promotion — QA green on 70
+          # cells, every tag pushed — reported as a failed run because a 527-char
+          # header got a 400 from Slack. The clamp fixes that trigger; `-f` is the
+          # class. A 429, a Slack 5xx, or the next payload limit nobody knew about
+          # would each do it again, and "the promotion worked but the run is red"
+          # is the most expensive kind of false alarm: it trains people to ignore
+          # red runs on the pipeline where red matters most.
+          #
+          # Retries first, because a transient really is worth retrying; then warn
+          # rather than exit. The step summary and the run itself remain the record.
+          if ! curl -sS --retry 3 --retry-delay 2 --retry-all-errors \
+                 -X POST "$SLACK_WEBHOOK_URL" \
+                 -H 'Content-type: application/json' \
+                 --data "$PAYLOAD" --fail-with-body; then
+            echo "::warning::Slack notification failed — the build/promotion result above is unaffected"
+          fi

--- a/.github/workflows/promote-base-image.yml
+++ b/.github/workflows/promote-base-image.yml
@@ -460,8 +460,9 @@ jobs:
           # chosen because atomic gating is p^n in per-cell reliability (~54% clean
           # at 12 cells x 95%), which drives operators to route around the gate. The
           # answer to that is not partial promotion, it is removing the flakiness:
-          # qa-gate.yml now draws a FRESH HOST when a cell blocks with zero failed
-          # tests, which is what that argument was really about.
+          # qa-gate.yml now draws a FRESH HOST on any failure and excludes the
+          # machine that failed (ADR 0029), which is what that argument was really
+          # about.
           #
           # What partial promotion assumed, and should not have: that a red cell is
           # evidence about one image. Every config shares the same ROOT overlay and

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -235,6 +235,8 @@ jobs:
         continue-on-error: true
         env:
           LOG_PATHS: ${{ inputs.log_paths }}
+          QA_REPO: ${{ inputs.repo }}
+          QA_TAG: ${{ inputs.tag }}
           EXTRA_ENV: ${{ inputs.extra_env }}
         run: |
           ARGS=()
@@ -359,6 +361,14 @@ jobs:
           # Emit what actually happened on the LAST attempt, never the loop flag.
           echo "exit_code=${_REAL_CODE}" >> "$GITHUB_OUTPUT"
           echo "attempts=${attempt}" >> "$GITHUB_OUTPUT"
+          # Surfaced, not just recorded. ADR 0029's "what would reverse this"
+          # cites the redraw RATE, and an output nothing reads cannot show it.
+          if [ "${attempt}" -gt 1 ]; then
+            echo "### QA redraws — ${QA_REPO} \`${QA_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "This cell took **${attempt}** attempts (final exit ${_REAL_CODE})." >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::cell needed ${attempt} attempts (final exit ${_REAL_CODE})"
+          fi
           if [ -s /tmp/qa-suspect-hosts.txt ]; then
             echo "suspect-hosts<<SUSPECT_EOF" >> "$GITHUB_OUTPUT"
             cat /tmp/qa-suspect-hosts.txt >> "$GITHUB_OUTPUT"

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -354,15 +354,22 @@ jobs:
         env:
           SUSPECTS: ${{ steps.test.outputs.suspect-hosts }}
           FINAL_CODE: ${{ steps.test.outputs.exit_code }}
+          # Via env:, not spliced into bash. Two reasons, and the second is why
+          # the previous version could not be tested at all: a dispatch input is
+          # free text, and wfexec.step_script REFUSES a step carrying an
+          # unresolved expression rather than guess at it — so an untestable step
+          # stayed untested, which is how three grep-only guards shipped here.
+          QA_REPO: ${{ inputs.repo }}
+          QA_TAG: ${{ inputs.tag }}
         run: |
           {
             if [ "${FINAL_CODE}" = "0" ]; then
-              echo "### De-verification candidates — ${{ inputs.repo }} \`${{ inputs.tag }}\`"
+              echo "### De-verification candidates — ${QA_REPO} \`${QA_TAG}\`"
               echo ""
               echo "These machines failed, then the SAME image passed on a fresh draw."
               echo "The redraw exonerates the image, so the host is the fault:"
             else
-              echo "### Failed hosts (image NOT exonerated) — ${{ inputs.repo }} \`${{ inputs.tag }}\`"
+              echo "### Failed hosts (image NOT exonerated) — ${QA_REPO} \`${QA_TAG}\`"
               echo ""
               echo "The cell never passed, so these are NOT de-verification"
               echo "candidates — the image is still a live suspect:"
@@ -371,7 +378,12 @@ jobs:
             echo "| machine | instance | exit | failed tests |"
             echo "|---|---|---|---|"
             while IFS='|' read -r m i c f; do
-              [ -n "$m" ] && echo "| \`$m\` | $i | $c | $f |"
+              # Skip rows with no machine. exit 3 (bad_instance) is emitted before
+              # any machine is bound, so it records `unknown` — and presenting
+              # that under "de-verification candidates" is a wrong accusation
+              # with no way to act on it.
+              case "$m" in ''|unknown) continue;; esac
+              echo "| \`$m\` | $i | $c | $f |"
             done <<< "${SUSPECTS}"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "${SUSPECTS}"

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -80,13 +80,24 @@ on:
         default: ""
       retries:
         description: >-
-          Extra attempts on an INFRA-inconclusive outcome only: no_offers, or a block
-          in which NO test actually failed (the host could not provide what the
-          required tests need — e.g. it presented no GPU — so nothing was tested and
-          a fresh draw is warranted). Never on a real failure, an instance crash or a
-          config error — retrying a red is how a gate becomes decoration.
-          bad_instance is excluded too: it already exhausted the client's own launch
-          attempts.
+          Extra attempts on ANY failure except config_error (4) and interrupted
+          (130) — ADR 0029. Reproducibility, not symptom, is what separates a bad
+          host from a bad image: a defect in the image fails every draw and still
+          blocks once attempts are exhausted, while a bad host does not survive a
+          fresh draw. Each failed attempt records the machine it ran on and
+          excludes it from the next draw.
+
+          This SUPERSEDES the previous "infra-inconclusive only" rule, which
+          redrew only when no test had failed. That was written for a GPU-less
+          box, where the required-pass gate fires on skips; it could not help when
+          a bad host makes a real test FAIL, which is most of what happens.
+
+          config_error is never retried (our own bug — retrying hides it), and
+          neither is 130 (a cancellation is a decision, not a bad draw).
+
+          NOTE: a deterministic image defect blocks, but a FLAKY one can now pass
+          by luck, because one passing redraw ends the loop. That cost is accepted
+          in ADR 0029 and the suspect-machine record is what makes it visible.
         required: false
         type: number
         default: 0
@@ -231,11 +242,13 @@ jobs:
           while IFS= read -r kv; do [ -n "$kv" ] && ARGS+=(--env "$kv"); done <<< "${EXTRA_ENV}"
           if [ "${{ inputs.require_floor }}" = "true" ]; then ARGS+=(--require-floor); fi
 
-          # Retry only an INFRA-inconclusive outcome (2 = no_offers: nothing in the
-          # market matched the floors, so the image was never tested). Never retry a
-          # real failure (1), an instance crash (5) or a config error (4) — retrying a
-          # red is how a gate turns into decoration. 3 (bad_instance) is excluded
-          # because the client already exhausted its own launch attempts internally.
+          # Retry ANY failure except config_error (4) and interrupted (130), and
+          # exclude the machine that failed (ADR 0029). Reproducibility rather than
+          # symptom is the discriminator: an image defect fails every draw and
+          # still blocks when attempts run out; a bad host does not survive a fresh
+          # one. Retrying a red does risk passing by luck — that cost is accepted
+          # in ADR 0029, bounded by the attempt count, and made visible by the
+          # per-attempt machine record.
           ATTEMPTS=$(( ${{ inputs.retries }} + 1 ))
           for attempt in $(seq 1 "$ATTEMPTS"); do
             [ "$attempt" -gt 1 ] && echo "::notice::attempt ${attempt}/${ATTEMPTS} after an inconclusive market result"
@@ -298,14 +311,23 @@ jobs:
             # image defect has to pass EVERY redraw to escape, not just one.
             #
             # NOT 4 (config_error): that is our bug, and retrying hides it.
-            if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 4 ] && [ "$CODE" -ne 2 ]; then
+            # NOT 4 (config_error: our bug, retrying hides it) and NOT 130
+            # (interrupted: qa_verdict calls a cancellation "not a pass", and a
+            # cancelled run is a decision someone made, not a bad draw).
+            if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 4 ] && [ "$CODE" -ne 2 ] && [ "$CODE" -ne 130 ]; then
               # Name the box before redrawing. A machine that fails a test the
               # image passes elsewhere is a de-verification candidate, and that is
               # only actionable if the machine id is recorded at the moment it
               # failed — the instance is destroyed immediately afterwards.
-              _mid=$(jq -r '.machine_id // empty' /tmp/qa-raw.json 2>/dev/null || echo "")
-              _iid=$(jq -r '.instance_id // empty' /tmp/qa-raw.json 2>/dev/null || echo "")
-              _failed_names=$(jq -r '[.tests[]? | select(.state=="failed") | .name] | join(",")' /tmp/qa-raw.json 2>/dev/null || echo "")
+              # Take the LAST complete {...} line, never the whole file — the same
+              # parse qa_verdict.py documents, after a whole-file parse once
+              # "turned a real PASS into a BLOCK". Anything the client prints on
+              # stdout alongside the payload would otherwise make jq fail, leave
+              # _mid empty, and the redraw would land back on the failed host.
+              grep '^{.*}$' /tmp/qa-raw.json 2>/dev/null | tail -n1 > /tmp/qa-raw-last.json || : > /tmp/qa-raw-last.json
+              _mid=$(jq -r '.machine_id // empty' /tmp/qa-raw-last.json 2>/dev/null || echo "")
+              _iid=$(jq -r '.instance_id // empty' /tmp/qa-raw-last.json 2>/dev/null || echo "")
+              _failed_names=$(jq -r '[.tests[]? | select(.state=="failed") | .name] | join(",")' /tmp/qa-raw-last.json 2>/dev/null || echo "")
               echo "SUSPECT-HOST machine=${_mid:-unknown} instance=${_iid:-unknown} exit=${CODE} failed=${_failed_names:-none}"
               echo "${_mid:-unknown}|${_iid:-unknown}|${CODE}|${_failed_names:-none}" >> /tmp/qa-suspect-hosts.txt
               echo "::warning::cell failed on machine ${_mid:-unknown} (exit ${CODE}, failed: ${_failed_names:-none}) — drawing another host; if a redraw passes, this machine is a de-verification candidate"

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -267,6 +267,12 @@ jobs:
             # below ALSO sets CODE=2, for a host that failed. Both wait, but for
             # opposite reasons, and only one of them is worth waiting long for.
             _RETRY_REASON="no_offers"
+            # The client's REAL exit code, before the loop rewrites it. CODE=2 is a
+            # LOOP-CONTROL flag ("go round again"); it is not a verdict. Emitting it
+            # as the verdict aliases a real test failure onto EXIT_NO_OFFERS, which
+            # qa_verdict.py short-circuits to `inconclusive` — and on the scheduled
+            # comfyui/vllm gates `inconclusive` soft-passes and PROMOTES UNGATED.
+            _REAL_CODE=$CODE
             echo "---- attempt ${attempt} verdict ----"; cat /tmp/qa-raw.json || echo "(no --raw output)"
 
             # DRAW ANOTHER HOST ON ANY FAILURE, AND NAME THE HOST.
@@ -328,7 +334,8 @@ jobs:
               sleep "$_delay"
             fi
           done
-          echo "exit_code=${CODE}" >> "$GITHUB_OUTPUT"
+          # Emit what actually happened on the LAST attempt, never the loop flag.
+          echo "exit_code=${_REAL_CODE}" >> "$GITHUB_OUTPUT"
           echo "attempts=${attempt}" >> "$GITHUB_OUTPUT"
           if [ -s /tmp/qa-suspect-hosts.txt ]; then
             echo "suspect-hosts<<SUSPECT_EOF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -262,6 +262,11 @@ jobs:
               > /tmp/qa-raw.json
             CODE=$?
             set -e
+            # WHY we may retry, which is not the same as the code we retry ON.
+            # Exit 2 from the client means the market had nothing; the redraw
+            # below ALSO sets CODE=2, for a host that failed. Both wait, but for
+            # opposite reasons, and only one of them is worth waiting long for.
+            _RETRY_REASON="no_offers"
             echo "---- attempt ${attempt} verdict ----"; cat /tmp/qa-raw.json || echo "(no --raw output)"
 
             # DRAW ANOTHER HOST ON ANY FAILURE, AND NAME THE HOST.
@@ -299,16 +304,27 @@ jobs:
               echo "${_mid:-unknown}|${_iid:-unknown}|${CODE}|${_failed_names:-none}" >> /tmp/qa-suspect-hosts.txt
               echo "::warning::cell failed on machine ${_mid:-unknown} (exit ${CODE}, failed: ${_failed_names:-none}) — drawing another host; if a redraw passes, this machine is a de-verification candidate"
               CODE=2      # treat as inconclusive: retry on a fresh offer
+              _RETRY_REASON="host"
             fi
 
             [ "$CODE" -ne 2 ] && break
             if [ "$attempt" -lt "$ATTEMPTS" ]; then
-              # Jitter: a matrix of cells that all went inconclusive did so because
-              # the market was thin for all of them at once, so an unjittered delay
-              # marches them back to the single-key account in lockstep (ADR 0005
-              # cond 6). Spread is up to +50%.
-              _delay=$(( ${{ inputs.retry_delay }} + RANDOM % ((${{ inputs.retry_delay }} / 2) + 1) ))
-              echo "no offers matched the floors; waiting ${_delay}s before retrying"
+              if [ "$_RETRY_REASON" = "host" ]; then
+                # A HOST failed. The market is not thin — there is nothing to wait
+                # for, and the machine that failed is now excluded, so the next
+                # draw is a different box. Waiting the market backoff here cost
+                # ~7 minutes per redraw for no reason. A small jitter only, so a
+                # matrix of cells does not re-enter the single-key QA account in
+                # lockstep (ADR 0005 cond 6).
+                _delay=$(( 5 + RANDOM % 20 ))
+                echo "host fault; drawing another machine in ${_delay}s"
+              else
+                # Genuinely no offers matched the floors. Here the wait IS the
+                # point: capacity has to appear. Jitter up to +50% for the same
+                # lockstep reason.
+                _delay=$(( ${{ inputs.retry_delay }} + RANDOM % ((${{ inputs.retry_delay }} / 2) + 1) ))
+                echo "no offers matched the floors; waiting ${_delay}s before retrying"
+              fi
               sleep "$_delay"
             fi
           done

--- a/docs/adr/0019-base-image-promotion-qa-gate.md
+++ b/docs/adr/0019-base-image-promotion-qa-gate.md
@@ -452,8 +452,7 @@ arithmetic was right, but it treated per-cell flakiness as fixed. It is not.
 The first promote to run under this ADR held exactly one tag, and the cause was a
 rented host that presented **no GPU**: `60/61/62` skipped, `skip != pass` blocked
 the cell. Nothing about the image was tested or faulty. That is a *bad draw*, and
-the answer to a bad draw is another draw — not a partial promotion. The gate now
-distinguishes the two by whether any test actually **failed**:
+the answer to a bad draw is another draw — not a partial promotion.
 
 > **SUPERSEDED 2026-08-19 by ADR 0029.** The zero-failure rule below — and its
 > 2026-08-14 extension to exit 5 — no longer describes the gate. On 2026-08-18
@@ -463,8 +462,9 @@ distinguishes the two by whether any test actually **failed**:
 > tests FAIL. A cell now redraws on any non-zero exit except `config_error`, and
 > records the machine it failed on. The paragraph below is kept as the reasoning
 > that was current at the time, not as the rule.
- a host that cannot
-run the GPU tests makes them SKIP, a defective image makes them FAIL. Zero
+
+The gate distinguished the two by whether any test actually **failed**: a host
+that cannot run the GPU tests makes them SKIP, a defective image makes them FAIL. Zero
 failures with a non-zero exit means nothing was tested, which is the same class as
 `no_offers`, and it is retried on a fresh offer. A single genuine failure still
 breaks immediately — retrying a real red until it passes by luck remains the thing

--- a/docs/adr/0029-qa-redraws-on-any-failure-and-names-the-host.md
+++ b/docs/adr/0029-qa-redraws-on-any-failure-and-names-the-host.md
@@ -46,11 +46,11 @@ None was an image defect. All six produced **failed tests**, so the zero-failure
 rule could not redraw any of them. That is the flaw: it was built for a host that
 makes tests SKIP, and a bad host mostly makes tests FAIL.
 
-An earlier attempt at this — the fault-domain model of ADR 0020, on the pytorch
-config-table branch — was dropped on 2026-08-18 during a rebase, to keep main's
-conventions while that branch landed. This ADR reaches the same conclusion from
+An earlier attempt at this — the fault-domain model described in option C below,
+drafted on the pytorch config-table branch and never merged — was dropped on
+2026-08-18 during a rebase, to keep main's conventions while that branch landed. This ADR reaches the same conclusion from
 the opposite direction, with the evidence the first run produced, and adds the
-part ADR 0020 did not have: naming the host.
+part that draft did not have: naming the host.
 
 ## Options considered
 
@@ -77,13 +77,18 @@ would have excluded healthy capacity and still drawn the bad boxes.
 
 ### C. Fault-domain classification in `qa_verdict.py` (rejected for now)
 
-ADR 0020's model: classify each outcome into HOST or IMAGE, retry the former.
+Classify each outcome into a HOST or an IMAGE fault domain and retry only the
+former: a timeout, a dead instance, `no_offers` and `bad_instance` are the host's;
+a real assertion failure, a required-test miss and a config error are the image's.
 Cleaner in principle, and it moves the decision into tested Python.
+
+This was drafted as ADR 0020 on the pytorch config-table branch and **never
+landed on `main`** — the number is unallocated in `docs/adr/` here, so the model
+is summarised above rather than cited, and a reader should not go looking for it.
 
 Rejected as the immediate step because it is a larger change to a shared verdict
 path, and because the discriminator it needs — *does this reproduce?* — is
-exactly what a redraw already measures. Reconsider if the redraw proves too
-coarse; the two are compatible.
+exactly what a redraw already measures. Reconsider if the redraw proves too coarse; the two are compatible.
 
 ### D. Redraw on any failure, and record the host (chosen)
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -591,11 +591,26 @@ invariant:
 > An auto tag may only move to a digest that PASSED live-GPU QA in this run, on
 > that exact digest. Anything else HOLDS the tag at its current digest.
 
-**A failing cell redraws before it blocks (ADR 0029).** `qa-gate.yml` is shared by
-base, pytorch, comfyui and vllm, and none of them carries retry logic of its own —
-so base-image is the reference for how a QA cell behaves everywhere. A cell now
-redraws on any non-zero exit except `config_error`, because reproducibility rather
-than symptom is what separates a bad host from a bad image: measured on 2026-08-18,
+Not statically checkable — it is a property of ~420 lines of bash inside
+`promote-base-image.yml`, and a linter cannot see a working gate versus a copy of
+one. It has been disarmed three times, each time with the whole suite green:
+
+| how it was disarmed | why the tests missed it |
+|---|---|
+| the hold check was written into `dry-run`, not `promote` | the test grepped the whole file and found the stray copy |
+| the `continue` was deleted from the hold branch | the test asserted the `if` line exists, not that it skips |
+| five assignments were deleted from the `dry-run` loop | nothing asserted anything about `dry-run` |
+
+### A failing cell redraws before it blocks (ADR 0029)
+
+`qa-gate.yml` is shared by base, comfyui and vllm (and imagegen-tests), none
+of which carries retry logic of its own — so base-image is the reference for
+how a QA cell behaves everywhere. (pytorch's gate is real but lives on an
+unmerged branch; it is NOT on main, so a reader following this to
+`promote-pytorch.yml` will not find a QA job there yet.)
+
+A cell redraws on any non-zero exit except `config_error` (4) and `interrupted`
+(130), because reproducibility rather than symptom is what separates a bad host from a bad image: measured on 2026-08-18,
 six of seventy pytorch cells blocked and every one investigated passed on other
 hardware, all of them with FAILED tests that the previous zero-failure rule could
 not redraw.
@@ -612,15 +627,6 @@ rule would have blocked it. A deterministic one still fails every draw and block
 The suspect record is what makes the trade defensible — an image failing across
 many DIFFERENT machines shows as a pattern rather than a green tick.
 
-Not statically checkable — it is a property of ~420 lines of bash inside
-`promote-base-image.yml`, and a linter cannot see a working gate versus a copy of
-one. It has been disarmed three times, each time with the whole suite green:
-
-| how it was disarmed | why the tests missed it |
-|---|---|
-| the hold check was written into `dry-run`, not `promote` | the test grepped the whole file and found the stray copy |
-| the `continue` was deleted from the hold branch | the test asserted the `if` line exists, not that it skips |
-| five assignments were deleted from the `dry-run` loop | nothing asserted anything about `dry-run` |
 
 There is **no bypass**: the `SKIP_QA` dispatch input added on 2026-08-05 was
 removed on 2026-08-07 (ADR 0019 cond 3, amended). Its untested-ness stuck to the
@@ -716,3 +722,4 @@ oobabooga). The `new-image` skill + generator encode them.
   stub `nvidia-smi` + `nvcc` on PATH + `UNSLOTH_LLAMA_CUDA_ARCHS`) **and** carry a post-build
   `test -f …/libggml-cuda.so` assertion so the CPU-only regression fails the build instead of
   shipping. **L056** gates the assertion. Both `unsloth-studio` and `aio-studio` are fixed (ADR 0016).
+

--- a/tools/template_manager/test_template.py
+++ b/tools/template_manager/test_template.py
@@ -1354,7 +1354,21 @@ def parse_args():
     parser.add_argument("--env", metavar="KEY=VAL", action="append", default=[],
                         help="Set instance env var (repeatable). Timeout overrides: "
                              "PROV_TIMEOUT, VLLM_HEALTH_TIMEOUT, INSTANCE_TEST_DEFAULT_TIMEOUT")
-    return parser.parse_args()
+    # argparse exits 2 on a usage error — the SAME code as EXIT_NO_OFFERS, which
+    # qa_verdict maps to `inconclusive`, which a scheduled run soft-passes and
+    # promotes UNGATED while Slack blames a thin market. A typo'd flag or any
+    # skew between the gate and this client would therefore fail OPEN on the
+    # unattended path. config_error is the one code the gate refuses to retry and
+    # the verdict tool maps to BLOCK, which is exactly right for "our harness is
+    # wrong". Latent until the gate began passing --exclude-machine.
+    try:
+        return parser.parse_args()
+    except SystemExit as e:
+        if e.code in (None, 0):
+            raise                      # --help and friends
+        print(json.dumps({"state": "config_error", "exit_code": EXIT_CONFIG_ERROR,
+                          "reason": "bad arguments to test_template.py"}))
+        sys.exit(EXIT_CONFIG_ERROR)
 
 
 def main():

--- a/tools/template_manager/tests/test_machine_exclusion.py
+++ b/tools/template_manager/tests/test_machine_exclusion.py
@@ -141,3 +141,45 @@ def test_a_host_fault_does_not_wait_for_market_capacity():
     assert "RANDOM %" in host_branch, (
         "keep a small jitter so a matrix does not re-enter the single-key QA "
         "account in lockstep (ADR 0005 cond 6)")
+
+
+# ---- the loop flag must never become the verdict ----------------------------
+
+def test_an_exhausted_redraw_reports_the_REAL_exit_code_not_the_loop_flag():
+    """The redraw sets CODE=2 to mean "go round again". Exit 2 is also
+    EXIT_NO_OFFERS, which `qa_verdict.classify` short-circuits to `inconclusive`
+    BEFORE it looks at any test result — and on the scheduled comfyui/vllm gates
+    `inconclusive` soft-passes and promotes UNGATED.
+
+    So emitting the loop flag as the verdict turns a real, reproducible test
+    failure into an automatic production promotion, twice a day, announced as
+    "no live test ran". `retries` defaults to 0, so those two pipelines never even
+    redraw — they got the aliasing with none of the benefit.
+    """
+    g = _gate()
+    assert "_REAL_CODE=$CODE" in g, (
+        "the client's real exit code is not preserved before the loop rewrites it")
+    assert 'echo "exit_code=${_REAL_CODE}"' in g, (
+        "the loop-control flag is emitted as the verdict; a real test failure "
+        "becomes EXIT_NO_OFFERS and soft-passes on the scheduled gates")
+    assert 'echo "exit_code=${CODE}"' not in g, (
+        "CODE is the loop flag, not a verdict")
+
+
+def test_a_real_failure_classifies_as_block_not_inconclusive():
+    """The end-to-end property, driven through the real classifier rather than
+    asserted about the YAML."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("qa_verdict", TM / "qa_verdict.py")
+    qv = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(qv)
+    raw = {"state": "failed", "got_result_event": True,
+           "tests": [{"name": "base/60-gpu-cuda", "state": "failed"}],
+           "stream_counts": {"passed": 10, "failed": 1, "skipped": 0}}
+    req = qv.parse_required("base/60-gpu-cuda")
+    assert qv.classify(1, raw, req)[0] == "block", "a real failure must block"
+    assert qv.classify(5, raw, req)[0] == "block", "an instance error must block"
+    # The bug, pinned: if the gate ever emits 2 for this payload the verdict flips.
+    assert qv.classify(2, raw, req)[0] == "inconclusive", (
+        "exit 2 means no-box-obtained; this is exactly why the loop flag must "
+        "never be emitted as the verdict")

--- a/tools/template_manager/tests/test_machine_exclusion.py
+++ b/tools/template_manager/tests/test_machine_exclusion.py
@@ -183,3 +183,37 @@ def test_a_real_failure_classifies_as_block_not_inconclusive():
     assert qv.classify(2, raw, req)[0] == "inconclusive", (
         "exit 2 means no-box-obtained; this is exactly why the loop flag must "
         "never be emitted as the verdict")
+
+
+def test_a_usage_error_is_config_error_not_no_offers():
+    """argparse exits 2 on a bad flag — the SAME code as EXIT_NO_OFFERS.
+
+    qa_verdict maps 2 to `inconclusive`, which a scheduled run soft-passes and
+    promotes UNGATED while Slack blames a thin market. So any skew between the
+    gate and this client — a typo, a flag added on one side only — failed OPEN on
+    the unattended path. Latent until the gate started passing --exclude-machine,
+    which is a new place for that skew to appear.
+    """
+    import subprocess, sys as _s
+    r = subprocess.run([_s.executable, str(TM / "test_template.py"), "--bogus-flag", "x"],
+                       capture_output=True, text=True)
+    assert r.returncode == 4, (
+        f"a usage error exited {r.returncode}; 2 is EXIT_NO_OFFERS and soft-passes "
+        f"on the schedule path")
+    assert "config_error" in r.stdout
+
+
+def test_help_still_exits_zero():
+    """The guard must not swallow --help."""
+    import subprocess, sys as _s
+    r = subprocess.run([_s.executable, str(TM / "test_template.py"), "--help"],
+                       capture_output=True, text=True)
+    assert r.returncode == 0
+
+
+def test_interrupted_is_not_redrawn():
+    """qa_verdict calls exit 130 'a cancellation is not a pass'. Redrawing it
+    would turn a decision someone made into a bad draw."""
+    g = _gate()
+    assert '[ "$CODE" -ne 130 ]' in g, (
+        "exit 130 (interrupted) is redrawn; a cancellation must not be retried")

--- a/tools/template_manager/tests/test_machine_exclusion.py
+++ b/tools/template_manager/tests/test_machine_exclusion.py
@@ -98,3 +98,46 @@ def test_the_gate_actually_PASSES_the_exclusions_to_the_client():
         "the redraw can re-pick the box it just failed on")
     assert "qa-suspect-hosts.txt" in gate.split("--exclude-machine")[0][-900:], (
         "the exclusions must be built from the recorded failures, not a fresh list")
+
+
+# ---- a host fault is not a market shortage ----------------------------------
+
+def _gate() -> str:
+    return (TM.parents[1] / ".github" / "workflows" / "qa-gate.yml").read_text()
+
+
+def test_a_host_fault_is_not_reported_as_no_offers():
+    """Observed 2026-08-19 in run 32236327488.
+
+    Making the redraw reuse exit code 2 gave that code two meanings — the
+    client's genuine `no_offers`, and our own "a host failed, draw again". The
+    wait branch only knew the first, so a cell that drew two GPU-less boxes in a
+    row reported `no offers matched the floors` twice. cu130 had 452 distinct
+    machines available at the time; nothing was short. The message sent the
+    reader to raise the floors, which would have been the wrong fix.
+    """
+    g = _gate()
+    assert '_RETRY_REASON="host"' in g, (
+        "the redraw branch must MARK itself as a host fault; merely having the "
+        "variable is not enough — if it stays 'no_offers' the message is wrong "
+        "again, which is the exact bug this guards")
+    assert '_RETRY_REASON="no_offers"' in g, (
+        "the default must remain the client's own no-offers meaning")
+    assert 'host fault; drawing another machine' in g, (
+        "a host-fault redraw must say so rather than blaming the market")
+    assert 'no offers matched the floors' in g, (
+        "the genuine market-shortage message must survive")
+
+
+def test_a_host_fault_does_not_wait_for_market_capacity():
+    """The two reasons want opposite waits. A thin market needs capacity to
+    appear, so the backoff IS the point. A bad host needs a different box, which
+    is available right now and already excluded — waiting the market backoff cost
+    about seven minutes per redraw for nothing, multiplied across 70 cells."""
+    g = _gate()
+    host_branch = g.split('if [ "$_RETRY_REASON" = "host" ]')[1][:700]
+    assert "inputs.retry_delay" not in host_branch, (
+        "the host-fault path must not use the market backoff")
+    assert "RANDOM %" in host_branch, (
+        "keep a small jitter so a matrix does not re-enter the single-key QA "
+        "account in lockstep (ADR 0005 cond 6)")

--- a/tools/template_manager/tests/test_promote_notification_truth.py
+++ b/tools/template_manager/tests/test_promote_notification_truth.py
@@ -511,7 +511,6 @@ def test_the_clamped_text_is_not_simply_discarded():
     dropping it would trade one lost message for a misleading one."""
     body = NOTIFY.read_text()
     assert "HEADER_OVERFLOW" in body, "the clamped text is discarded"
-    overflow = body.split("HEADER_OVERFLOW")[-1]
     assert "section" in body.split('if [[ -n "$HEADER_OVERFLOW" ]]')[-1][:400], (
         "the overflow must be re-attached as a body block, not thrown away")
 
@@ -521,8 +520,26 @@ def test_the_clamp_is_defensive_in_the_shared_notifier_not_only_the_caller():
     callers. The component that knows Slack's limits is the one that must hold
     them."""
     callers = [p.name for p in (REPO / ".github" / "workflows").glob("*.yml")
-               if "notify-slack.yml" in p.read_text()]
+               if p.name != "notify-slack.yml" and "notify-slack.yml" in p.read_text()]
     assert len(callers) >= 3, (
         f"expected several callers of the shared notifier, found {callers}")
     assert "${#HEADER_TEXT} -gt 150" in NOTIFY.read_text(), (
         "the clamp must live in the shared notifier so no caller can break it")
+
+
+def test_the_word_boundary_cut_does_not_eat_the_budget():
+    """The trim must be conditional on the TRIMMED length, not the pre-trim one.
+
+    The first version tested `${#_cut}`, which is always 147 at that point, so
+    the condition was vacuously true. A headline whose tail is a space-free list
+    — a comma-joined tag list — then trimmed back to the last space in the prose
+    prefix. Measured: 194 characters in, 27 out. The full text survived in the
+    overflow block, so nothing was lost, but the header collapsed to a fifth of
+    its budget.
+    """
+    body = NOTIFY.read_text()
+    assert "${#_trim} -gt 120" in body, (
+        "the word-boundary guard must test the trimmed string; testing the "
+        "fixed-length cut is vacuously true and throws away the budget")
+    assert "${#_cut} -gt 120" not in body, (
+        "this is the vacuous form — _cut is always 147 where it is tested")

--- a/tools/template_manager/tests/test_promote_notification_truth.py
+++ b/tools/template_manager/tests/test_promote_notification_truth.py
@@ -478,3 +478,51 @@ def test_exoneration_is_distinguished_from_a_still_suspect_image():
         "the report must distinguish a redraw-exonerated image from one that "
         "never passed; otherwise good hosts get de-verified for an image bug")
     assert 'FINAL_CODE' in body, "the distinction must key on the cell's final outcome"
+
+
+# ---- the notifier must survive any caller's headline -------------------------
+
+NOTIFY = REPO / ".github" / "workflows" / "notify-slack.yml"
+
+
+def test_the_slack_header_is_clamped_to_slacks_limit():
+    """Observed 2026-08-19, run 32239585814.
+
+    promote-pytorch built a 527-character headline enumerating the QA'd
+    artifacts. Slack's header block is plain_text with a hard 150-character
+    limit, so the whole POST was rejected with HTTP 400 and the notification was
+    lost — including the part that says whether anything shipped. The promotion
+    had fully SUCCEEDED, every tag pushed, and the run still reported failure
+    because the only thing that broke was the announcement of the success.
+
+    This file already truncates the tags section for its 3000-char limit; the
+    header was never clamped, so any of the five callers could break the shared
+    notifier.
+    """
+    body = NOTIFY.read_text()
+    assert "${#HEADER_TEXT} -gt 150" in body, (
+        "the header is not clamped to Slack's 150-char limit, so a long headline "
+        "from any caller loses the entire notification to an HTTP 400")
+
+
+def test_the_clamped_text_is_not_simply_discarded():
+    """A headline long enough to clamp is carrying information. The body has a
+    3000-char limit rather than 150, so the overflow belongs there — silently
+    dropping it would trade one lost message for a misleading one."""
+    body = NOTIFY.read_text()
+    assert "HEADER_OVERFLOW" in body, "the clamped text is discarded"
+    overflow = body.split("HEADER_OVERFLOW")[-1]
+    assert "section" in body.split('if [[ -n "$HEADER_OVERFLOW" ]]')[-1][:400], (
+        "the overflow must be re-attached as a body block, not thrown away")
+
+
+def test_the_clamp_is_defensive_in_the_shared_notifier_not_only_the_caller():
+    """Fixing only promote-pytorch would leave the same trap for the other four
+    callers. The component that knows Slack's limits is the one that must hold
+    them."""
+    callers = [p.name for p in (REPO / ".github" / "workflows").glob("*.yml")
+               if "notify-slack.yml" in p.read_text()]
+    assert len(callers) >= 3, (
+        f"expected several callers of the shared notifier, found {callers}")
+    assert "${#HEADER_TEXT} -gt 150" in NOTIFY.read_text(), (
+        "the clamp must live in the shared notifier so no caller can break it")

--- a/tools/template_manager/tests/test_qa_gate_executed.py
+++ b/tools/template_manager/tests/test_qa_gate_executed.py
@@ -278,3 +278,70 @@ def test_a_short_prefix_with_a_space_free_tail_keeps_its_budget(tmp_path):
     assert len(header) >= 140, (
         f"header collapsed to {len(header)} chars — the word-boundary trim ate "
         f"the budget by trimming back to the only space, in the prefix")
+
+
+def test_a_failed_notification_does_not_fail_the_run_it_reports_on(tmp_path):
+    """A fully successful promotion reported as a failed run, because the
+    announcement got a 400. The clamp fixes that trigger; `curl -f` is the class —
+    a 429, a Slack 5xx, or the next payload limit would each do it again.
+
+    "The promotion worked but the run is red" is the most expensive false alarm:
+    it trains people to discount red on the pipeline where red matters most.
+    """
+    script = wfexec.step_script(NOTIFY, "notify", "Notify Slack")
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    bindir = workdir / "bin"
+    bindir.mkdir()
+    # curl that always fails, as Slack would on any non-2xx
+    (bindir / "curl").write_text('#!/bin/bash\nexit 22\n')
+    (bindir / "curl").chmod(0o755)
+    r, _, _ = _run(script, workdir, {
+        "HEADLINE": "PyTorch promoted", "BUILD_RESULT": "success", "STATUS": "",
+        "IMAGE_NAME": "PyTorch", "IMAGE_TAGS": "[]", "TRIGGER": "schedule",
+        "IMAGE_REF": "2026-08-18", "RUN_URL": "https://example/1",
+        "SLACK_WEBHOOK_URL": "https://hooks.example/x"})
+    assert r.returncode == 0, (
+        "a failed Slack POST failed the step, turning a successful promotion "
+        f"into a red run: {r.stderr}")
+    assert "::warning::" in (r.stdout + r.stderr), "the failure must still be surfaced"
+
+
+def test_a_redraw_is_visible_in_the_job_summary(tmp_path):
+    """ADR 0029's own reversal tripwire cites the redraw RATE. An output nothing
+    reads cannot show it, so a cell that needed extra attempts says so."""
+    tm = tmp_path / "tm"
+    tm.mkdir(parents=True, exist_ok=True)
+    (tm / "counter").write_text("0")
+    (tm / "test_template.py").write_text(
+        "import sys, pathlib\n"
+        "c = pathlib.Path(__file__).with_name('counter')\n"
+        "i = int(c.read_text()); c.write_text(str(i + 1))\n"
+        f"print({RED!r} % (35974 + i))\n"
+        "sys.exit(1 if i == 0 else 0)\n")
+    (tmp_path / "qa-suspect-hosts.txt").write_text("")
+    script = _loop_script().replace("/tmp/qa-suspect-hosts.txt",
+                                    str(tmp_path / "qa-suspect-hosts.txt"))
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    (bindir / "python").write_text(f'#!/bin/bash\nexec {sys.executable} "$@"\n')
+    (bindir / "python").chmod(0o755)
+    (bindir / "sleep").write_text('#!/bin/bash\nexit 0\n')
+    (bindir / "sleep").chmod(0o755)
+    r, summary, _ = _run(script, tmp_path, {
+        "TM": str(tm), "LOG_PATHS": "", "EXTRA_ENV": "",
+        "QA_REPO": "pytorch", "QA_TAG": "auto-cu126"})
+    assert r.returncode == 0, r.stderr
+    assert "QA redraws" in summary and "2** attempts" in summary, (
+        f"a redraw left no trace in the job summary:\n{summary}")
+
+
+def test_interrupted_is_never_redrawn(tmp_path):
+    """exit 130. qa_verdict calls a cancellation "not a pass"; redrawing it turns
+    a decision someone made into a bad draw, and spends money doing it. Executed
+    rather than grepped, because a grep for the literal survives moving the test
+    out of the condition."""
+    r, out, _ = _run_loop(tmp_path, [130, 0], [35974, 136916])
+    assert out["exit_code"] == "130", "a cancellation must not be retried"
+    assert out["attempts"] == "1", (
+        f"redrew a cancelled run ({out['attempts']} attempts)")

--- a/tools/template_manager/tests/test_qa_gate_executed.py
+++ b/tools/template_manager/tests/test_qa_gate_executed.py
@@ -1,0 +1,280 @@
+"""Run the gate's shell, don't grep it.
+
+A blind panel mutation-tested the guards added alongside these steps and found
+three that pass while the behaviour they name is destroyed:
+
+  * `>> /tmp/qa-suspect-hosts.txt` -> `>`  (only the last suspect survives)
+  * inverting the exoneration test        (tells a human to de-verify healthy
+                                           hosts, and clears genuinely bad ones)
+  * deleting `HEADER_TEXT="${_cut}…"`     (header never shortened; the HTTP 400
+                                           that lost a whole notification returns)
+
+All three were greps for a string the same commit had just written. wfexec.py
+exists precisely to end that pattern — its docstring records the gate being
+disarmed twice with the suite green — and it was not used. These tests execute
+the real `run:` blocks with stubbed externals and assert on what comes out.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wfexec  # noqa: E402
+
+QA_GATE = wfexec.QA_GATE
+NOTIFY = wfexec.REPO / ".github/workflows/notify-slack.yml"
+
+
+def _run(script: str, workdir: Path, env: dict, stub_curl: bool = False):
+    """bash -e the script with a PATH that can carry a stubbed curl."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    bindir = workdir / "bin"
+    bindir.mkdir(exist_ok=True)
+    if stub_curl:
+        # Capture the payload instead of POSTing it, and succeed, so the test
+        # asserts on what WOULD be sent rather than on Slack's availability.
+        (bindir / "curl").write_text(
+            '#!/bin/bash\nfor a in "$@"; do prev=$a; done\n'
+            'while [ $# -gt 0 ]; do [ "$1" = "--data" ] && { echo "$2" > "$CURL_BODY"; }; shift; done\n'
+            'exit 0\n')
+        (bindir / "curl").chmod(0o755)
+    summary = workdir / "summary.md"
+    summary.write_text("")
+    out = workdir / "gh_out"
+    out.write_text("")
+    e = {"PATH": f"{bindir}:/usr/bin:/bin", "HOME": str(workdir),
+         "GITHUB_STEP_SUMMARY": str(summary), "GITHUB_OUTPUT": str(out), **env}
+    r = subprocess.run(["bash", "-e", "-c", script], cwd=workdir,
+                       capture_output=True, text=True, env=e)
+    return r, summary.read_text(), out.read_text()
+
+
+# ---- the exoneration branch (ADR 0029 binding condition 3) -------------------
+
+REPORT = "Report suspect hosts"
+
+
+def _report(workdir, suspects: str, final_code: str):
+    script = wfexec.step_script(QA_GATE, "qa", REPORT)
+    return _run(script, workdir, {"SUSPECTS": suspects, "FINAL_CODE": final_code,
+                                  "QA_REPO": "pytorch", "QA_TAG": "qa-1-auto-cu126"})
+
+
+def test_a_cell_that_passed_after_a_redraw_names_de_verification_candidates(tmp_path):
+    r, summary, _ = _report(tmp_path, "35974|48034321|1|pytorch.d/40-nccl-init", "0")
+    assert r.returncode == 0, r.stderr
+    assert "De-verification candidates" in summary
+    assert "NOT exonerated" not in summary
+    assert "35974" in summary
+
+
+def test_a_cell_that_NEVER_passed_must_not_name_de_verification_candidates(tmp_path):
+    """The image is still a live suspect, so these hosts are not evidence.
+    Inverting the branch would tell an operator to remove healthy third-party
+    machines from the marketplace for a defect that is ours."""
+    r, summary, _ = _report(tmp_path, "35974|48034321|1|pytorch.d/40-nccl-init", "1")
+    assert r.returncode == 0, r.stderr
+    assert "NOT exonerated" in summary, (
+        "a cell that never passed must not present its hosts as at fault")
+    assert "De-verification candidates" not in summary
+
+
+def test_an_unknown_machine_is_not_offered_for_de_verification(tmp_path):
+    """exit 3 (bad_instance) is emitted before any machine is bound, so the
+    record is `unknown`. Presenting that as a candidate is noise at best and a
+    wrong accusation at worst."""
+    r, summary, _ = _report(tmp_path, "unknown|unknown|3|none", "0")
+    assert r.returncode == 0, r.stderr
+    assert "`unknown`" not in summary, "an unknown machine id must not be tabled"
+
+
+def test_every_recorded_attempt_appears_not_just_the_last(tmp_path):
+    """Kills the `>>` -> `>` mutation: one machine failing is a bad host, several
+    DIFFERENT machines failing the same image is the pattern that says the image
+    is at fault — which is the whole mitigation ADR 0029 rests on."""
+    r, summary, _ = _report(
+        tmp_path, "35974|1|1|a\n136916|2|1|a\n140359|3|1|a", "0")
+    assert r.returncode == 0, r.stderr
+    for m in ("35974", "136916", "140359"):
+        assert m in summary, f"machine {m} missing from the report"
+
+
+# ---- the Slack header clamp -------------------------------------------------
+
+def _notify(workdir, headline: str, build_result="success"):
+    script = wfexec.step_script(NOTIFY, "notify", "Notify Slack")
+    body = workdir / "body.json"
+    env = {"HEADLINE": headline, "BUILD_RESULT": build_result, "STATUS": "",
+           "IMAGE_NAME": "PyTorch (Production)", "IMAGE_TAGS": "[]",
+           "TRIGGER": "workflow_dispatch", "IMAGE_REF": "2026-08-18",
+           "RUN_URL": "https://example/run/1", "CURL_BODY": str(body),
+           "SLACK_WEBHOOK_URL": "https://hooks.example/x"}
+    r, _, _ = _run(script, workdir, env, stub_curl=True)
+    payload = json.loads(body.read_text()) if body.exists() else None
+    return r, payload
+
+
+def _blocks(payload):
+    # Slack payload is {"attachments":[{"blocks":[...]}]}, not top-level blocks.
+    return payload["attachments"][0]["blocks"]
+
+
+def _header_of(payload):
+    for b in _blocks(payload):
+        if b.get("type") == "header":
+            return b["text"]["text"]
+    raise AssertionError("no header block")
+
+
+LONG = ("PyTorch promoted — 70/70 artifacts QA'd on live GPUs (amd64, single GPU; "
+        "mini exhaustively, auto+multi at default python). Tested: "
+        + ",".join(f"2.13.0-cuda-12.6.3-py31{i}" for i in range(9)))
+
+
+def test_a_long_headline_is_clamped_below_slacks_header_limit(tmp_path):
+    """Slack's header block is plain_text with a hard 150-char limit and rejects
+    the WHOLE post with HTTP 400 above it — losing the notification entirely,
+    including whether anything shipped. Measured live at 527 chars."""
+    r, payload = _notify(tmp_path, LONG)
+    assert r.returncode == 0, r.stderr
+    assert payload is not None, "no payload was sent"
+    assert len(_header_of(payload)) <= 150, (
+        f"header is {len(_header_of(payload))} chars; Slack rejects >150 with a 400")
+
+
+def test_the_clamped_text_survives_in_the_body(tmp_path):
+    """A headline long enough to clamp is carrying information; the body limit is
+    3000, not 150. Dropping it would trade a lost message for a misleading one."""
+    _, payload = _notify(tmp_path, LONG)
+    blob = json.dumps(payload)
+    assert "70/70 artifacts" in blob
+    assert LONG[-30:] in blob, "the tail of the headline was discarded"
+
+
+def test_the_clamp_does_not_eat_the_budget_on_a_space_free_tail(tmp_path):
+    """The word-boundary trim must be conditional on the TRIMMED length. Testing
+    the fixed-width cut is vacuously true, and a comma-joined tag tail then
+    trimmed back into the prose prefix: 194 chars in, 27 out."""
+    _, payload = _notify(tmp_path, LONG)
+    assert len(_header_of(payload)) >= 100, (
+        f"header collapsed to {len(_header_of(payload))} chars — the trim ate the budget")
+
+
+def test_a_short_headline_is_left_alone(tmp_path):
+    _, payload = _notify(tmp_path, "PyTorch promoted")
+    assert "…" not in _header_of(payload)
+
+
+# ---- the redraw loop itself --------------------------------------------------
+#
+# The step carries seven scalar `${{ }}` inputs, so wfexec.step_script refuses it.
+# They are bound explicitly below and the result is asserted to contain no
+# leftover expression — the script under test is the one CI runs, with its inputs
+# supplied, rather than a paraphrase of it.
+
+_BIND = {"inputs.label": "qa-test", "inputs.max_price": "1.00",
+         "inputs.require_floor": "false", "inputs.retries": "2",
+         "inputs.retry_delay": "0", "inputs.timeout": "60",
+         "steps.create.outputs.hash": "deadbeef"}
+
+
+def _loop_script(retries="2"):
+    import yaml as _y
+    wf = _y.safe_load(QA_GATE.read_text())
+    step = [s for s in wf["jobs"]["qa"]["steps"] if s.get("id") == "test"][0]
+    script = step["run"]
+    for expr, val in {**_BIND, "inputs.retries": retries}.items():
+        script = script.replace("${{ " + expr + " }}", val)
+    assert "${{" not in script, "unresolved expression — bind it, never guess"
+    return script
+
+
+RED = ('{"state":"failed","got_result_event":true,"machine_id":%d,'
+       '"tests":[{"name":"base/60-gpu-cuda","state":"failed"}],'
+       '"stream_counts":{"passed":1,"failed":1,"skipped":0}}')
+
+
+def _run_loop(tmp_path, exit_codes, machines):
+    """Stub the client: one exit code + machine id per attempt, in order."""
+    tm = tmp_path / "tm"
+    tm.mkdir(parents=True, exist_ok=True)
+    (tm / "counter").write_text("0")
+    (tm / "test_template.py").write_text(
+        "import sys, pathlib\n"
+        f"codes = {list(exit_codes)!r}\nmachines = {list(machines)!r}\n"
+        "c = pathlib.Path(__file__).with_name('counter')\n"
+        "i = int(c.read_text()); c.write_text(str(i + 1))\n"
+        "i = min(i, len(codes) - 1)\n"
+        f"print({RED!r} % machines[i])\n"
+        "sys.exit(codes[i])\n")
+    # a fresh suspect file per run, as a real runner VM would have
+    (tmp_path / "qa-suspect-hosts.txt").write_text("")
+    script = _loop_script().replace("/tmp/qa-suspect-hosts.txt",
+                                    str(tmp_path / "qa-suspect-hosts.txt"))
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    # `python` (the workflow calls it unqualified) and `sleep` are externals, and
+    # stubbing an external is what wfexec already does for `crane`. Stubbing sleep
+    # keeps the real backoff arithmetic under test while not spending it.
+    (bindir / "python").write_text(f'#!/bin/bash\nexec {sys.executable} "$@"\n')
+    (bindir / "python").chmod(0o755)
+    (bindir / "sleep").write_text('#!/bin/bash\nexit 0\n')
+    (bindir / "sleep").chmod(0o755)
+    r, _, out = _run(script, tmp_path, {"TM": str(tm), "LOG_PATHS": "", "EXTRA_ENV": ""})
+    outputs = dict(l.split("=", 1) for l in out.splitlines() if "=" in l and not l.startswith("suspect"))
+    return r, outputs, (tmp_path / "qa-suspect-hosts.txt").read_text()
+
+
+def test_an_exhausted_redraw_emits_the_REAL_code_so_a_red_still_BLOCKS(tmp_path):
+    """The defect four reviewers found independently. CODE=2 is a loop flag, but
+    it was emitted as the verdict — and exit 2 is EXIT_NO_OFFERS, which
+    qa_verdict short-circuits to `inconclusive` before reading any test result.
+    On a scheduled run that soft-passes and PROMOTES the broken image."""
+    r, out, _ = _run_loop(tmp_path, [1, 1, 1], [35974, 136916, 140359])
+    assert r.returncode == 0, r.stderr
+    assert out["exit_code"] == "1", (
+        f"emitted exit_code={out['exit_code']}; 2 means no_offers, which "
+        f"soft-passes on the schedule path and promotes a failing image")
+
+
+def test_every_attempt_is_recorded_not_just_the_last(tmp_path):
+    """Kills `>>` -> `>`. One machine failing is a bad host; several DIFFERENT
+    machines failing the same image is the pattern ADR 0029's whole mitigation
+    rests on, and it only exists if every attempt is kept."""
+    _, _, suspects = _run_loop(tmp_path, [1, 1, 1], [35974, 136916, 140359])
+    for m in ("35974", "136916", "140359"):
+        assert m in suspects, f"machine {m} was overwritten; only the last survived"
+
+
+def test_a_pass_after_a_redraw_ends_the_loop_and_reports_success(tmp_path):
+    r, out, suspects = _run_loop(tmp_path, [1, 0], [35974, 136916])
+    assert out["exit_code"] == "0"
+    assert "35974" in suspects and "136916" not in suspects
+
+
+def test_config_error_is_never_redrawn(tmp_path):
+    """Exit 4 is our own bug; retrying it would make a broken gate look healthy."""
+    r, out, suspects = _run_loop(tmp_path, [4, 0], [35974, 136916])
+    assert out["exit_code"] == "4", "config_error must not be retried"
+    assert out["attempts"] == "1"
+
+
+# A SHORT prose prefix followed by a long space-free tail. This is the shape that
+# exposes a word-boundary trim guarded on the pre-trim length: the only space is
+# near the start, so trimming to it discards almost the entire budget. The first
+# version of the guard tested ${#_cut}, always 147 here, so it always trimmed.
+TIGHT = "PyTorch promoted: " + ",".join(f"2.13.0-cuda-12.6.3-py31{i}" for i in range(12))
+
+
+def test_a_short_prefix_with_a_space_free_tail_keeps_its_budget(tmp_path):
+    _, payload = _notify(tmp_path, TIGHT)
+    header = _header_of(payload)
+    assert len(header) <= 150, "must still respect Slack's limit"
+    assert len(header) >= 140, (
+        f"header collapsed to {len(header)} chars — the word-boundary trim ate "
+        f"the budget by trimming back to the only space, in the prefix")


### PR DESCRIPTION
Remediation of a blind four-reviewer panel on the ADR 0029 work.
Verdicts: `fatal-flaw` / `not-deployable` / `critical-gaps` / `must-fix-present`.

## The unanimous defect

All four found it independently. The redraw set `CODE=2` as a **loop-control
flag** and then emitted it as the **verdict**. Exit 2 is `EXIT_NO_OFFERS`, which
`qa_verdict.classify` short-circuits to `inconclusive` *before reading any test
result*. On `schedule`, `inconclusive` sets `soft_pass=true` and exits 0 — so
`merge-manifests` runs and the production manifest is pushed.

`build-comfyui` and `build-vllm` run on `cron: '0 0,12'` and neither sets
`retries` (default 0). Those two pipelines got the laundering with **zero**
redraws: a reproducible test failure promoted to production twice a day,
announced as *"no live test ran"*.

```
classify(1, <payload with a failed required test>) -> block
classify(2, <the SAME payload>)                    -> inconclusive
```

Fixed by `_REAL_CODE`: `CODE` stays a loop flag and never reaches a consumer.

## The finding that mattered more

The test-engineer mutation-tested my guards and found **three that pass while the
behaviour they name is destroyed** — all greps for a string the same commit had
just written. The repo already contains `wfexec.py`, written to end exactly that
pattern, and I had not used it.

**16 tests now execute the real `run:` blocks** with stubbed externals and assert
on rendered Slack blocks, job-summary tables and loop outputs. Two steps became
env-driven so `wfexec.step_script` would accept them — which is also the
injection-safe form.

All eight panel mutations are caught, including three of my own defects.

## Also fixed

**Correctness** — exit 130 no longer redrawn (`qa_verdict` calls a cancellation
"not a pass"); argparse usage errors emit `config_error` rather than 2, which was
a fail-open on the unattended path that `--exclude-machine` had made reachable;
the suspect read no longer whole-file-parses `qa-raw.json`; `unknown` machines are
no longer tabled as de-verification candidates.

**Docs that contradicted the code** — the `retries` contract every caller reads;
ADR 0019's supersession notice (spliced mid-sentence, so lazy continuation
rendered the *old* rule inside the notice); ADR 0029's citations of an ADR
unallocated in this repo; `invariants.md` claiming pytorch shares the gate, which
is false on main, in the file CLAUDE.md designates as verified against reality;
and "five callers" where 29 workflows call it.

**Operational** — the notifier retries then warns instead of reddening a
successful promotion; the redraw rate is now visible, since ADR 0029's reversal
tripwire cited a number nothing read.

## Deliberately NOT closed

- **The boot-race question** (red-team #2): three of the six exhibits may be a
  flaky *image* defect in an artifact whose job is to own supervisord ordering. If
  so, ADR 0029's premise is half wrong. Needs N-repeat runs on contended hosts,
  not an edit.
- **Ops S8**: no rollback path for a soft-passed comfy/vllm promotion — prod tags
  are overwritten in place with no prior digest recorded.

385 template_manager; lint clean (27 images).