### PR TITLE
chore(derivatives): move every base/pytorch pin to the detection-carrying 2026-08-26

### DIFF
--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -220,7 +220,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-21
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-26
         # arm64 is intentionally absent: ACE-Step-1.5's pyproject.toml
         # declares `torchao ; platform_machine == 'aarch64'`, and torchao
         # ships no aarch64 wheels (manylinux_x86_64 only), so the upstream
@@ -239,7 +239,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-21
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-aio-studio-base.yml
+++ b/.github/workflows/build-aio-studio-base.yml
@@ -15,7 +15,7 @@ on:
       PYTORCH_BASE:
         description: "Multi-torch base image"
         required: true
-        default: "vastai/pytorch:multi-210-291-271-2026-08-21"
+        default: "vastai/pytorch:multi-210-291-271-2026-08-26"
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
         required: true

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -101,8 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-21
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-26
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -202,8 +202,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-21
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-linux-desktop.yml
+++ b/.github/workflows/build-linux-desktop.yml
@@ -94,9 +94,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-08-21
-          - vastai/base-image:cuda-12.9-mini-py312-2026-08-21
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-21
+          - vastai/base-image:cuda-13.2-mini-py312-2026-08-26
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-26
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-26
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -159,9 +159,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-08-21
-          - vastai/base-image:cuda-12.9-mini-py312-2026-08-21
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-21
+          - vastai/base-image:cuda-13.2-mini-py312-2026-08-26
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-26
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-oobabooga.yml
+++ b/.github/workflows/build-oobabooga.yml
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
         # arm64 is intentionally absent: oobabooga's accelerator wheels
         # (exllamav3, flash_attn, xformers, llama_cpp_binaries) are x86_64-only.
         # Re-add the arm64 entry once those gain aarch64 CUDA wheels (and update
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
         # arm64 is intentionally absent: torchcodec is required at runtime
         # (transitive via torchaudio.load() in toolkit/dataloader_mixins.py)
         # but ships no aarch64 Linux wheels at any version. Re-add when
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   DEFAULT_DOCKERHUB_REPO: "sd-forge"
-  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-21"
+  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-26"
   # 7 days in seconds
   COMMIT_AGE_THRESHOLD: 604800
 

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
         # arm64 is intentionally absent: `torchao` (transitive via
         # unsloth-zoo>=2026.5.3 -> unsloth) only publishes amd64 manylinux
         # wheels as of v0.17.0+cu128. Re-add when upstream torchao ships
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-voicebox.yml
+++ b/.github/workflows/build-voicebox.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
         # arm64 is intentionally absent: Wan2GP requires onnxruntime-gpu
         # (pulled from the Azure ort-cuda-13-nightly index), which has no
         # aarch64 wheels — and PyPI's stable onnxruntime-gpu is also
@@ -236,7 +236,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-26
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-21
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-26
 
     steps:
       - name: Checkout

--- a/derivatives/pytorch/derivatives/a1111/Dockerfile
+++ b/derivatives/pytorch/derivatives/a1111/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/comfyui/Dockerfile
+++ b/derivatives/pytorch/derivatives/comfyui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fluxgym/Dockerfile
+++ b/derivatives/pytorch/derivatives/fluxgym/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fooocus/Dockerfile
+++ b/derivatives/pytorch/derivatives/fooocus/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/invokeai/Dockerfile
+++ b/derivatives/pytorch/derivatives/invokeai/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
+++ b/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/Dockerfile
+++ b/derivatives/pytorch/derivatives/oobabooga/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/README.build.md
+++ b/derivatives/pytorch/derivatives/oobabooga/README.build.md
@@ -16,7 +16,7 @@ example below pins a tag for a reproducible local build; pass any commit/branch/
 ```bash
 docker buildx build \
     --platform linux/amd64 \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26 \
     --build-arg OOBABOOGA_REF=v4.9 \
     . -t repo/image:tag --push
 ```

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/sd-forge/Dockerfile
+++ b/derivatives/pytorch/derivatives/sd-forge/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/swarmui/Dockerfile
+++ b/derivatives/pytorch/derivatives/swarmui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
 FROM ${PYTORCH_BASE}
 
 LABEL org.opencontainers.image.source="https://github.com/vastai/"

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/wan2gp/Dockerfile
+++ b/derivatives/pytorch/derivatives/wan2gp/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/whisper/Dockerfile
+++ b/derivatives/pytorch/derivatives/whisper/Dockerfile
@@ -13,7 +13,7 @@
 # 2.8.0). The UPPER bound is real too — upstream master carries
 # "# 2.9 deprecates used functions" against it — so this is a fixed point, not a
 # floor to raise later: do not move it to 2.9.x without re-reading upstream.
