### PR TITLE
test(vllm): prove serverless detection end to end with a real worker

### DIFF
--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -364,10 +364,27 @@ jobs:
       # more tests that must have passed (base/85 and the pyworker score) because in
       # this mode they are no longer inert. Keeping it here is the difference between
       # QA scaffolding and the template's own configuration.
+      # THE AUTOSCALER'S OWN SIGNALS, NOT SERVERLESS=true (ADR 0034). This cell is now the
+      # only end-to-end proof of the inference: base's detection cells switch the mode but
+      # base has no engine, so nothing there shows a REAL worker starting and reaching a
+      # benchmark score under a mode the image inferred rather than was told.
+      #
+      # Both sentinels are self-evidently fake and safe in plaintext — the stage tests
+      # PRESENCE only and never reads either value, and .invalid cannot resolve.
+      #
+      # Every test named below can only pass if the image inferred the mode: they open
+      # with `is_serverless || test_skip`, and runner.sh turns a skipped REQUIRED test
+      # into REQUIRED-FAIL. So a broken inference is a red cell, not a quiet green.
+      #
+      # The EXPLICIT SERVERLESS=true path keeps its coverage on sglang and llama-cpp,
+      # whose serverless cells are unchanged — 9 of 10 published autoscaler templates
+      # still declare it, so that path must stay tested somewhere.
       extra_env: |
-        SERVERLESS=true
-        INSTANCE_TEST_REQUIRE_PASS=base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services vllm.d/10-vllm-serving vllm.d/12-vllm-contract vllm.d/20-serverless-pyworker
-      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services vllm.d/10-vllm-serving vllm.d/12-vllm-contract vllm.d/20-serverless-pyworker"
+        MASTER_TOKEN=qa-detection-sentinel-not-a-real-token
+        REPORT_ADDR=https://qa-detection-sentinel.invalid
+        SERVERLESS_DETECT_EXPECT=detected
+        INSTANCE_TEST_REQUIRE_PASS=base/15-boot-markers base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services vllm.d/10-vllm-serving vllm.d/12-vllm-contract vllm.d/20-serverless-pyworker
+      require_tests: "base/15-boot-markers base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services vllm.d/10-vllm-serving vllm.d/12-vllm-contract vllm.d/20-serverless-pyworker"
       retries: 2
     secrets:
       VAST_API_KEY: ${{ secrets.VAST_API_KEY }}

--- a/.github/workflows/promote-base-image.yml
+++ b/.github/workflows/promote-base-image.yml
@@ -458,6 +458,12 @@ jobs:
         MASTER_TOKEN=qa-detection-sentinel-not-a-real-token
         REPORT_ADDR=https://qa-detection-sentinel.invalid
         SERVERLESS_DETECT_EXPECT=detected
+        # Base has no inference engine, so a worker here is meaningless — but pyworker.sh
+        # starts on ANY serverless instance with no onstart bootstrap, which is precisely
+        # this cell. Without this it curl-pipes start_server.sh to root and then dies in
+        # the SDK looking up an unmapped VAST_TCP_PORT_3000, unnoticed, because L067
+        # deliberately removed base's pyworker assertion. This cell tests the MODE SWITCH.
+        SUPERVISOR_SKIP_PYWORKER=true
         INSTANCE_TEST_REQUIRE_PASS=base/15-boot-markers base/85-serverless-services
         PROV_TIMEOUT=900
         INSTANCE_TEST_DEFAULT_TIMEOUT=900

--- a/tools/imagegen/imagegen/linter.py
+++ b/tools/imagegen/imagegen/linter.py
@@ -714,7 +714,22 @@ def _serverless_gate_callers(repo: Path) -> dict[str, int]:
             pairs = dict(
                 ln.split("=", 1) for ln in env.splitlines()
                 if "=" in ln and not ln.lstrip().startswith("#"))
