### PR TITLE
chore(derivatives): pins sat on 2026-06-15, so nine weeks of base fixes reached none of them

### DIFF
--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -220,7 +220,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-15
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-21
         # arm64 is intentionally absent: ACE-Step-1.5's pyproject.toml
         # declares `torchao ; platform_machine == 'aarch64'`, and torchao
         # ships no aarch64 wheels (manylinux_x86_64 only), so the upstream
@@ -239,7 +239,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-15
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-aio-studio-base.yml
+++ b/.github/workflows/build-aio-studio-base.yml
@@ -15,7 +15,7 @@ on:
       PYTORCH_BASE:
         description: "Multi-torch base image"
         required: true
-        default: "vastai/pytorch:multi-210-291-271-2026-06-15"
+        default: "vastai/pytorch:multi-210-291-271-2026-08-21"
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
         required: true

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -101,8 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-06-15
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-21
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -191,8 +191,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-06-15
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-linux-desktop.yml
+++ b/.github/workflows/build-linux-desktop.yml
@@ -94,9 +94,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-06-15
-          - vastai/base-image:cuda-12.9-mini-py312-2026-06-15
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-06-15
+          - vastai/base-image:cuda-13.2-mini-py312-2026-08-21
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-21
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-21
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -159,9 +159,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-06-15
-          - vastai/base-image:cuda-12.9-mini-py312-2026-06-15
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-06-15
+          - vastai/base-image:cuda-13.2-mini-py312-2026-08-21
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-21
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-12.9-mini-py312-2026-06-15
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-21
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-12.9-mini-py312-2026-06-15
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-oobabooga.yml
+++ b/.github/workflows/build-oobabooga.yml
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
         # arm64 is intentionally absent: oobabooga's accelerator wheels
         # (exllamav3, flash_attn, xformers, llama_cpp_binaries) are x86_64-only.
         # Re-add the arm64 entry once those gain aarch64 CUDA wheels (and update
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
         # arm64 is intentionally absent: torchcodec is required at runtime
         # (transitive via torchaudio.load() in toolkit/dataloader_mixins.py)
         # but ships no aarch64 Linux wheels at any version. Re-add when
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   DEFAULT_DOCKERHUB_REPO: "sd-forge"
-  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-06-15"
+  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-21"
   # 7 days in seconds
   COMMIT_AGE_THRESHOLD: 604800
 

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
         # arm64 is intentionally absent: `torchao` (transitive via
         # unsloth-zoo>=2026.5.3 -> unsloth) only publishes amd64 manylinux
         # wheels as of v0.17.0+cu128. Re-add when upstream torchao ships
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-voicebox.yml
+++ b/.github/workflows/build-voicebox.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
         # arm64 is intentionally absent: Wan2GP requires onnxruntime-gpu
         # (pulled from the Azure ort-cuda-13-nightly index), which has no
         # aarch64 wheels — and PyPI's stable onnxruntime-gpu is also
@@ -236,7 +236,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-21
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-21
 
     steps:
       - name: Checkout

--- a/derivatives/llama-cpp/Dockerfile
+++ b/derivatives/llama-cpp/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-06-15
+ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-08-21
 
 FROM ${BASE_IMAGE}
 ARG BASE_IMAGE

--- a/derivatives/pytorch/derivatives/a1111/Dockerfile
+++ b/derivatives/pytorch/derivatives/a1111/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/comfyui/Dockerfile
+++ b/derivatives/pytorch/derivatives/comfyui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fluxgym/Dockerfile
+++ b/derivatives/pytorch/derivatives/fluxgym/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fooocus/Dockerfile
+++ b/derivatives/pytorch/derivatives/fooocus/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/invokeai/Dockerfile
+++ b/derivatives/pytorch/derivatives/invokeai/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
+++ b/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/Dockerfile
+++ b/derivatives/pytorch/derivatives/oobabooga/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/README.build.md
+++ b/derivatives/pytorch/derivatives/oobabooga/README.build.md
@@ -16,7 +16,7 @@ example below pins a tag for a reproducible local build; pass any commit/branch/
 ```bash
 docker buildx build \
     --platform linux/amd64 \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21 \
     --build-arg OOBABOOGA_REF=v4.9 \
     . -t repo/image:tag --push
 ```

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/sd-forge/Dockerfile
+++ b/derivatives/pytorch/derivatives/sd-forge/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/swarmui/Dockerfile
+++ b/derivatives/pytorch/derivatives/swarmui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
 FROM ${PYTORCH_BASE}
 
 LABEL org.opencontainers.image.source="https://github.com/vastai/"

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/wan2gp/Dockerfile
+++ b/derivatives/pytorch/derivatives/wan2gp/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/whisper/Dockerfile
+++ b/derivatives/pytorch/derivatives/whisper/Dockerfile
@@ -1,4 +1,19 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-06-15
+# torch 2.8.0, NOT the 2.7.1 its siblings use, and not a free choice. Whisper-WebUI
+# v1.0.8 — the release this image builds — declares in requirements.txt
+#
+#     torchaudio>=2.8.0,<2.9.0
+#
+# and the strip below removes that line, because the pytorch base is the single
+# source of truth for the torch ecosystem. So the pin was silently unsatisfied: the
+# 2.7.1 base ships torchaudio 2.7.1, BELOW upstream's floor, and the drift-guard at
+# the end of the RUN then dutifully asserted that nothing had changed. Stripping a
+# constraint moves the obligation to this line; it does not discharge it.
+#
+# 2.8.0 satisfies the range exactly (torch-companions.json: 2.8.0 -> torchaudio
+# 2.8.0). The UPPER bound is real too — upstream master carries
+# "# 2.9 deprecates used functions" against it — so this is a fixed point, not a
+# floor to raise later: do not move it to 2.9.x without re-reading upstream.
+ARG PYTORCH_BASE=vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-21
 
 FROM ${PYTORCH_BASE}
 