-ARG PYTORCH_BASE=vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-21
+ARG PYTORCH_BASE=vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-26
 
 FROM ${PYTORCH_BASE}
 


### PR DESCRIPTION
Pure date substitution: `2026-08-21` → `2026-08-26` on every dated base/pytorch pin. **47 references across 30 files, no other change.**

## Why

Every derivative pins a dated base or pytorch tag, in its Dockerfile `ARG` and again in its build workflow. Those pins sat on `2026-08-21`, which predates ADR 0034's serverless detection. A scheduled autobuild of any derivative would therefore have rebuilt it on a base with no `01-detect-serverless.sh` and quietly shipped an image that cannot infer the mode.

The point of putting detection in base is that every image inherits it. A stale pin is where that inheritance silently stops.

## What I verified before bumping

**Every target tag exists in the registry.** A pin to a tag that was never published fails at `docker build`, per image, hours later.

One correction worth flagging for the reviewer: my first pass reported four combos missing and six derivatives blocked. That was wrong — DockerHub's `/tags/list` paginates and I had read only the first 1000 of 1642 tags. Paged properly, all 15 pytorch tags and all 3 base tags resolve. Re-checkable with:

```bash
# follow the rel="next" Link header; a single page silently truncates
curl -sD- -H "Authorization: Bearer $TOK" \
  "https://registry-1.docker.io/v2/vastai/pytorch/tags/list?n=1000" | grep -i ^link
```

**The new pytorch really is built on the detection-carrying base.** Without this the bump would be pointless, so I checked lineage by layer digests rather than trusting the build date:

| | built FROM base `2026-08-21` | built FROM base `2026-08-26` |
|---|---|---|
| `pytorch:...-2026-08-21` | **true** | false |
| `pytorch:...-2026-08-26` | false | **true** |

The base's 23 layers appear as an exact prefix of the pytorch manifest in each true case.

## Scope

**Torch versions are untouched.** Every image keeps its exact torch/python/CUDA combination and moves only the date. Those pins encode per-upstream constraints — ostris needs torchcodec 0.9.1 against torch 2.9.1, a1111 and fluxgym are on 2.7.1 — so changing one here would be an unrelated, unreviewed upgrade.

| pin | images |
|---|---|
| `2.7.1-cu128-cuda-12.9-mini-py310/311/312` | a1111, fluxgym, fooocus, kohya_ss, invokeai, wan2gp |
| `2.8.0-cu128-cuda-12.9-mini-py312` | whisper |
| `2.9.1-cu128-cuda-12.9-mini-py311/312` | sd-forge, oobabooga, ostris-ai-toolkit, voicebox |
| `2.10.0-cu128-cuda-12.9-mini-py311/312` | ace-step, comfyui, swarmui, unsloth-studio |
| `2.10.0-cu130-cuda-13.2-mini-py312`, `multi-210-291-271` | linux-desktop, aio-studio-base |
| `base-image:{cuda-12.9-mini,cuda-13.2-mini,stock-ubuntu24.04}-py312` | linux-desktop, comfyui |

**The five external images need no change.** They build with `base_image_source=.` and take `ROOT/` from the repo checkout, so they carry detection already — which is why vLLM and SGLang could be built from main days ago and still have it.

## Not fixed here

`L005` gates that a pin is **concrete**; nothing gates its **age**. Pins sat on `2026-06-15` for nine weeks (#253) and have now gone stale twice in one week. A concrete pin nobody bumps is as stale as a floating one is unpredictable, and only the floating case is gated today. Raising it rather than bolting a third change onto this PR — worth deciding separately whether that becomes a rule.

## Checks

`imagegen lint --all` → `baseline CLEAN ✓` (27 images), 314 tests green across the linter and notification-truth suites. No image is rebuilt by this PR; the pins take effect on each image's next build.
