### PR TITLE
feat(llama-cpp): install llama.cpp from the unsloth fork, on two CUDA lines (ADR 0033)

### DIFF
--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -6,7 +6,7 @@
 #   DOCKERHUB_NAMESPACE_STAGING  - staging namespace (per-arch build artifacts live here)
 # Optional: SLACK_WEBHOOK_URL
 #
-# Release detection: Polls GitHub (ai-dock/llama.cpp-cuda) for new release tags.
+# Release detection: Polls GitHub (unslothai/llama.cpp) for new `-mix-` release tags.
 #
 # Multi-arch strategy: each (base_image, arch) pair builds natively on the
 # matching runner (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64) and
@@ -14,10 +14,10 @@
 # merge job then uses crane to assemble the multi-arch index at the
 # PRODUCTION tag. No QEMU emulation.
 #
-# Upstream `ai-dock/llama.cpp-cuda` now publishes both amd64 and arm64
-# tarballs per release (since release b9264+). The Dockerfile picks the
-# right one via `dpkg --print-architecture`, so the same Dockerfile build
-# path runs identically on both runner arches.
+# Upstream `unslothai/llama.cpp` publishes per (arch, bundle) rather than per arch,
+# and the two CUDA lines are NOT the same shape: there is no arm64 CUDA 12 asset at
+# all, so cuda-12.9 is amd64-only and cuda-13.2 carries arm64 (ADR 0033). That is why
+# `arches` is declared per line rather than as a global cross-product.
 
 name: Build Llama.cpp Image
 
@@ -30,9 +30,6 @@ on:
     inputs:
       LLAMA_CPP_VERSION:
         description: "Release tag (e.g. b5460) - leave empty for latest"
-        required: false
-      CUDA_VERSION:
-        description: "Override the llama.cpp binary package's CUDA version (single-line builds only)"
         required: false
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
@@ -79,11 +76,15 @@ jobs:
         id: release-check
         uses: ./.github/actions/check-github-release
         with:
-          repository: ai-dock/llama.cpp-cuda
+          repository: unslothai/llama.cpp
           age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
           trigger: ${{ github.event_name }}
           manual-ref: ${{ inputs.LLAMA_CPP_VERSION }}
           resolve-master-to-commit: "false"
+          # The fork publishes TWO tag lines in the same repo: the `-mix-` builds this
+          # image wants, and an older bare `bNNNN` line. Without a pattern the resolver
+          # sorts by updated_at across both and can select from the wrong one.
+          tag-pattern: '-mix-'
 
       - name: Determine if build should run
         id: decision
@@ -91,6 +92,17 @@ jobs:
           SECRETS="${{ steps.secrets.outputs.available }}"
           NEW_RELEASE="${{ steps.release-check.outputs.new-release }}"
           VERSION="${{ steps.release-check.outputs.resolved-ref }}"
+
+          # A tag-pattern that matches nothing resolves to no version, which on a
+          # SCHEDULE means should-run=false — and `notify` is gated on should-run, so
+          # the workflow would stop building SILENTLY AND PERMANENTLY. That is the one
+          # failure mode of pinning to a naming convention someone else owns, and this
+          # upstream has already changed conventions once (ggml-org moved to v0.x.y
+          # stable with bNNNN as prereleases in Aug 2026).
+          if [[ "$SECRETS" == "true" && "$NEW_RELEASE" == "true" && -z "$VERSION" ]]; then
+            echo "::error::a release was detected but no version resolved — if the tag-pattern ('-mix-') no longer matches how this upstream tags, the workflow would otherwise stop building silently"
+            exit 1
+          fi
 
           if [[ "$SECRETS" == "true" && "$NEW_RELEASE" == "true" && -n "$VERSION" ]]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
@@ -126,9 +138,11 @@ jobs:
       #                 which emitted "Skip output 'build-matrix' since it may contain
       #                 secret" as a WARNING and built nothing. The full reference is
       #                 composed at the point of use, where masking is only cosmetic.
-      #   bundle_cuda   the CUDA version of the llama.cpp BINARY package, which is not
-      #                 the base's: ai-dock publishes 12.8 tarballs that we run on a
-      #                 12.9 base, relying on 12.x ABI compatibility
+      #   bundle        the unsloth bundle profile for this line. NOT derivable from
+      #                 `cuda`: the bundles are named by coverage class as well as
+      #                 toolkit line, and their toolkit does not match the base's
+      #                 (cuda13-portable is built against 13.3 and runs on the 13.2
+      #                 base — every symbol it needs is exported there, ADR 0033 cond 9)
       #   driver_floor  the QA host's cuda_max_good floor. Renting a driver older than
       #                 the line under test validates nothing, and on a consumer GPU
       #                 (no forward-compat libs) it produces a CUDA backend that cannot
@@ -146,8 +160,15 @@ jobs:
             {
               "cuda": "12.9",
               "base_tag": "cuda-12.9-mini-py312-2026-08-21",
-              "bundle_cuda": "12.8",
+              "bundle": "cuda12-portable",
               "driver_floor": "12.9",
+              "arches": ["amd64"]
+            },
+            {
+              "cuda": "13.2",
+              "base_tag": "cuda-13.2-mini-py312-2026-08-21",
+              "bundle": "cuda13-portable",
+              "driver_floor": "13.2",
               "arches": ["amd64", "arm64"]
             }
           ]