-            if pairs.get("SERVERLESS", "").strip().lower() != "true":
+            # A cell turns serverless ON two ways now (ADR 0034), and this must mirror
+            # the IMAGE's activation rule or the rule silently stops covering cells that
+            # exercise the inferred path — which is exactly what would happen if a caller
+            # swapped SERVERLESS=true for the autoscaler signals.
+            _sl = pairs.get("SERVERLESS", "").strip().lower()
+            if _sl == "false":
+                continue                       # explicit off beats everything
+            _inferred = bool(pairs.get("MASTER_TOKEN", "").strip()
+                             and pairs.get("REPORT_ADDR", "").strip())
+            if _sl != "true" and not _inferred:
+                continue
+            # A cell that explicitly skips the worker does not need the port. The rule's
+            # whole rationale is that the pyworker SDK looks up VAST_TCP_PORT_3000
+            # unguarded; with no worker there is nothing to look it up. Base's detection
+            # cell is the case: it exercises the mode switch on an image with no engine.
+            if pairs.get("SUPERVISOR_SKIP_PYWORKER", "").strip().lower() == "true":
                 continue
             try:
                 port = int(pairs.get("WORKER_PORT", "3000").strip())

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -2728,3 +2728,64 @@ def test_L077_the_real_repo_is_in_date():
     repo = find_repo_root(Path(__file__).resolve().parent)
     expired = [f for f in L.lint_repo(repo) if f.code == "L077" and f.severity == L.ERROR]
     assert not expired, f"a declared expiry has passed: {[(f.path, f.msg) for f in expired]}"
+
+
+def test_L073_covers_a_cell_that_infers_serverless(tmp_path):
+    """ADR 0034. A cell can now turn serverless on by supplying the autoscaler signals
+    instead of SERVERLESS=true. L073 keyed strictly on the literal, so such a cell would
+    have dropped out of the rule entirely and the worker-port requirement would go
+    unenforced — the defect L073 exists for (KeyError: 'VAST_TCP_PORT_3000', measured
+    live on the first serverless cell ever run) would come straight back."""
+    img = make(tmp_path)
+    _write_template(img, "name: QA\nimage: vastai/x\n" + _FLOORS)   # no port 3000 mapped
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "build-img.yml").write_text(
+        "jobs:\n  qa:\n    uses: ./.github/workflows/qa-gate.yml\n"
+        "    with:\n      template_dir: img/templates/qa\n"
+        "      extra_env: |\n        MASTER_TOKEN=sentinel\n        REPORT_ADDR=https://a\n")
+    assert "L073" in errs(img, tmp_path)
+
+
+def test_L073_ignores_a_cell_with_only_one_signal(tmp_path):
+    """One signal does not activate the mode in the image, so it must not be treated as
+    a serverless cell here either — mirroring the activation rule rather than guessing."""
+    img = make(tmp_path)
+    _write_template(img, "name: QA\nimage: vastai/x\n" + _FLOORS)
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "build-img.yml").write_text(
+        "jobs:\n  qa:\n    uses: ./.github/workflows/qa-gate.yml\n"
+        "    with:\n      template_dir: img/templates/qa\n"
+        "      extra_env: |\n        MASTER_TOKEN=sentinel\n")
+    assert "L073" not in errs(img, tmp_path)
+
+
+def test_L073_explicit_false_beats_the_signals(tmp_path):
+    """SERVERLESS=false wins over the inference in the image; the rule must agree."""
+    img = make(tmp_path)
+    _write_template(img, "name: QA\nimage: vastai/x\n" + _FLOORS)
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "build-img.yml").write_text(
+        "jobs:\n  qa:\n    uses: ./.github/workflows/qa-gate.yml\n"
+        "    with:\n      template_dir: img/templates/qa\n"
+        "      extra_env: |\n        SERVERLESS=false\n        MASTER_TOKEN=s\n        REPORT_ADDR=https://a\n")
+    assert "L073" not in errs(img, tmp_path)
+
+
+def test_L073_ignores_a_cell_that_skips_the_worker(tmp_path):
+    """The rule exists because the pyworker SDK looks up VAST_TCP_PORT_3000 unguarded.
+    A cell that sets SUPERVISOR_SKIP_PYWORKER=true starts no worker, so there is nothing
+    to look it up — demanding a port mapping there would be cargo-culting the rule past
+    its own rationale. Base's detection cell is exactly this: mode switch, no engine."""
+    img = make(tmp_path)
+    _write_template(img, "name: QA\nimage: vastai/x\n" + _FLOORS)
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "build-img.yml").write_text(
+        "jobs:\n  qa:\n    uses: ./.github/workflows/qa-gate.yml\n"
+        "    with:\n      template_dir: img/templates/qa\n"
+        "      extra_env: |\n        MASTER_TOKEN=s\n        REPORT_ADDR=https://a\n"
+        "        SUPERVISOR_SKIP_PYWORKER=true\n")
+    assert "L073" not in errs(img, tmp_path)