### PR DESCRIPTION
Every pytorch-nested derivative pins a **dated** base tag and takes `ROOT/` from that
layer. They were all on `2026-06-15`, so **nothing merged into base in nine weeks is in
any of them** — the readiness work (L069/L070/L071), ADR 0030's phase gate, the four
permanent-WARN fixes, and the aiohttp CVE. The pin is the delivery mechanism, and it had
not moved.

Bumped to **2026-08-21**, the tags promoted today off two clean gates: base zero-WARN,
pytorch 70/70.

Each pin is bumped in **both** places it lives — the `Dockerfile` ARG default and the
build workflow's `base_image` matrix. A CI build takes the workflow's value and a local
`docker build` takes the ARG, so the two silently disagreeing is worse than either being
stale.

## Whisper also moves torch, and it is the only one that does

`2.7.1` → `2.8.0`. Whisper-WebUI **v1.0.8** — the release this image builds — declares:

```
torchaudio>=2.8.0,<2.9.0
```

and our Dockerfile **strips that line**, because the pytorch base is the single source of
truth for the torch ecosystem. The 2.7.1 base ships torchaudio **2.7.1**, below upstream's
floor — so the constraint was silently unsatisfied, while the drift-guard at the end of
the RUN asserted that nothing had changed. Which was true, and beside the point.
**Stripping a constraint moves the obligation to the pin; it does not discharge it.**

`torch-companions.json` maps `2.8.0 -> torchaudio 2.8.0`, satisfying the range exactly.
The upper bound is real too — upstream master carries `# 2.9 deprecates used functions` —
so this is a fixed point, not a floor to raise later. The reasoning is recorded at the pin
so nobody tidies it back to match its siblings.

## Nothing else moves torch — each upstream was checked, not assumed

| image | upstream says | our pin | verdict |
|---|---|---|---|
| ace-step | `torch==2.10.0+cu128` (linux x86_64) | 2.10.0 | exact match |
| invokeai | `torch==2.7.1+cu128` (PyPI `[cuda]`) | 2.7.1 | exact match |
| oobabooga | `TORCH_VERSION = "2.9.0"`, cu128 | 2.9.1 | patch above |
| kohya_ss | `torch==2.7.0+cu128` | 2.7.1 | patch above |
| unsloth-studio | `torch<2.12.0,>=2.4.0` | 2.10.0 | in range; **2.12+ excluded** |
| voicebox | unpinned — but our flash-attn wheel is `cu12torch2.9` | 2.9.1 | wheel pins it |
| ostris-ai-toolkit | built at pinned ref `6870ab4`; `torchao==0.10.0`, no torch pin | 2.9.1 | no signal |
| **whisper** | **`torchaudio>=2.8.0,<2.9.0`** | ~~2.7.1~~ **2.8.0** | **was below floor** |
| a1111, comfyui, fooocus, sd-forge, fluxgym, wan2gp | torch unpinned | — | left alone |

An unpinned upstream is not an invitation. Moving those is a discretionary upgrade with
no upstream signal behind it, and each costs a rebuild plus a live-GPU QA run.

## Two things found on the way, deliberately not fixed here

- **`fooocus`, `kohya_ss` and `swarmui` have no build workflow at all.** Only the
  Dockerfile ARG could be bumped, because there is nothing else to bump — they cannot be
  built by CI as things stand.
- **SwarmUI's own comfy installer now uses `--index-url .../cu130`.** Our pin is
  cu128/cuda-12.9. Moving it is a CUDA-13 question with host-driver consequences, not a
  pin bump.

`linux-desktop` and `llama-cpp` are included: they pin dated **base-image** tags rather
than pytorch ones, but carry the identical staleness.

## Evidence

- **Every referenced tag confirmed present on DockerHub** before committing, not inferred
  from the naming scheme — including the three untouched floating tags, checked directly
  rather than reported as missing off a truncated tag listing.
- `imagegen lint --all` baseline **CLEAN** (27 images, 0 errors).
- All build workflows parse; no `2026-06-15` survives outside docs and test fixtures,
  where it is historical record.
- **398 passed, 9 skipped.**

## Landing this

Static checks are a fast gate, not a correctness gate (ADR 0001) — every one of these
needs a real build. `comfyui` is the one with a live-GPU QA gate, so it self-verifies on
merge; the rest need a dispatched build each, and **whisper's is the one to watch**, being
the only behavioural change in the PR.