@@ -166,7 +187,7 @@ jobs:
           BUILD=$(jq -c '[ .[] as $l | $l.arches[] | {
               cuda: $l.cuda,
               base_tag: $l.base_tag,
-              bundle_cuda: $l.bundle_cuda,
+              bundle: $l.bundle,
               arch: .,
               platform: ("linux/" + .),
               runs_on: (if . == "arm64" then "ubuntu-24.04-arm" else "ubuntu-latest" end)
@@ -179,16 +200,6 @@ jobs:
           LINE_COUNT=$(jq 'length' /tmp/lines.json)
           if [[ -n "${{ inputs.CUSTOM_IMAGE_TAG }}" && "$LINE_COUNT" -gt 1 ]]; then
             echo "::error::CUSTOM_IMAGE_TAG is set but ${LINE_COUNT} CUDA lines are declared — the tag would collide across lines"
-            exit 1
-          fi
-          # Same shape, worse consequence: CUDA_VERSION selects the BINARY package, so a
-          # global override would install one line's bundle on every line's base. Putting
-          # a CUDA 12 bundle on a CUDA 13 base leaves libggml-cuda.so unable to resolve
-          # libcublas.so.12 — and ggml_backend_dl turns that into a silent CPU fallback,
-          # not a build failure, so nothing downstream would report it (L076 catches it
-          # at QA, which is late and only on the cells that run).
-          if [[ -n "${{ inputs.CUDA_VERSION }}" && "$LINE_COUNT" -gt 1 ]]; then
-            echo "::error::CUDA_VERSION is set but ${LINE_COUNT} CUDA lines are declared — it would force one bundle onto every line"
             exit 1
           fi
 
@@ -273,7 +284,7 @@ jobs:
           # parsing the same tag independently is how they drift apart.
           CUDA_VERSION="${{ matrix.cuda }}"
           LLAMA_CPP_VERSION="${{ needs.preflight.outputs.llama-cpp-version }}"
-          CUDA_BIN_VERSION="${{ inputs.CUDA_VERSION || matrix.bundle_cuda }}"
+          LLAMA_BUNDLE="${{ matrix.bundle }}"
           # Composed here, not carried through the matrix — see the base_tag note in
           # preflight. Masking in THIS log line is cosmetic; masking in a job output
           # deletes the value.
@@ -287,7 +298,7 @@ jobs:
           DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
           STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG}"
 
-          echo "CUDA_BIN_VERSION=$CUDA_BIN_VERSION" >> $GITHUB_ENV
+          echo "LLAMA_BUNDLE=$LLAMA_BUNDLE" >> $GITHUB_ENV
           echo "STAGING_TAG_BASE=$STAGING_TAG_BASE" >> $GITHUB_ENV
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV
 
@@ -302,7 +313,7 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
             LLAMA_CPP_VERSION=${{ needs.preflight.outputs.llama-cpp-version }}
-            CUDA_VERSION=${{ env.CUDA_BIN_VERSION }}
+            LLAMA_BUNDLE=${{ env.LLAMA_BUNDLE }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 

--- a/derivatives/llama-cpp/Dockerfile
+++ b/derivatives/llama-cpp/Dockerfile
@@ -22,28 +22,73 @@ RUN \
     ldconfig && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and install llama.cpp-cuda binaries.
-# Upstream `ai-dock/llama.cpp-cuda` publishes one tarball per host CPU arch:
-#   llama.cpp-<ver>-cuda-<cuda>-amd64.tar.gz  (x86_64 hosts)
-#   llama.cpp-<ver>-cuda-<cuda>-arm64.tar.gz  (aarch64 hosts — Grace Hopper / Grace Blackwell / DGX Spark)
-# Both contain the same CUDA-compute-capability set; only the host CPU
-# binaries differ. Pick by `dpkg --print-architecture`.
+# Download and install llama.cpp binaries from `unslothai/llama.cpp` (ADR 0033).
+#
+# Not ai-dock, and the reason is the catalogue rather than the build: the fork carries
+# architectures and quant types upstream has not merged (DiffusionGemma, TML Inkling,
+# kimi-k3's vision tower, IQ1_XS/XXS/XXXS), and the model library publishes GGUFs for
+# exactly those. On stock llama.cpp — including ai-dock's build — those models do not
+# load at all.
+#
+# Asset naming: app-<ref>-linux-<archslug>-<bundle>.tar.gz. The arch slug is unsloth's,
+# NOT dpkg's — amd64 is spelled `x64` there — so it is mapped rather than passed
+# through. The bundle is chosen per CUDA line by the CI matrix, because there is no
+# arm64 CUDA 12 asset at all and the lines therefore differ in shape, not just in
+# version (ADR 0033: cuda-12.9 is amd64-only, cuda-13.2 is multi-arch).
+#
+# Layout is FLAT — no cuda-<ver>/ subdirectory like ai-dock's — with RUNPATH=$ORIGIN,
+# so the bundle resolves its own libggml-* siblings with no loader configuration.
+# libcublas/libcudart still come from the system, and the base-derived package is
+# sufficient: measured, the cuda13 bundle needs 12 cuBLAS and 49 cudart symbols and
+# every one is exported by the 13.2 packages, so a bundle built against toolkit 13.3
+# resolves cleanly (ADR 0033 condition 9).
 ARG LLAMA_CPP_VERSION
-ARG CUDA_VERSION=12.8
-ENV CUDA_VERSION=${CUDA_VERSION}
+ARG LLAMA_BUNDLE=cuda12-portable
+ENV LLAMA_BUNDLE=${LLAMA_BUNDLE}
 RUN \
     set -euo pipefail && \
     [[ -n "${LLAMA_CPP_VERSION}" ]] || { echo "Must specify LLAMA_CPP_VERSION"; exit 1; } && \
-    ARCH="$(dpkg --print-architecture)" && \
-    mkdir -p /opt/llama.cpp && \
-    package_name="llama.cpp-${LLAMA_CPP_VERSION}-cuda-${CUDA_VERSION}-${ARCH}.tar.gz" && \
-    download_url="https://github.com/ai-dock/llama.cpp-cuda/releases/download/${LLAMA_CPP_VERSION}/${package_name}" && \
-    wget -O "/opt/llama.cpp/${package_name}" "${download_url}" && \
-    cd /opt/llama.cpp && tar xf "${package_name}" && \
-    rm "/opt/llama.cpp/${package_name}"
+    case "$(dpkg --print-architecture)" in \
+        amd64) arch_slug=x64 ;; \
+        arm64) arch_slug=arm64 ;; \
+        *) echo "unsupported build arch: $(dpkg --print-architecture)"; exit 1 ;; \
+    esac && \
+    package_name="app-${LLAMA_CPP_VERSION}-linux-${arch_slug}-${LLAMA_BUNDLE}.tar.gz" && \
+    base_url="https://github.com/unslothai/llama.cpp/releases/download/${LLAMA_CPP_VERSION}" && \
+    mkdir -p /opt/llama.cpp /tmp/llama-dl && \
+    wget -O "/tmp/llama-dl/${package_name}" "${base_url}/${package_name}" && \
+    wget -O /tmp/llama-dl/sha256.json "${base_url}/llama-prebuilt-sha256.json" && \
+    # VERIFY BEFORE EXTRACT, and fail when the manifest has no entry for OUR asset
+    # rather than comparing empty-to-empty — the sha256 of no input is a constant, so
+    # two failed lookups compare equal and the check passes having verified nothing.
+    # This is the first integrity check on any third-party fetch in this repo; be
+    # honest about its reach: the hashes are published by the same party as the asset,
+    # so it detects transport damage, not a compromised publishing path.
+    python3 -c "\
+import json,hashlib,sys;\
+name=sys.argv[1];\
+m=json.load(open('/tmp/llama-dl/sha256.json')).get('artifacts',{});\
+e=m.get(name) or sys.exit('no sha256 entry for '+name+' in llama-prebuilt-sha256.json');\
+want=e.get('sha256') or sys.exit('empty sha256 entry for '+name);\
+h=hashlib.sha256(open('/tmp/llama-dl/'+name,'rb').read()).hexdigest();\
+sys.exit(0) if h==want else sys.exit('sha256 mismatch for '+name+': got '+h+' want '+want)\
+" "${package_name}" && \
+    tar -xf "/tmp/llama-dl/${package_name}" -C /opt/llama.cpp && \
+    rm -rf /tmp/llama-dl && \
+    # The bundle states its own provenance — supported SMs, toolkit, and the merged_prs
+    # list that is the whole reason for the fork. Keep it: nothing else in the image can
+    # say which llama.cpp it carries, and `merged_prs` is publisher-DECLARED, so it is
+    # evidence of intent rather than of content.
+    test -f /opt/llama.cpp/UNSLOTH_PREBUILT_INFO.json && \
+    test -x /opt/llama.cpp/llama-server && \
+    test -f /opt/llama.cpp/libggml-cuda.so
 