### PR DESCRIPTION
Base's detection cells (ADR 0034) prove the mode **switches**, but base has no inference
engine — so nothing yet showed a **real worker serving under a mode the image inferred**
rather than was told. vLLM builds directly over base, so its serverless QA cell now
supplies the autoscaler's own signals instead of `SERVERLESS=true`.

## Proven on hardware

Run 32959318682, both cells (cu129 + cu130) green. With **no `SERVERLESS` anywhere** in
the template or the overrides:

```
serverless mode: detected (recorded SERVERLESS=true)
verdict is 'detected' as this cell expected
PASS: base/85-serverless-services
PASS: vllm.d/10-vllm-serving
PASS: vllm.d/12-vllm-contract — enforcing, 0 violation(s)
PASS: vllm.d/20-serverless-pyworker — serving on :3000 and scored 480.37 on this run
22 passed, 0 failed, 7 skipped
```

Full chain: signals arrive → boot stage infers → export reaches supervisord → six
services stop → vLLM serves → pyworker binds :3000 → a benchmark score written by that
run.

Every test the cell requires opens with `is_serverless || test_skip`, and `runner.sh`
turns a skipped REQUIRED test into `REQUIRED-FAIL` — so a broken inference is a red cell,
not a quiet green.

## The explicit path keeps its coverage

`sglang` and `llama-cpp` serverless cells are **unchanged** and still declare
`SERVERLESS=true`. 9 of 10 published autoscaler templates use that path, so it must stay
tested somewhere — swapping it everywhere would trade away coverage of the mode
production actually uses.

## L073 had to learn the inferred path first

`linter.py`'s serverless-gate detection keyed strictly on the literal `SERVERLESS` in a
caller's `extra_env`. Without widening it, this swap would have silently removed vLLM
from the rule requiring the QA template to map the worker port — bringing back the exact
defect L073 exists for (`KeyError: 'VAST_TCP_PORT_3000'` inside `Metrics()`, measured
live on the first serverless cell ever run). It now mirrors the image's activation rule:
`SERVERLESS=true`, or both signals, with an explicit `false` beating the inference.

## Widening it found a real defect in base's own gate

The baseline broke immediately, and correctly. Base ships `pyworker.conf`, and
`pyworker.sh` starts on **any** serverless instance without an onstart bootstrap — which
is precisely base's detection cells. Those 10 cells have been curl-piping
`start_server.sh` to root and starting a worker on an image with **no engine**, which
then dies in the SDK looking up an unmapped `VAST_TCP_PORT_3000`. They passed because
L067 deliberately removed base's pyworker assertion, so nothing was watching.

Fixed by not starting one — the base detection cell sets `SUPERVISOR_SKIP_PYWORKER=true`,
using the escape hatch that already exists. Mapping the port instead would have satisfied
the rule while leaving a pointless worker fetching third-party code as root on every base
promote. L073 now exempts a cell that explicitly skips the worker: with no worker there is
nothing to look the port up, and a rule should not outlive its own rationale.

## Known gap, not addressed here

`build-vllm.yml` and `build-sglang.yml` set no `evidence_name` on their QA cells, so those
cells upload no verdict payload — verifying this run meant grepping logs full of
3,000-word benchmark prompts. `build-llama-cpp.yml` already has it. One line each,
deliberately left out of this PR to keep it to one concern.

`imagegen lint --all` clean, 546 + 419 tests pass.