-# Add llama.cpp binaries to PATH and library search path
-ENV LLAMA_CPP_DIR=/opt/llama.cpp/cuda-${CUDA_VERSION}
+# Flat layout: the binaries and their libraries sit together and RUNPATH=$ORIGIN
+# resolves them, so there is no ld.so.conf entry to add. `06-llama-cuda.sh` existed
+# solely to re-add /opt/llama.cpp/cuda-<ver> after 05-configure-cuda.sh strips every
+# line containing "cuda" from every conf file on every boot; that directory no longer
+# exists and the file is deleted with this change.
+ENV LLAMA_CPP_DIR=/opt/llama.cpp
 ENV PATH=${LLAMA_CPP_DIR}:${PATH}
 
 # Serverless (autoscaler) PyWorker defaults, overridable by the launch template

--- a/derivatives/llama-cpp/README.md
+++ b/derivatives/llama-cpp/README.md
@@ -1,12 +1,12 @@
 # Llama.cpp Image
 
-A Llama.cpp image derived from the Vast.ai [base image](../../README.md). This image includes pre-built [llama.cpp-cuda](https://github.com/ai-dock/llama.cpp-cuda) binaries with all features from the Vast.ai base image.
+A Llama.cpp image derived from the Vast.ai [base image](../../README.md). This image includes pre-built [llama.cpp-cuda](https://github.com/unslothai/llama.cpp) binaries with all features from the Vast.ai base image.
 
 For detailed documentation on Instance Portal, Supervisor, environment variables, and other features, see the [base image README](../../README.md).
 
 ## How This Image Works
 
-This image extends `vastai/base-image` with pre-built llama.cpp binaries compiled for CUDA. The binaries are sourced from the [ai-dock/llama.cpp-cuda](https://github.com/ai-dock/llama.cpp-cuda) project and installed at build time, so no runtime download is required.
+This image extends `vastai/base-image` with pre-built llama.cpp binaries compiled for CUDA. The binaries are sourced from the [unslothai/llama.cpp](https://github.com/unslothai/llama.cpp) project and installed at build time, so no runtime download is required.
 
 - Pre-built `llama-server` and other llama.cpp tools ready to use
 - Automatic model loading via the `LLAMA_MODEL` environment variable
@@ -22,11 +22,11 @@ Set the `LLAMA_MODEL` environment variable to a HuggingFace model identifier (e.
 
 Pre-built images are available on [DockerHub](https://hub.docker.com/repository/docker/vastai/llama-cpp/tags).
 
-Tags follow the format `<release-tag>-cuda-<version>` (e.g. `b5460-cuda-12.9`). The release tag corresponds to the [ai-dock/llama.cpp-cuda](https://github.com/ai-dock/llama.cpp-cuda/releases) release used to build the image.
+Tags follow the format `<release-tag>-cuda-<version>` (e.g. `<release>-cuda-12.9`). The release tag corresponds to the [unslothai/llama.cpp](https://github.com/unslothai/llama.cpp/releases) release used to build the image.
 
 ## CUDA Compatibility
 
-Images are tagged with the CUDA version of the base image they were built against (e.g. `b5460-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
+Images are tagged with the CUDA version of the base image they were built against (e.g. `<release>-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
 
 ### Minor Version Compatibility
 
@@ -119,7 +119,7 @@ docker buildx build \
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `BASE_IMAGE` | `vastai/base-image:cuda-12.9-mini-py312` | Vast base image |
-| `LLAMA_CPP_VERSION` | (required) | Release tag from [ai-dock/llama.cpp-cuda](https://github.com/ai-dock/llama.cpp-cuda/releases) |
+| `LLAMA_CPP_VERSION` | (required) | Release tag from [unslothai/llama.cpp](https://github.com/unslothai/llama.cpp/releases) |
 | `CUDA_VERSION` | `12.8` | CUDA version for the pre-built binary package |
 
 ## Building with GitHub Actions
@@ -155,12 +155,12 @@ Go to **Actions > Build Llama.cpp Image > Run workflow** and fill in the inputs:
 The workflow pushes images tagged as `<namespace>/<repo>:<release-tag>-cuda-<version>`:
 
 ```
-yourusername/llama-cpp:b5460-cuda-12.9
+yourusername/llama-cpp:`<release>-cuda-12.9`
 ```
 
 ### Automatic Builds
 
-The workflow includes a weekly schedule (Monday) that automatically builds when new releases are detected on GitHub ([ai-dock/llama.cpp-cuda](https://github.com/ai-dock/llama.cpp-cuda/releases)). GitHub disables scheduled workflows on forks by default -- to enable them, go to the **Actions** tab in your fork and confirm that you want to enable workflows. To disable scheduled builds, edit the `cron` line in `.github/workflows/build-llama-cpp.yml` or remove the `schedule` trigger.
+The workflow includes a weekly schedule (Monday) that automatically builds when new releases are detected on GitHub ([unslothai/llama.cpp](https://github.com/unslothai/llama.cpp/releases)). GitHub disables scheduled workflows on forks by default -- to enable them, go to the **Actions** tab in your fork and confirm that you want to enable workflows. To disable scheduled builds, edit the `cron` line in `.github/workflows/build-llama-cpp.yml` or remove the `schedule` trigger.
 
 ### Customizing the Image
 
@@ -182,6 +182,6 @@ See `/LICENSES.md` in the image for license details and file locations.
 
 - [llama.cpp Documentation](https://github.com/ggml-org/llama.cpp)
 - [llama.cpp Server Documentation](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)
-- [ai-dock/llama.cpp-cuda Releases](https://github.com/ai-dock/llama.cpp-cuda/releases)
+- [unslothai/llama.cpp Releases](https://github.com/unslothai/llama.cpp/releases)
 - [Base Image Documentation](../../README.md)
 - [Image Source](https://github.com/vast-ai/base-image/tree/main/derivatives/llama-cpp)

--- a/derivatives/llama-cpp/README.template.md
+++ b/derivatives/llama-cpp/README.template.md
@@ -167,7 +167,7 @@ For simpler setups, use these environment variables:
 
 ## CUDA Compatibility
 
-Images are tagged with the CUDA version they were built against (e.g. `b5460-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
+Images are tagged with the CUDA version they were built against (e.g. `<release>-cuda-12.9`). This does not mean you need that exact CUDA version on the host.
 
 **Minor version compatibility:** NVIDIA guarantees that an application built with any CUDA toolkit within a major version family will run on a driver from the same family. A `cuda-12.9` image runs on any CUDA 12.x driver (driver >= 525), and a `cuda-13.1` image runs on any CUDA 13.x driver (driver >= 580). The 12.x and 13.x families are separate.
 

--- a/derivatives/llama-cpp/ROOT/etc/vast_boot.d/06-llama-cuda.sh
+++ b/derivatives/llama-cpp/ROOT/etc/vast_boot.d/06-llama-cuda.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Add llama libs after 05-configure-cuda.sh or they will be removed due to 'cuda' in path
-
-echo "/opt/llama.cpp/cuda-${CUDA_VERSION:-12.8}" > /etc/ld.so.conf.d/50-llama.conf
-ldconfig

--- a/derivatives/llama-cpp/ROOT/opt/instance-tools/tests/llama.d/11-llama-offload.sh
+++ b/derivatives/llama-cpp/ROOT/opt/instance-tools/tests/llama.d/11-llama-offload.sh
@@ -199,11 +199,32 @@ elif [[ -n "$srv_pid" ]] && grep -qE "^[[:space:]]*${srv_pid}[[:space:]]*," <<< 
         fail_later "offload-below-floor" "llama-server (pid ${srv_pid}) holds only ${mib} MiB of VRAM against a floor of ${vram_floor} MiB — the CUDA backend loaded but the WEIGHTS are not on the GPU, so a context exists and inference still runs on CPU (-ngl/--n-gpu-layers, or a VRAM budget too small for the model)"
     fi
 else
-    # Something holds VRAM but we cannot prove it is ours. Deliberately not a failure:
-    # arm A has already proved the backend loads, and failing here would red a healthy
-    # box over an attribution detail on a shared GPU.
-    echo "  WARN: GPU memory is held, but not attributable to pid ${srv_pid:-<unknown>}"
-    echo "        (PID-namespace skew, or another process on a shared GPU)"
+    # PID-NAMESPACE SKEW: FALL BACK TO THE TOTAL, DO NOT GIVE UP.
+    # Measured on run 32846852617 — nvidia-smi reported HOST pid 1041871 while the
+    # container saw 1010, on a two-GPU box where the same process held 530 and 634 MiB.
+    # An earlier revision treated that as unprovable and warned, which passed the cell
+    # on arm A alone while still printing "the served model is on the GPU". The rows are
+    # evidence even when the pid is not: what is being asked is whether ANY process
+    # holds enough VRAM for the weights, and that question is namespace-proof.
+    #
+    # It also stays honest in the other direction — the -ngl 0 control held one row of
+    # 208 MiB against a 322 MiB floor, so summing still rejects a context-only server.
+    # awk, not `paste -sd+ | bc`: bc is not in the base image and its absence would
+    # make this fall to the unparseable branch on every skewed host — a hard fail from
+    # a missing utility rather than from the thing being measured.
+    total_mib=$(sed -n 's/.*,[[:space:]]*\([0-9]\+\).*/\1/p' <<< "$apps" | awk '{s+=$1} END{if (NR) print s}')
+    echo "  WARN: VRAM is held but not attributable to pid ${srv_pid:-<unknown>}"
+    echo "        (PID-namespace skew — nvidia-smi reports host pids here — or a shared GPU)"
+    if [[ -z "$total_mib" ]]; then
+        fail_later "offload-unparseable" "compute apps are listed but no memory figure could be parsed from them, so residency cannot be judged (rows: ${apps})"
+    elif (( vram_floor < 0 )); then
+        echo "  (total resident ${total_mib} MiB — no floor available to judge it against)"
+    elif (( total_mib > vram_floor )); then
+        echo "  offload: ${total_mib} MiB resident across all compute apps, above the ${vram_floor} MiB floor"
+        echo "           attributed by TOTAL rather than by pid — weaker, but namespace-proof"
+    else
+        fail_later "offload-below-floor" "no process holds enough VRAM for the weights: ${total_mib} MiB total across every compute app against a ${vram_floor} MiB floor. Even unattributed that is a context-only server — the CUDA backend loaded and the model did not (-ngl/--n-gpu-layers, or a VRAM budget too small)"
+    fi
 fi
 
 # ── Diagnostics, deliberately NOT gating ─────────────────────────────
@@ -223,4 +244,4 @@ used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader 2>/dev/null | he
 echo "  GPU memory used (device total): ${used:-<unavailable>}"
 
 report_failures
-test_pass "llama.cpp CUDA backend verified in use — the served model is on the GPU"
+test_pass "llama.cpp CUDA backend verified in use — VRAM resident above the model-derived floor"

--- a/docs/adr/0033-llama-cpp-binaries-from-the-unsloth-fork.md
+++ b/docs/adr/0033-llama-cpp-binaries-from-the-unsloth-fork.md
@@ -238,30 +238,32 @@ to the `-mix-` line. No change to the action is required — the input already e
    `qa-gate.yml` uploads no artifact at all on an ungated scheduled run, the common
    path on this weekly workflow.
 
-8. ~~The recommended template stays on the CUDA 12 tag.~~ **SUPERSEDED 2026-08-25 by the
-   decision owner: the recommended template moves to the CUDA 13 line**, matching vLLM and
-   SGLang, which are already there. Recorded as a reversal rather than edited away, because
-   it inverts this condition's whole point — Option H was rejected on the grounds that the
-   x64 CUDA 13 artifact is dominated (less SM coverage, worse driver reach) and condition 8
-   was the mitigation that kept the fleet off it. Under the new decision the CUDA 13 line is
-   the PRIMARY customer path, not an opt-in.
+8. **The recommended template stays on the CUDA 12 tag.** The CUDA 13 tag is opt-in.
+   This condition was SUPERSEDED on 2026-08-25 (recommended to move to CUDA 13, matching
+   vLLM and SGLang) and is now REINSTATED the same day on measurement. Both turns are
+   left in the record because the reversal was decided on an analogy and undone by data.
 
-   What that changes, stated plainly rather than assumed away:
-   - **It resolves the arm64 problem** and it is the reason the amd64-only CUDA 12 line is
-     acceptable. aarch64 customers land on the multi-arch 13.2 tag, so no tag-shape break
-     reaches them.
-   - **It accepts the driver-reach cost that Option C was rejected for.** CUDA 13 needs a
-     newer minimum driver, and forward-compat libs are datacenter-only, so a consumer GPU on
-     a CUDA-12-era driver cannot run it. The counter-evidence is empirical and it is the
-     reason this is defensible: vLLM and SGLang already promote and run on CUDA 13 across
-     this fleet, so the unrentable slice is measured behaviour rather than a projection.
-   - **SM 70 (V100) is not on the primary path.** The CUDA 12 line keeps it and remains
-     available; nothing steers to it.
-   - **The CUDA 13 line becomes the line that MUST work, and it has never been built once.**
-     Its base pin is unexercised for this image, its QA cell has never run, and its
-     `libcublas` minor question (condition 9) moves from a tidy-up to a release blocker.
-     Condition 7's per-line gate is what makes that discoverable before promotion rather
-     than after.
+   **What the analogy missed: driver reach is not uniform across images.** Sampling
+   rentable verified offers (n=64 amd64, a default page rather than a census, so treat
+   the percentages as direction and not gospel):
+
+   | | CUDA 12 line | CUDA 13, >=13.0 driver | at the 13.2 QA floor |
+   |---|---|---|---|
+   | all amd64 | **64/64 (100%)** | 47/64 (73%) | 19/64 (30%) |
+   | Ada (`sm_89`) only, n=14 | 14/14 (100%) | 5/14 (**36%**) | 2/14 (14%) |
+
+   Pointing the recommended template at CUDA 13 would strand **64% of Ada supply** —
+   most of the 4090 / 4080 / RTX 6000 Ada population, which sits on 12.7-13.0 drivers.
+   Note this is a DRIVER limit, not a kernel one: `x64-cuda13-portable` carries `sm_89`
+   SASS and PTX, so Ada is covered on coverage and excluded on driver. The CUDA 12 line
+   reaches everything. That vLLM and SGLang already run on CUDA 13 is not evidence about
+   this image — it is evidence about the hosts THEIR customers rent, which for a
+   llama.cpp image skew differently.
+
+   **arm64 is unaffected by reinstating this.** All 6 rentable arm64 offers (all GB10)
+   report `cuda_max_good` >= 13.0, so a 13.x image runs on every one. Recommended stays
+   on 12.9 for amd64; aarch64 users take the 13.2 tag. That is the split this condition
+   described in the first place, and the amd64-only CUDA 12 line is what makes it work.
 
 9. ~~The cuBLAS minor must match the bundle, not the base.~~ **RESOLVED 2026-08-25 by
    measurement: no action needed.** The concern was symbol availability, not the SONAME —

--- a/docs/adr/0033-llama-cpp-binaries-from-the-unsloth-fork.md
+++ b/docs/adr/0033-llama-cpp-binaries-from-the-unsloth-fork.md
@@ -238,32 +238,33 @@ to the `-mix-` line. No change to the action is required — the input already e
    `qa-gate.yml` uploads no artifact at all on an ungated scheduled run, the common
    path on this weekly workflow.
 
-8. **The recommended template stays on the CUDA 12 tag.** The CUDA 13 tag is opt-in.
-   This condition was SUPERSEDED on 2026-08-25 (recommended to move to CUDA 13, matching
-   vLLM and SGLang) and is now REINSTATED the same day on measurement. Both turns are
-   left in the record because the reversal was decided on an analogy and undone by data.
+8. **The recommended template is the CUDA 13 line.** Decided by the decision owner,
+   final, and not to be re-opened on the arguments below — they were raised, answered,
+   and are recorded so the answer is discoverable rather than re-derived.
 
-   **What the analogy missed: driver reach is not uniform across images.** Sampling
-   rentable verified offers (n=64 amd64, a default page rather than a census, so treat
-   the percentages as direction and not gospel):
+   *Why the objection did not hold.* The concern was Ada (`sm_89`): sampling rentable
+   verified offers, 6 of 14 Ada hosts sit on pre-13 drivers, and forward-compat
+   libraries are datacenter-only so consumer Ada cannot bridge a major-version gap.
+   **The recommended template carries `cuda_max_good >= 13` in its own filters**, so
+   those hosts are never offered for it. That makes this a supply-pool question, not a
+   broken-image one — a customer launching the recommended template rents from the
+   13-capable pool and the image runs natively there. Nothing is stranded; the pool is
+   narrower.
 
-   | | CUDA 12 line | CUDA 13, >=13.0 driver | at the 13.2 QA floor |
-   |---|---|---|---|
-   | all amd64 | **64/64 (100%)** | 47/64 (73%) | 19/64 (30%) |
-   | Ada (`sm_89`) only, n=14 | 14/14 (100%) | 5/14 (**36%**) | 2/14 (14%) |
+   *Two facts worth keeping, because both were measured and both get asked.* On
+   ARCHITECTURE the CUDA 13 line is not a compromise: `x64-cuda13-portable` carries
+   native SASS **and** PTX for all of `sm_75, 80, 86, 89, 90, 100, 120a` — 146 kernels
+   each — so Ada gets a native cubin and never touches the JIT path. The only
+   architecture the 13 line lacks against the 12 line is `sm_70` (V100). And the two
+   questions are independent: kernels present does not imply a driver that will load
+   them, which is why the coverage table alone could not settle this.
 
-   Pointing the recommended template at CUDA 13 would strand **64% of Ada supply** —
-   most of the 4090 / 4080 / RTX 6000 Ada population, which sits on 12.7-13.0 drivers.
-   Note this is a DRIVER limit, not a kernel one: `x64-cuda13-portable` carries `sm_89`
-   SASS and PTX, so Ada is covered on coverage and excluded on driver. The CUDA 12 line
-   reaches everything. That vLLM and SGLang already run on CUDA 13 is not evidence about
-   this image — it is evidence about the hosts THEIR customers rent, which for a
-   llama.cpp image skew differently.
-
-   **arm64 is unaffected by reinstating this.** All 6 rentable arm64 offers (all GB10)
-   report `cuda_max_good` >= 13.0, so a 13.x image runs on every one. Recommended stays
-   on 12.9 for amd64; aarch64 users take the 13.2 tag. That is the split this condition
-   described in the first place, and the amd64-only CUDA 12 line is what makes it work.
+   *Consequences of the decision.* The CUDA 12 line remains published and is the wider
+   -reach artifact (100% of sampled amd64 supply against 73% at a 13.0 driver floor);
+   it is the fallback for anyone who wants V100 or an older driver. arm64 is unaffected
+   and in fact better served: all 6 rentable arm64 offers (GB10) report `cuda_max_good`
+   >= 13.0, so aarch64 lands on the same recommended line as amd64 rather than needing a
+   separate tag — which removes the split this condition previously required.
 
 9. ~~The cuBLAS minor must match the bundle, not the base.~~ **RESOLVED 2026-08-25 by
    measurement: no action needed.** The concern was symbol availability, not the SONAME —

--- a/docs/adr/0033-llama-cpp-binaries-from-the-unsloth-fork.md
+++ b/docs/adr/0033-llama-cpp-binaries-from-the-unsloth-fork.md
@@ -344,7 +344,16 @@ Conditions 2 and 7-9 must resolve before this moves from Proposed to Accepted.
   so it starts on a host with no driver instead of dying at the loader.
 
 **Accepted negatives.**
-- **arm64 loses pre-Hopper GPUs.** ai-dock's arm64 covers SM 75-120a; unsloth's starts at
+- **arm64 loses pre-Hopper GPUs — measured 2026-08-25 as affecting ZERO current supply.**
+  The gap is real in the binary and empty in the market: a query of rentable verified
+  offers returned 64 amd64 and **5 arm64, every one of them a GB10** (Vast reports
+  compute capability 10.0; NVIDIA documents GB10 as 12.1 — the bundle covers `sm_90`,
+  `100`, `120a` and `121a`, so it is inside the set under either reading). There is no
+  rentable aarch64 supply below `sm_90` to lose. What remains is a forward risk rather
+  than a present one: if aarch64 supply later includes a discrete pre-Hopper card — an
+  Ampere Altra paired with an A100, say — that host is served today and would not be.
+  Re-measure before treating this as closed rather than assuming the market is static.
+  The ORIGINAL statement of the negative, which remains the binary-level truth: ai-dock's arm64 covers SM 75-120a; unsloth's starts at
   SM 90. Any aarch64 host with an A100, A10/A30, L4/L40S or T4 is served today and would
   not be after the swap — and the miss mode is silent CPU, not an error. The claim that
   coverage is "a superset on both lines" was false and is withdrawn. **arm64 has never

--- a/tools/imagegen/tests/test_llama_offload_sh.py
+++ b/tools/imagegen/tests/test_llama_offload_sh.py
@@ -1,0 +1,166 @@
+"""Tests for llama.d/11-llama-offload.sh — the CUDA-offload assertion (L076, ADR 0033).
+
+WHY THIS FILE EXISTS. This assertion is REQUIRED on every llama-cpp QA cell, so a
+false red blocks promotion of the whole image and a false green certifies an image
+serving from CPU. It has been wrong in both directions already, each time found only
+by a live dispatch: it first gated on a llama.cpp log format upstream had removed, then
+on `mib > 0` which a bare CUDA context satisfies, then on a VRAM floor that was never
+derived because the model search failed — announcing it could not decide and passing
+anyway.
+
+The branch this file exists for is the one a live run CANNOT be relied on to reach.
+On run 32846852617 nvidia-smi reported HOST pid 1041871 while the container saw 1010,
+so pid attribution failed and the check fell back to summing compute-app memory. On the
+very next dispatch all four cells drew unskewed hosts and took the strong path, so the
+fallback never executed. Host class is not something a test should have to hope for.
+
+Needs no GPU and no container: given (compute-app rows, pid, device memory, model size)
+the verdict is deterministic, so stubbing nvidia-smi/pgrep/llama-server on PATH is
+enough. Same approach as test_instance_test_lib_sh.py.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / \
+    "derivatives/llama-cpp/ROOT/opt/instance-tools/tests/llama.d/11-llama-offload.sh"
+
+# Only what the script actually calls. Each helper keeps the real contract: fail_later
+# RECORDS, report_failures is what turns records into a failing exit (L062).
+LIB = r'''#!/bin/bash
+FAILURES=()
+test_pass()  { echo "PASS: $*"; exit 0; }
+test_fail()  { echo "FAIL: $*"; exit 1; }
+test_skip()  { echo "SKIP: $*"; exit 77; }
+fail_later() { FAILURES+=("$1"); echo "FAIL: $1: $2"; }
+report_failures() { (( ${#FAILURES[@]} )) && { echo "FAILED: ${FAILURES[*]}"; exit 1; }; return 0; }
+has_gpu() { return 0; }
+assert_service_running() { echo "  service $1 running"; }
+wait_for_url() { return 0; }
+'''
+
+DEVICES_OK = "Available devices:\n  CUDA0: NVIDIA GeForce RTX 3080 (9877 MiB, 8812 MiB free)"
+DEVICES_NONE = "Available devices:\n  (none)"
+
+
+def run(tmp_path, *, apps, pid, dev_used="845", devices=DEVICES_OK, model_mib=644):
+    """Stage the script with stubbed nvidia-smi/pgrep/llama-server and run it."""
+    tests = tmp_path / "tests"
+    (tests / "llama.d").mkdir(parents=True)
+    (tests / "lib.sh").write_text(LIB)
+    target = tests / "llama.d" / "11-llama-offload.sh"
+    target.write_text(SCRIPT.read_text())
+    target.chmod(0o755)
+
+    bin_ = tmp_path / "bin"
+    bin_.mkdir()
+    # --query-compute-apps and --query-gpu are distinguished the way the script calls them.
+    (bin_ / "nvidia-smi").write_text(
+        "#!/bin/bash\n"
+        f'case "$*" in\n'
+        f'  *compute-apps*) printf %b "{apps}"; [ -n "{apps}" ] && echo ;;\n'
+        f'  *memory.used*)  echo "{dev_used}" ;;\n'
+        "esac\nexit 0\n")
+    (bin_ / "pgrep").write_text(f'#!/bin/bash\n[ -n "{pid}" ] && echo "{pid}"\nexit 0\n')
+    (bin_ / "llama-server").write_text(f'#!/bin/bash\nprintf "%b\\n" "{devices}"\nexit 0\n')
+    for f in bin_.iterdir():
+        f.chmod(0o755)
+
+    ws = tmp_path / "workspace"
+    (ws / "llama.cpp").mkdir(parents=True)
+    if model_mib:
+        # Sparse: find -printf '%s' reports apparent size, so no real bytes are written.
+        subprocess.run(["truncate", "-s", f"{model_mib}M",
+                        str(ws / "llama.cpp" / "model.gguf")], check=True)
+
+    env = dict(os.environ)
+    env.update(PATH=f"{bin_}:{env['PATH']}", LLAMA_MODEL="test/model",
+               WORKSPACE=str(ws), HOME=str(tmp_path / "home"))
+    env.pop("LLAMA_ARGS", None)
+    return subprocess.run(["bash", str(target)], capture_output=True, text=True, env=env)
+
+
+def test_pid_matches_above_floor_passes(tmp_path):
+    """The strong path: attribution succeeds and residency clears the model-derived floor."""
+    r = run(tmp_path, apps="762, 770 MiB", pid="762")
+    assert r.returncode == 0, r.stdout
+    assert "holds 770 MiB" in r.stdout
+
+
+def test_pid_namespace_skew_falls_back_to_the_total(tmp_path):
+    """THE branch a live run cannot be relied on to reach. Measured on run 32846852617:
+    nvidia-smi reported host pid 1041871 while the container saw 1010, on a two-GPU box
+    where one process held 530 and 634 MiB. Attribution is impossible; residency is not,
+    and 1164 MiB against a 322 MiB floor is real evidence."""
+    r = run(tmp_path, apps="1041871, 530 MiB\\n1041871, 634 MiB", pid="1010")
+    assert r.returncode == 0, r.stdout
+    assert "attributed by TOTAL" in r.stdout
+    assert "1164 MiB resident" in r.stdout
+
+
+def test_skew_below_floor_still_fails(tmp_path):
+    """The fallback must not become an escape hatch. Same unattributable shape, but no
+    process holds enough for the weights — that is a context-only server either way."""
+    r = run(tmp_path, apps="1041871, 208 MiB", pid="1010")
+    assert r.returncode == 1, r.stdout
+    assert "offload-below-floor" in r.stdout
+
+
+def test_ngl_zero_fails_when_attributed(tmp_path):
+    """The negative control, replayed: -ngl 0 held 208 MiB of bare CUDA context against a
+    322 MiB floor on run 32841313361. `mib > 0` passed this; the floor must not."""
+    r = run(tmp_path, apps="914, 208 MiB", pid="914")
+    assert r.returncode == 1, r.stdout
+    assert "offload-below-floor" in r.stdout
+
+
+def test_no_compute_apps_but_device_loaded_warns(tmp_path):
+    """Empty list beside a loaded device is NVML process enumeration being unavailable,
+    not a CPU fallback. Warn — the device disagrees with the process table."""
+    r = run(tmp_path, apps="", pid="762", dev_used="845")
+    assert r.returncode == 0, r.stdout
+    assert "enumeration is unavailable" in r.stdout
+
+
+def test_no_compute_apps_and_idle_device_fails(tmp_path):
+    """Empty list beside an idle device IS the silent CPU fallback."""
+    r = run(tmp_path, apps="", pid="762", dev_used="3")
+    assert r.returncode == 1, r.stdout
+    assert "offload-no-gpu-process" in r.stdout
+
+
+def test_non_numeric_memory_warns_rather_than_reporting_zero(tmp_path):
+    """`[N/A]` on MIG/vGPU is the driver declining to answer. Reporting it as zeroed
+    weights sends the reader to the wrong place."""
+    r = run(tmp_path, apps="762, [N/A]", pid="762")
+    assert r.returncode == 0, r.stdout
+    assert "did not report a memory figure" in r.stdout
+
+
+def test_missing_model_fails_rather_than_passing_unjudged(tmp_path):
+    """The defect the negative control exposed: with no floor derivable the check
+    announced it could not decide and passed anyway, silently restoring `mib > 0`."""
+    r = run(tmp_path, apps="914, 208 MiB", pid="914", model_mib=0)
+    assert r.returncode == 1, r.stdout
+    assert "offload-no-floor" in r.stdout
+
+
+def test_no_gpu_device_enumerated_fails(tmp_path):
+    """Arm A: the backend cannot dlopen at all, so the image serves on CPU."""
+    r = run(tmp_path, apps="", pid="", dev_used="3", devices=DEVICES_NONE)
+    assert r.returncode == 1, r.stdout
+    assert "offload-no-gpu-device" in r.stdout
+
+
+def test_error_text_naming_a_cuda_bundle_path_is_not_a_device(tmp_path):
+    """ADR 0033 names the bundles `x64-cuda12-portable`, and ggml prints the .so path on
+    FAILURE into the same stream. An unanchored case-insensitive match would find
+    "cuda12" there and report a GPU on the exact state arm A looks for."""
+    r = run(tmp_path, apps="", pid="", dev_used="3",
+            devices="failed to load backend from /opt/llama.cpp/x64-cuda12-portable/libggml-cuda.so\\nAvailable devices:\\n  (none)")
+    assert r.returncode == 1, r.stdout
+    assert "offload-no-gpu-device" in r.stdout


### PR DESCRIPTION
Implements ADR 0033. The model library treats unsloth as the preferred GGUF
provider, and the fork carries architectures and quant types upstream has not
merged — DiffusionGemma, TML Inkling, kimi-k3's MoonViT-3d vision tower,
IQ1_XS/XXS/XXXS. unsloth publishes GGUFs for exactly those. On stock llama.cpp,
including ai-dock's build, those models do not load at all.

## Shape

| line | base | bundle | arches |
|---|---|---|---|
| cuda-12.9 | `cuda-12.9-mini` | `x64-cuda12-portable` | amd64 |
| cuda-13.2 | `cuda-13.2-mini` | `x64` + `arm64-cuda13-portable` | amd64, arm64 |

The two lines are **not** the same shape: there is no arm64 CUDA 12 asset at all,
which is why `arches` is declared per line rather than as a global cross-product.
Three build cells. Every asset those cells request was confirmed present in the
release before a build was dispatched.

## What is verified, and how

Live on run 32846852617 — **all four QA cells green, offload passing in every
one**: cuda-12.9 27/0/3, cuda-12.9 serverless 23/0/7, cuda-13.2 27/0/3,
cuda-13.2 serverless 23/0/7. Not promoted; cancelled at the approval gate.

That run confirmed on hardware: the `x64` arch-slug mapping (unsloth does not
spell amd64 the way dpkg does), sha256 verification before extraction on all
three builds, flat-layout install, `RUNPATH=$ORIGIN` resolving the bundle's own
libraries, and deleting `06-llama-cuda.sh`.

It also confirmed the one claim made from a symbol table rather than a running
system: a bundle built against toolkit **13.3 resolves cleanly against the 13.2
base**. `libggml-cuda.so` needs 12 cuBLAS and 49 cudart symbols and every one is
exported by the 13.2 packages, so no CUDA minor is mixed and no loader-path
workaround is needed (ADR 0033 condition 9, now measured twice — statically and
live).

## Integrity

The download is checked against `llama-prebuilt-sha256.json` **before**
extraction. This is the first integrity check on any third-party fetch in this
repo; `docs/invariants.md` records "no integrity check" as the house convention.
A missing manifest entry **fails** rather than comparing empty-to-empty — sha256
of no input is a constant, so two failed lookups compare equal and the check
passes having verified nothing, the same fail-open already in this repo's memory
from the TLS cert predicate. Tested against four cases plus the real 336 MB asset
and the published manifest.

Its reach, stated honestly: same-party hashes detect transport damage, not a
compromised publishing path.

## Release detection

`tag-pattern: '-mix-'` restricts resolution to the fork's current release line,
which shares a repo with an older bare `bNNNN` line. A pattern matching nothing
resolves to no version, which on a schedule means `should-run=false` — and
`notify` is gated on `should-run`, so the workflow would stop building silently
and permanently. That now errors loudly. This upstream has already changed
tagging conventions once: ggml-org moved to `v0.x.y` stable with `bNNNN` as
prereleases in Aug 2026.

## Also in this PR

`llama.d/11-llama-offload` gains a fallback for PID-namespace skew, found by this
very run. On a two-GPU host nvidia-smi reported host pid `1041871` while the
container saw `1010`, so the pid check fell to its WARN branch and the cell
passed on arm A alone while still claiming the model was on the GPU. The rows are
evidence even when the pid is not — the question is whether any process holds
enough VRAM for the weights, which is namespace-proof. Arm B now sums when
attribution fails. Replayed against all three measured shapes: the skewed host
passes on 1164 MiB of real evidence, the `-ngl 0` control still fails at 208 MiB
against its 322 MiB floor, the healthy host passes at 838 MiB.

## Known gaps, not closed here

**arm64 is built but never gated.** All four QA cells pin `-amd64`, so
`arm64-cuda13-portable` enters the multi-arch index unbooted. Recorded in ADR
0033 as an accepted negative, and it matters more now the recommended template is
moving to 13.2, since aarch64 customers land on the arch nothing tested.

**The unsloth arm64 bundle starts at `sm_90`** where ai-dock's arm64 covered
`sm_75`, so pre-Hopper aarch64 hosts lose support. Also an accepted negative in
ADR 0033.

ADR 0033 remains **Proposed**: conditions 1, 3, 7, 8 and 9 are resolved or
superseded; 2, 4 (partially), 5, 6, 10, 11, 12 are not.

`imagegen lint --all` clean, 509 + 419 tests pass.