### PR TITLE
test(qa): one serverless cell per image — ComfyUI gets its first ever, and the advisory ramp that wasn't one

### DIFF
--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -193,8 +193,121 @@ jobs:
       DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  # Serverless cell — the FIRST one ComfyUI has ever had. The image has baked
+  # BACKEND=comfyui-json and EXPOSE 3000 for some time and `comfyui.d/20-serverless-pyworker`
+  # has been in the suite the whole while, dormant behind its `is_serverless` guard: the
+  # assertion existed and had never once executed, on any cell, anywhere. That is L067's
+  # shape — a test whose mode is never switched on is not coverage.
+  #
+  # PROVISIONING_COMFYUI_WORKFLOWS is carried over from the standard cell and is NOT
+  # scaffolding here: unlike the LLM engines, whose benchmark payload the worker
+  # synthesises from a model name, comfyui-json benchmarks a real WORKFLOW that
+  # convert-workflows.sh derives from this file. Without it the worker has nothing to
+  # drive and never reaches a score, which is the one thing this cell asserts.
+  #
+  # The worker's contract with this image is hardcoded upstream and matched here:
+  # 127.0.0.1:18288 (api-wrapper's uvicorn), /var/log/portal/api-wrapper.log (derived
+  # from `[program:api-wrapper]`) and /health. None of it is passed as env, because all
+  # of it is the image's own — passing it would test our values instead of the image's.
+  #
+  # IT DOES NOT GATE YET, on the same ramp every other engine's serverless cell uses:
+  # named in merge-manifests' `needs` so it is ORDERED ahead of the production approval
+  # prompt, absent from its `if` so it cannot BLOCK.
+  qa-serverless:
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      # cuda/py are constants per variant (matching the build matrix), so the
+      # staging tag is built inline below — no per-cell shell derivation.
+      matrix:
+        include:
+          - { cuda: "12.9", py: "py312" }
+          - { cuda: "13.2", py: "py312" }
+    uses: ./.github/workflows/qa-gate.yml
+    with:
+      repo: ${{ inputs.DOCKERHUB_REPO || 'comfy' }}
+      tag: ${{ inputs.CUSTOM_IMAGE_TAG || needs.preflight.outputs.comfyui-ref }}-cuda-${{ matrix.cuda }}-${{ matrix.py }}-amd64
+      template_dir: derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa
+      label: base-image-qa-comfyui-serverless
+      log_paths: "/var/log/portal/comfyui.log /var/log/portal/api-wrapper.log"
+      # SHA-pinned so the QA box provisions the workflow on the ref under test.
+      extra_env: |
+        SERVERLESS=true
+        # REPORT_ADDR is not product configuration and must not be left to the image:
+        # start_server.sh and the SDK both default it to https://run.vast.ai, so omitting
+        # it posts worker status to the PRODUCTION autoscaler from a disposable QA box.
+        # `.invalid` is RFC 2606 reserved and can never resolve. Gated by L079.
+        REPORT_ADDR=https://qa-no-autoscaler.invalid
+        PROVISIONING_COMFYUI_WORKFLOWS=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json
+        INSTANCE_TEST_REQUIRE_PASS=base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services comfyui.d/10-comfyui-serving comfyui.d/20-serverless-pyworker
+      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services comfyui.d/10-comfyui-serving comfyui.d/20-serverless-pyworker"
+      # ADR 0029 condition 5: the redraw rule is not forked per image. This gate ran
+      # retries: 0 while base and pytorch ran 2, so a bad host red here blocked a
+      # promote that the same image would have survived on any other image's gate.
+      # A real defect still blocks — it fails every draw — and each failed attempt
+      # records its machine and excludes it from the next.
+      retries: 2
+    secrets:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # start_server.sh: `[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit`.
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  # Detection cell (ADR 0034) — identical to qa-serverless above but supplying the
+  # AUTOSCALER'S OWN SIGNALS instead of SERVERLESS=true, so the image must INFER the mode.
+  # Both are kept: 9 of 10 published autoscaler templates still declare SERVERLESS=true
+  # and the platform does not yet inject it, so the declared path is today's production
+  # path while the inferred one is being rolled out.
+  #
+  # Both sentinels are self-evidently fake and safe in plaintext — 01-detect-serverless.sh
+  # tests PRESENCE only and never reads either value, and .invalid cannot resolve. The
+  # MASTER_TOKEN here is not a credential and must never be replaced with one.
+  #
+  # SERVERLESS_DETECT_EXPECT=detected makes base/15-boot-markers assert the VERDICT the
+  # stage recorded rather than merely that the instance came up.
+  qa-serverless-detect:
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      # cuda/py are constants per variant (matching the build matrix), so the
+      # staging tag is built inline below — no per-cell shell derivation.
+      matrix:
+        include:
+          - { cuda: "12.9", py: "py312" }
+          - { cuda: "13.2", py: "py312" }
+    uses: ./.github/workflows/qa-gate.yml
+    with:
+      repo: ${{ inputs.DOCKERHUB_REPO || 'comfy' }}
+      tag: ${{ inputs.CUSTOM_IMAGE_TAG || needs.preflight.outputs.comfyui-ref }}-cuda-${{ matrix.cuda }}-${{ matrix.py }}-amd64
+      template_dir: derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa
+      label: base-image-qa-comfyui-serverless-detect
+      log_paths: "/var/log/portal/comfyui.log /var/log/portal/api-wrapper.log"
+      # SHA-pinned so the QA box provisions the workflow on the ref under test.
+      extra_env: |
+        MASTER_TOKEN=qa-detection-sentinel-not-a-real-token
+        REPORT_ADDR=https://qa-detection-sentinel.invalid
+        SERVERLESS_DETECT_EXPECT=detected
+        PROVISIONING_COMFYUI_WORKFLOWS=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json
+        INSTANCE_TEST_REQUIRE_PASS=base/15-boot-markers base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services comfyui.d/10-comfyui-serving comfyui.d/20-serverless-pyworker
+      require_tests: "base/15-boot-markers base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services comfyui.d/10-comfyui-serving comfyui.d/20-serverless-pyworker"
+      # ADR 0029 condition 5: the redraw rule is not forked per image. This gate ran
+      # retries: 0 while base and pytorch ran 2, so a bad host red here blocked a
+      # promote that the same image would have survived on any other image's gate.
+      # A real defect still blocks — it fails every draw — and each failed attempt
+      # records its machine and excludes it from the next.
+      retries: 2
+    secrets:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # start_server.sh: `[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit`.
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
   merge-manifests:
-    needs: [preflight, build, qa]
+    needs: [preflight, build, qa, qa-serverless, qa-serverless-detect]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -307,8 +307,23 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   merge-manifests:
+    # qa-serverless and qa-serverless-detect are in `needs` to ORDER them ahead of the
+    # production approval prompt, and absent from the `if` so they cannot BLOCK — the
+    # advisory ramp every other engine's serverless cell uses.
+    #
+    # `!cancelled()` is what makes that true, and it is not decoration. A job named in
+    # `needs` blocks BY DEFAULT: GitHub implicitly skips a job when anything it needs
+    # fails, so "absent from the if" is not enough on its own. Measured 2026-08-27 —
+    # adding the two cells to `needs` alone silently made them gating, and a config_error
+    # in one skipped merge-manifests for a run whose four other cells were green.
+    # `!cancelled()` switches that implicit skip off, which is why the results that MUST
+    # still block are then named explicitly.
     needs: [preflight, build, qa, qa-serverless, qa-serverless-detect]
-    if: needs.preflight.outputs.should-run == 'true'
+    if: >-
+      !cancelled()
+      && needs.preflight.outputs.should-run == 'true'
+      && needs.build.result == 'success'
+      && needs.qa.result == 'success'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     strategy:

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -232,60 +232,27 @@ jobs:
       label: base-image-qa-comfyui-serverless
       log_paths: "/var/log/portal/comfyui.log /var/log/portal/api-wrapper.log"
       # SHA-pinned so the QA box provisions the workflow on the ref under test.
-      extra_env: |
-        SERVERLESS=true
-        # REPORT_ADDR is not product configuration and must not be left to the image:
-        # start_server.sh and the SDK both default it to https://run.vast.ai, so omitting
-        # it posts worker status to the PRODUCTION autoscaler from a disposable QA box.
-        # `.invalid` is RFC 2606 reserved and can never resolve. Gated by L079.
-        REPORT_ADDR=https://qa-no-autoscaler.invalid
-        PROVISIONING_COMFYUI_WORKFLOWS=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json
-        INSTANCE_TEST_REQUIRE_PASS=base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services comfyui.d/10-comfyui-serving comfyui.d/20-serverless-pyworker
-      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services comfyui.d/10-comfyui-serving comfyui.d/20-serverless-pyworker"
-      # ADR 0029 condition 5: the redraw rule is not forked per image. This gate ran
-      # retries: 0 while base and pytorch ran 2, so a bad host red here blocked a
-      # promote that the same image would have survived on any other image's gate.
-      # A real defect still blocks — it fails every draw — and each failed attempt
-      # records its machine and excludes it from the next.
-      retries: 2
-    secrets:
-      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
-      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      # start_server.sh: `[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit`.
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
-  # Detection cell (ADR 0034) — identical to qa-serverless above but supplying the
-  # AUTOSCALER'S OWN SIGNALS instead of SERVERLESS=true, so the image must INFER the mode.
-  # Both are kept: 9 of 10 published autoscaler templates still declare SERVERLESS=true
-  # and the platform does not yet inject it, so the declared path is today's production
-  # path while the inferred one is being rolled out.
-  #
-  # Both sentinels are self-evidently fake and safe in plaintext — 01-detect-serverless.sh
-  # tests PRESENCE only and never reads either value, and .invalid cannot resolve. The
-  # MASTER_TOKEN here is not a credential and must never be replaced with one.
-  #
-  # SERVERLESS_DETECT_EXPECT=detected makes base/15-boot-markers assert the VERDICT the
-  # stage recorded rather than merely that the instance came up.
-  qa-serverless-detect:
-    needs: [preflight, build]
-    if: needs.preflight.outputs.should-run == 'true'
-    strategy:
-      fail-fast: false
-      # cuda/py are constants per variant (matching the build matrix), so the
-      # staging tag is built inline below — no per-cell shell derivation.
-      matrix:
-        include:
-          - { cuda: "12.9", py: "py312" }
-          - { cuda: "13.2", py: "py312" }
-    uses: ./.github/workflows/qa-gate.yml
-    with:
-      repo: ${{ inputs.DOCKERHUB_REPO || 'comfy' }}
-      tag: ${{ inputs.CUSTOM_IMAGE_TAG || needs.preflight.outputs.comfyui-ref }}-cuda-${{ matrix.cuda }}-${{ matrix.py }}-amd64
-      template_dir: derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa
-      label: base-image-qa-comfyui-serverless-detect
-      log_paths: "/var/log/portal/comfyui.log /var/log/portal/api-wrapper.log"
-      # SHA-pinned so the QA box provisions the workflow on the ref under test.
+      # THE AUTOSCALER'S OWN SIGNALS, NOT SERVERLESS=true (ADR 0034). ONE serverless cell,
+      # exercising the INFERRED path, because that is the strictly harder one: it requires
+      # 01-detect-serverless.sh to run, decide and EXPORT SERVERLESS — and the export to
+      # reach the test runner, since `is_serverless` reads the variable, not the marker
+      # file. A declared SERVERLESS=true arrives via docker -e and is a SUBSET of that, so
+      # a cell passing here would pass there.
+      #
+      # It therefore doubles as the per-image canary for "did this image actually inherit
+      # the stage": a stale base pin yields an image with no 01-detect-serverless.sh,
+      # where a DECLARED cell still passes and this one cannot.
+      #
+      # The declared branch keeps its coverage where it is cheap and exact —
+      # tools/imagegen/tests/test_detect_serverless_sh.py drives the real script through
+      # every branch, including an explicit true and an explicit false, with no GPU.
+      #
+      # Both sentinels are self-evidently fake and safe in plaintext: the stage tests
+      # PRESENCE only and never reads either value, and .invalid cannot resolve. The
+      # MASTER_TOKEN here is not a credential and must never be replaced with one.
+      #
+      # Every test named below opens with `is_serverless || test_skip`, and runner.sh turns
+      # a skipped REQUIRED test into REQUIRED-FAIL — a broken inference is a red cell.
       extra_env: |
         MASTER_TOKEN=qa-detection-sentinel-not-a-real-token
         REPORT_ADDR=https://qa-detection-sentinel.invalid
@@ -305,7 +272,6 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       # start_server.sh: `[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit`.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
   merge-manifests:
     # qa-serverless and qa-serverless-detect are in `needs` to ORDER them ahead of the
     # production approval prompt, and absent from the `if` so they cannot BLOCK — the
@@ -318,7 +284,7 @@ jobs:
     # in one skipped merge-manifests for a run whose four other cells were green.
     # `!cancelled()` switches that implicit skip off, which is why the results that MUST
     # still block are then named explicitly.
-    needs: [preflight, build, qa, qa-serverless, qa-serverless-detect]
+    needs: [preflight, build, qa, qa-serverless]
     if: >-
       !cancelled()
       && needs.preflight.outputs.should-run == 'true'

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -256,6 +256,26 @@ jobs:
       extra_env: |
         MASTER_TOKEN=qa-detection-sentinel-not-a-real-token
         REPORT_ADDR=https://qa-detection-sentinel.invalid
+        # UNSECURED skips the pubkey gate, and it undoes a QA-only side effect rather
+        # than weakening the test. REPORT_ADDR above is an unresolvable sentinel (L079),
+        # so `GET ${REPORT_ADDR}/pubkey/` CANNOT succeed — five attempts, then
+        # `backend_errored`, on every cell, always. The gate therefore proves nothing
+        # here: it is guaranteed to fail for a reason QA created, and skipping it masks
+        # nothing observable, because no configuration of ours could make it pass.
+        #
+        # What it costs without this: the worker benchmarks fine (`.has_benchmark` is
+        # written at backend.py:857, BEFORE the gate at :915 — which is why these cells
+        # were already green) and then dies at the last step, so every QA worker ends
+        # its life `errored` and each cell burns ~60s waiting for a key that cannot
+        # arrive. Measured on a live 2x5090 debug box: detection worked, sglang served,
+        # benchmark 995.55 written, then "Cannot mark model as loaded: pubkey fetch
+        # failed".
+        #
+        # SCOPE: QA scaffolding, and it must never reach a template — there it would
+        # disable request-signature verification on a live worker (__check_signature
+        # returns True immediately). It lives in extra_env precisely because a
+        # template.yml is what a production template gets copied from. Gated by L080.
+        UNSECURED=true
         SERVERLESS_DETECT_EXPECT=detected
         PROVISIONING_COMFYUI_WORKFLOWS=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/sd15-txt2img.json
         INSTANCE_TEST_REQUIRE_PASS=base/15-boot-markers base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services comfyui.d/10-comfyui-serving comfyui.d/20-serverless-pyworker

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -387,91 +387,27 @@ jobs:
       set_filters: "cuda_max_good.gte=${{ matrix.driver_floor }}"
       evidence_name: qa-evidence-llama-cpp-serverless-cuda-${{ matrix.cuda }}
       log_paths: "/var/log/portal/llama.log /var/log/portal/pyworker.log /workspace/pyworker.log /workspace/debug.log"
-      extra_env: |
-        SERVERLESS=true
-        # REPORT_ADDR is NOT product configuration, and it is the one variable this
-        # cell must not leave to the image. The worker POSTs its status to
-        # ${REPORT_ADDR}/worker_status/, and BOTH layers default that to the live
-        # autoscaler — start_server.sh `${REPORT_ADDR:-https://run.vast.ai}` and the
-        # SDK's backend.py `os.environ.get("REPORT_ADDR", "https://run.vast.ai")`. So
-        # omitting it does not send nothing; it sends to PRODUCTION. Until 2026-08-27
-        # this cell did exactly that on every run: a disposable QA instance announcing
-        # itself to the real autoscaler as a worker, with an unset MASTER_TOKEN and a
-        # real CONTAINER_ID. Nobody chose it and nobody would have gone looking.
-        #
-        # `.invalid` is reserved by RFC 2606 and can never resolve, so the POST fails
-        # in DNS and the run cannot touch any live endpoint. The cost is honest and
-        # bounded: metrics.py retries 3x/2s at DEBUG and carries on, so the worker
-        # still starts, serves and benchmarks — this cell never proved that status
-        # REACHES the autoscaler, and now it does not pretend to. Gated by L079.
-        REPORT_ADDR=https://qa-no-autoscaler.invalid
-        # UNSECURED skips the pubkey gate, and it undoes a QA-only side effect rather
-        # than weakening the test. REPORT_ADDR above is an unresolvable sentinel (L079),
-        # so `GET ${REPORT_ADDR}/pubkey/` CANNOT succeed — five attempts, then
-        # `backend_errored`, on every cell, always. The gate therefore proves nothing
-        # here: it is guaranteed to fail for a reason QA created, and skipping it masks
-        # nothing observable, because no configuration of ours could make it pass.
-        #
-        # What it costs without this: the worker benchmarks fine (`.has_benchmark` is
-        # written at backend.py:857, BEFORE the gate at :915 — which is why these cells
-        # were already green) and then dies at the last step, so every QA worker ends
-        # its life `errored` and each cell burns ~60s waiting for a key that cannot
-        # arrive. Measured on a live 2x5090 debug box: detection worked, sglang served,
-        # benchmark 995.55 written, then "Cannot mark model as loaded: pubkey fetch
-        # failed".
-        #
-        # SCOPE: QA scaffolding, and it must never reach a template — there it would
-        # disable request-signature verification on a live worker (__check_signature
-        # returns True immediately). It lives in extra_env precisely because a
-        # template.yml is what a production template gets copied from. Gated by L080.
-        UNSECURED=true
-        INSTANCE_TEST_REQUIRE_PASS=base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services llama.d/10-llama-serving llama.d/11-llama-offload llama.d/12-llama-contract llama.d/20-serverless-pyworker
-      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services llama.d/10-llama-serving llama.d/11-llama-offload llama.d/12-llama-contract llama.d/20-serverless-pyworker"
-      retries: 2
-    secrets:
-      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
-      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      # start_server.sh aborts when BACKEND is set and HF_TOKEN is not.
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
-  # Detection cell (ADR 0034). Identical to `qa-serverless` above in every respect but
-  # one: it supplies the AUTOSCALER'S OWN SIGNALS instead of SERVERLESS=true, so the
-  # image must INFER the mode rather than be told it. Both cells are kept, because they
-  # test different things and both are live: 9 of 10 published autoscaler templates
-  # still declare SERVERLESS=true, and the platform has not yet been changed to inject
-  # it — so the declared path is today's production path and the inferred path is the
-  # one being rolled out.
-  #
-  # Both sentinel values are self-evidently fake and safe in plaintext:
-  # 01-detect-serverless.sh tests PRESENCE only and never reads either value, and
-  # .invalid cannot resolve. MASTER_TOKEN here is not a credential and must never be
-  # replaced with one.
-  #
-  # SERVERLESS_DETECT_EXPECT=detected makes base/15-boot-markers assert the VERDICT the
-  # stage recorded, not merely that the instance came up. Every llama.d test named below
-  # additionally opens with `is_serverless || test_skip`, and runner.sh turns a skipped
-  # REQUIRED test into REQUIRED-FAIL — so a broken inference is a red cell, never a
-  # quiet green.
-  #
-  # IT DOES NOT GATE YET, on the same ramp as qa-serverless: ORDERED ahead of the
-  # approval prompt via `needs`, absent from the `if`.
-  qa-serverless-detect:
-    needs: [preflight, build]
-    if: needs.preflight.outputs.should-run == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.preflight.outputs.merge-matrix) }}
-    uses: ./.github/workflows/qa-gate.yml
-    with:
-      repo: ${{ inputs.DOCKERHUB_REPO || 'llama-cpp' }}
-      tag: ${{ inputs.CUSTOM_IMAGE_TAG || format('{0}-cuda-{1}', needs.preflight.outputs.llama-cpp-version, matrix.cuda) }}-amd64
-      template_dir: derivatives/llama-cpp/templates/llama-cpp-qa
-      label: base-image-qa-llama-cpp-serverless-detect
-      set_filters: "cuda_max_good.gte=${{ matrix.driver_floor }}"
-      evidence_name: qa-evidence-llama-cpp-serverless-detect-cuda-${{ matrix.cuda }}
-      log_paths: "/var/log/portal/llama.log /var/log/portal/pyworker.log /workspace/pyworker.log /workspace/debug.log"
+      # THE AUTOSCALER'S OWN SIGNALS, NOT SERVERLESS=true (ADR 0034). ONE serverless cell,
+      # exercising the INFERRED path, because that is the strictly harder one: it requires
+      # 01-detect-serverless.sh to run, decide and EXPORT SERVERLESS — and the export to
+      # reach the test runner, since `is_serverless` reads the variable, not the marker
+      # file. A declared SERVERLESS=true arrives via docker -e and is a SUBSET of that, so
+      # a cell passing here would pass there.
+      #
+      # It therefore doubles as the per-image canary for "did this image actually inherit
+      # the stage": a stale base pin yields an image with no 01-detect-serverless.sh,
+      # where a DECLARED cell still passes and this one cannot.
+      #
+      # The declared branch keeps its coverage where it is cheap and exact —
+      # tools/imagegen/tests/test_detect_serverless_sh.py drives the real script through
+      # every branch, including an explicit true and an explicit false, with no GPU.
+      #
+      # Both sentinels are self-evidently fake and safe in plaintext: the stage tests
+      # PRESENCE only and never reads either value, and .invalid cannot resolve. The
+      # MASTER_TOKEN here is not a credential and must never be replaced with one.
+      #
+      # Every test named below opens with `is_serverless || test_skip`, and runner.sh turns
+      # a skipped REQUIRED test into REQUIRED-FAIL — a broken inference is a red cell.
       extra_env: |
         MASTER_TOKEN=qa-detection-sentinel-not-a-real-token
         REPORT_ADDR=https://qa-detection-sentinel.invalid
@@ -505,7 +441,6 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       # start_server.sh aborts when BACKEND is set and HF_TOKEN is not.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
   merge-manifests:
     # qa-serverless is in `needs` to ORDER it ahead of the approval prompt and absent
     # from the `if` so it cannot BLOCK. `!cancelled()` is what stops a failed
@@ -533,7 +468,7 @@ jobs:
     # an ungated scheduled run, which is the common path on this weekly workflow.
     # "Read the artifact, treat absent as pass" is exactly the shape of the last two
     # defects fixed on this repo.
-    needs: [preflight, build, qa, qa-serverless, qa-serverless-detect]
+    needs: [preflight, build, qa, qa-serverless]
     if: >-
       !cancelled()
       && needs.preflight.outputs.should-run == 'true'

--- a/.github/workflows/build-sglang.yml
+++ b/.github/workflows/build-sglang.yml
@@ -346,110 +346,27 @@ jobs:
       # more tests that must have passed (base/85 and the pyworker score) because in
       # this mode they are no longer inert. Keeping it here is the difference between
       # QA scaffolding and the template's own configuration.
-      extra_env: |
-        SERVERLESS=true
-        # REPORT_ADDR is NOT product configuration, and it is the one variable this
-        # cell must not leave to the image. The worker POSTs its status to
-        # ${REPORT_ADDR}/worker_status/, and BOTH layers default that to the live
-        # autoscaler — start_server.sh `${REPORT_ADDR:-https://run.vast.ai}` and the
-        # SDK's backend.py `os.environ.get("REPORT_ADDR", "https://run.vast.ai")`. So
-        # omitting it does not send nothing; it sends to PRODUCTION. Until 2026-08-27
-        # this cell did exactly that on every run: a disposable QA instance announcing
-        # itself to the real autoscaler as a worker, with an unset MASTER_TOKEN and a
-        # real CONTAINER_ID. Nobody chose it and nobody would have gone looking.
-        #
-        # `.invalid` is reserved by RFC 2606 and can never resolve, so the POST fails
-        # in DNS and the run cannot touch any live endpoint. The cost is honest and
-        # bounded: metrics.py retries 3x/2s at DEBUG and carries on, so the worker
-        # still starts, serves and benchmarks — this cell never proved that status
-        # REACHES the autoscaler, and now it does not pretend to. Gated by L079.
-        REPORT_ADDR=https://qa-no-autoscaler.invalid
-        # UNSECURED skips the pubkey gate, and it undoes a QA-only side effect rather
-        # than weakening the test. REPORT_ADDR above is an unresolvable sentinel (L079),
-        # so `GET ${REPORT_ADDR}/pubkey/` CANNOT succeed — five attempts, then
-        # `backend_errored`, on every cell, always. The gate therefore proves nothing
-        # here: it is guaranteed to fail for a reason QA created, and skipping it masks
-        # nothing observable, because no configuration of ours could make it pass.
-        #
-        # What it costs without this: the worker benchmarks fine (`.has_benchmark` is
-        # written at backend.py:857, BEFORE the gate at :915 — which is why these cells
-        # were already green) and then dies at the last step, so every QA worker ends
-        # its life `errored` and each cell burns ~60s waiting for a key that cannot
-        # arrive. Measured on a live 2x5090 debug box: detection worked, sglang served,
-        # benchmark 995.55 written, then "Cannot mark model as loaded: pubkey fetch
-        # failed".
-        #
-        # SCOPE: QA scaffolding, and it must never reach a template — there it would
-        # disable request-signature verification on a live worker (__check_signature
-        # returns True immediately). It lives in extra_env precisely because a
-        # template.yml is what a production template gets copied from. Gated by L080.
-        UNSECURED=true
-        INSTANCE_TEST_REQUIRE_PASS=base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services sglang.d/10-sglang-serving sglang.d/12-sglang-contract sglang.d/20-serverless-pyworker
-      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services sglang.d/10-sglang-serving sglang.d/12-sglang-contract sglang.d/20-serverless-pyworker"
-      retries: 2
-    secrets:
-      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
-      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      # start_server.sh: `[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit`.
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
-  # Detection cell (ADR 0034). Identical to `qa-serverless` above in every respect but
-  # one: it supplies the AUTOSCALER'S OWN SIGNALS instead of SERVERLESS=true, so the
-  # image must INFER the mode rather than be told it. Both cells are kept, because they
-  # test different things and both are live: 9 of 10 published autoscaler templates
-  # still declare SERVERLESS=true, and the platform has not yet been changed to inject
-  # it — so the declared path is today's production path and the inferred path is the
-  # one being rolled out.
-  #
-  # Both sentinel values are self-evidently fake and safe in plaintext:
-  # 01-detect-serverless.sh tests PRESENCE only and never reads either value, and
-  # .invalid cannot resolve. MASTER_TOKEN here is not a credential and must never be
-  # replaced with one.
-  #
-  # SERVERLESS_DETECT_EXPECT=detected makes base/15-boot-markers assert the VERDICT the
-  # stage recorded, not merely that the instance came up. Every sglang.d test named below
-  # additionally opens with `is_serverless || test_skip`, and runner.sh turns a skipped
-  # REQUIRED test into REQUIRED-FAIL — so a broken inference is a red cell, never a
-  # quiet green.
-  #
-  # IT DOES NOT GATE YET, on the same ramp as qa-serverless: ORDERED ahead of the
-  # approval prompt via `needs`, absent from the `if`.
-  qa-serverless-detect:
-    needs: [preflight, build]
-    if: needs.preflight.outputs.should-run == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.preflight.outputs.merge-matrix) }}
-    uses: ./.github/workflows/qa-gate.yml
-    with:
-      repo: ${{ inputs.DOCKERHUB_REPO || 'sglang' }}
-      tag: ${{ inputs.CUSTOM_IMAGE_TAG || needs.preflight.outputs.sglang-version }}-cuda-${{ matrix.cuda }}-amd64
-      template_dir: external/sglang/templates/sglang-qa
-      label: base-image-qa-sglang-serverless-detect
-      log_paths: "/var/log/portal/sglang.log /var/log/portal/pyworker.log /workspace/pyworker.log /workspace/debug.log"
-      # THE ONLY PRODUCT DIFFERENCE FROM THE STANDARD CELL IS SERVERLESS=true. That is
-      # the whole claim of the serverless-enablement work — one template, one env var
-      # — so a gate that quietly needed three more variables would not be testing it.
+      # THE AUTOSCALER'S OWN SIGNALS, NOT SERVERLESS=true (ADR 0034). ONE serverless cell,
+      # exercising the INFERRED path, because that is the strictly harder one: it requires
+      # 01-detect-serverless.sh to run, decide and EXPORT SERVERLESS — and the export to
+      # reach the test runner, since `is_serverless` reads the variable, not the marker
+      # file. A declared SERVERLESS=true arrives via docker -e and is a SUBSET of that, so
+      # a cell passing here would pass there.
       #
-      # MODEL_NAME is GONE and its absence is now part of the test. pyworker's
-      # core.py resolves the benchmark model from MODEL_NAME, VLLM_MODEL,
-      # SGLANG_MODEL or LLAMA_MODEL, precisely so an on-demand template that sets only
-      # the engine var works unchanged in serverless. The template sets the engine var,
-      # so passing MODEL_NAME here would paper over that resolution instead of
-      # exercising it. If it fails, the benchmark raises and 20-serverless-pyworker
-      # reds on a missing score — loudly, which is what we want.
+      # It therefore doubles as the per-image canary for "did this image actually inherit
+      # the stage": a stale base pin yields an image with no 01-detect-serverless.sh,
+      # where a DECLARED cell still passes and this one cannot.
       #
-      # MODEL_LOG is GONE for the same reason: the worker's EngineDefaults already
-      # carry this engine's log path, and passing it tested our value rather than the
-      # image's.
+      # The declared branch keeps its coverage where it is cheap and exact —
+      # tools/imagegen/tests/test_detect_serverless_sh.py drives the real script through
+      # every branch, including an explicit true and an explicit false, with no GPU.
       #
-      # INSTANCE_TEST_REQUIRE_PASS stays, and is NOT a product difference. No customer
-      # template carries it — it is how the gate asserts, and the serverless cell has
-      # more tests that must have passed (base/85 and the pyworker score) because in
-      # this mode they are no longer inert. Keeping it here is the difference between
-      # QA scaffolding and the template's own configuration.
+      # Both sentinels are self-evidently fake and safe in plaintext: the stage tests
+      # PRESENCE only and never reads either value, and .invalid cannot resolve. The
+      # MASTER_TOKEN here is not a credential and must never be replaced with one.
+      #
+      # Every test named below opens with `is_serverless || test_skip`, and runner.sh turns
+      # a skipped REQUIRED test into REQUIRED-FAIL — a broken inference is a red cell.
       extra_env: |
         MASTER_TOKEN=qa-detection-sentinel-not-a-real-token
         REPORT_ADDR=https://qa-detection-sentinel.invalid
@@ -483,13 +400,12 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       # start_server.sh: `[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit`.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
   merge-manifests:
     # qa-serverless is in `needs` to ORDER it and absent from the `if` so it cannot
     # BLOCK. `!cancelled()` is what stops a failed serverless cell skipping this job,
     # and it also switches off the implicit "skip if any needed job failed" — so the
     # two results that MUST still block are named explicitly.
-    needs: [preflight, build, qa, qa-serverless, qa-serverless-detect]
+    needs: [preflight, build, qa, qa-serverless]
     if: >-
       !cancelled()
       && needs.preflight.outputs.should-run == 'true'

--- a/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/template.yml
+++ b/derivatives/pytorch/derivatives/comfyui/templates/comfyui-qa/template.yml
@@ -27,6 +27,16 @@ ports:
   - "8188:8188"                   # ComfyUI
   - "8288:8288"                   # API Wrapper
   - "8384:8384"                   # Syncthing
+  # The serverless worker's port, MANDATORY for the serverless cells rather than
+  # decorative. The platform injects VAST_TCP_PORT_<n> only for ports a template MAPS,
+  # and the pyworker SDK looks up exactly that with no guard —
+  #     worker_port = os.environ[f"VAST_TCP_PORT_{os.environ['WORKER_PORT']}"]
+  # (vastai/serverless/server/lib/metrics.py) — so an unmapped 3000 is a KeyError inside
+  # Metrics() during Backend construction, before the worker binds anything or runs a
+  # benchmark. Measured live on the first serverless cell ever run, on vLLM. Gated by
+  # L073. Harmless on the standard cell: nothing binds 3000 there, and base/28 scans
+  # LISTENERS rather than mappings, so an unused mapping is not an exposure.
+  - "3000:3000"                   # serverless worker (pyworker)
 env:
   COMFYUI_ARGS: "--disable-auto-launch --disable-xformers --port 18188 --enable-cors-header"
   # api-wrapper /health probes the backend's /system_stats + WebSocket; point it at

--- a/tools/template_manager/tests/test_promote_notification_truth.py
+++ b/tools/template_manager/tests/test_promote_notification_truth.py
@@ -688,3 +688,97 @@ def test_the_guard_runs_when_a_BUILD_workflow_changes():
                    for p in paths), (
             f"imagegen-tests.yml does not run on {event} to .github/workflows/**, so the "
             f"notification-truth guard cannot see a headline edit; paths={paths}")
+
+
+# ---- an ADVISORY cell must not block by omission (2026-08-27) ----------------
+#
+# The serverless cells sit on ADR 0006's advisory ramp: named in merge-manifests' `needs`
+# so they are ORDERED ahead of the production approval prompt, absent from its `if` so
+# they cannot BLOCK. Every workflow's comment says exactly that.
+#
+# It is not true by default. A job named in `needs` blocks unless you say otherwise:
+# GitHub implicitly skips a job when anything it needs fails, and only `!cancelled()`
+# (or `always()`) switches that off. build-comfyui.yml carried the ramp comment while its
+# `if` was a bare `needs.preflight.outputs.should-run == 'true'` — so adding the two cells
+# to `needs` silently made them GATING, and one config_error skipped merge-manifests on a
+# run whose four other cells were green. The documentation said advisory and the machinery
+# said blocking.
+
+
+def _serverless_cell_names(jobs: dict) -> set:
+    """Jobs that hand qa-gate.yml an extra_env which turns serverless on."""
+    out = set()
+    for jn, j in jobs.items():
+        if not isinstance(j, dict) or not str(j.get("uses", "")).endswith("qa-gate.yml"):
+            continue
+        env = str((j.get("with") or {}).get("extra_env", "") or "")
+        pairs = dict(ln.split("=", 1) for ln in env.splitlines()
+                     if "=" in ln and not ln.lstrip().startswith("#"))
+        declared = pairs.get("SERVERLESS", "").strip().lower() == "true"
+        inferred = bool(pairs.get("MASTER_TOKEN", "").strip() and pairs.get("REPORT_ADDR", "").strip())
+        if declared or inferred:
+            out.add(jn)
+    return out
+
+
+def test_an_advisory_serverless_cell_cannot_block_the_promotion_job():
+    """Wherever a serverless cell is wired for ORDERING, the promoting job must carry
+    `!cancelled()` — otherwise the cell gates, which is the opposite of the ramp."""
+    bad = []
+    for f in sorted(WF.glob("*.yml")):
+        try:
+            data = yaml.safe_load(f.read_text())
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        jobs = data.get("jobs") or {}
+        cells = _serverless_cell_names(jobs)
+        if not cells:
+            continue
+        for promoter in _PROMOTING_JOBS:
+            job = jobs.get(promoter)
+            if not isinstance(job, dict):
+                continue
+            needs = job.get("needs") or []
+            if isinstance(needs, str):
+                needs = [needs]
+            wired = cells & set(needs)
+            if not wired:
+                continue
+            cond = " ".join(str(job.get("if", "")).split())
+            if "!cancelled()" not in cond and "always()" not in cond:
+                bad.append(
+                    f"{f.name}:{promoter} needs {sorted(wired)} for ordering but its `if` "
+                    f"has no !cancelled(), so those cells BLOCK by GitHub's default")
+    assert not bad, "advisory cells that actually gate:\n  " + "\n  ".join(bad)
+
+
+def test_the_ramp_still_blocks_on_the_things_it_should():
+    """The other half: `!cancelled()` switches off the implicit skip for EVERYTHING, so
+    the results that must still block have to be named explicitly. Turning the ramp on
+    without naming them would let a red build or a red standard cell promote."""
+    bad = []
+    for f in sorted(WF.glob("*.yml")):
+        try:
+            data = yaml.safe_load(f.read_text())
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        jobs = data.get("jobs") or {}
+        if not _serverless_cell_names(jobs):
+            continue
+        for promoter in _PROMOTING_JOBS:
+            job = jobs.get(promoter)
+            if not isinstance(job, dict):
+                continue
+            cond = " ".join(str(job.get("if", "")).split())
+            if "!cancelled()" not in cond:
+                continue
+            needs = job.get("needs") or []
+            for must in ("build", "qa"):
+                if must in needs and f"needs.{must}.result == 'success'" not in cond:
+                    bad.append(f"{f.name}:{promoter} disables the implicit skip but never "
+                               f"requires `{must}` to succeed")
+    assert not bad, "\n  ".join(bad)


### PR DESCRIPTION
Three commits. Touches **all four** serverless-capable engines, not just ComfyUI — the branch name undersells it.

## 1. ComfyUI's serverless assertion had never executed

`comfyui.d/20-serverless-pyworker.sh` has been in the suite the whole time, dormant behind its `is_serverless` guard, and `build-comfyui.yml` had no cell that turns serverless on. The assertion had run **zero times, on any cell, anywhere**, while the image had baked `BACKEND=comfyui-json` and `EXPOSE 3000` for just as long. That's L067's shape: a test whose mode is never switched on is not coverage.

The QA template also gains `3000:3000`. It had never mapped it because it had never run a serverless cell — and L073 couldn't have caught that, being scoped to gates that *actually* enable serverless, of which ComfyUI had none.

Both gates were **proved to bite** rather than trusted to be quiet: unmapping 3000 fires L073 on the template, dropping `REPORT_ADDR` fires L079 on the job.

## 2. The advisory cells gated the promotion they were meant only to order

My own commit message claimed they were "absent from its `if` so they cannot block". False. **A job named in `needs` blocks by default** — GitHub implicitly skips a job when anything it needs fails, and only `!cancelled()` switches that off. ComfyUI's `merge-manifests` had a bare `needs.preflight.outputs.should-run == 'true'`, unlike the other three engines.

Measured: four of six cells green and `merge-manifests` **skipped**, because two cells hit a config error that never reached a GPU. An advisory cell took down a promotion.

Two guards, because the fix has two halves that break independently:
- an advisory serverless cell in a promoting job's `needs` requires that job's `if` to carry `!cancelled()`
- a job that *has* `!cancelled()` must then name `build` and `qa` explicitly — disabling the implicit skip disables it for everything, so fixing one hole carelessly opens the other

## 3. One serverless cell per image, and it tests the harder path

sglang, llama-cpp and comfyui each ran a **declared** cell and an **inferred** one; vLLM ran only inferred — so vLLM had no coverage of the path 9 of 10 published autoscaler templates actually use. Incoherent, and largely redundant besides.

The two diverge for about four lines. `01-detect-serverless.sh` either records `declared` and leaves an existing `SERVERLESS` alone, or records `detected` and exports it; after that line every consumer reads only `SERVERLESS` and cannot tell how it was set.

**Keeping the inferred one is the right way round**, because it is strictly harder: it needs the stage to run, decide *and* export, and the export to reach the test runner — `is_serverless()` reads the variable, not the marker file. A declared `SERVERLESS=true` arrives via `docker -e` and is a subset.

It also doubles as the per-image canary for *"did this image actually inherit the stage?"* — a stale base pin yields an image with no `01-detect-serverless.sh`, where a declared cell still passes and this one cannot. Exactly the failure #259 existed to prevent, and nothing else on an engine image catches it.

The declared branch keeps cheaper, exact coverage in `test_detect_serverless_sh.py`, which drives the real script through every branch with no GPU.

All four engines are now identical: one `qa-serverless`, inferred, requiring `base/15-boot-markers` so the verdict itself is asserted. ComfyUI keeps `PROVISIONING_COMFYUI_WORKFLOWS`, load-bearing there — comfyui-json benchmarks a real workflow rather than synthesising one from a model name.

## Evidence

Run `33087478119`, all **six** cells green — `qa`, `qa-serverless` (declared) and `qa-serverless-detect` (inferred) on both CUDA lines — with `merge-manifests` reaching its gate instead of skipping. So the redundant cell was removed while passing, not while hiding a red. Net saving: six live-GPU cells per full sweep.

`comfyui.d/20-serverless-pyworker` on its first ever execution: `port 3000 listening`, benchmark score **39.97** from the provisioned sd15 workflow, `7 required test(s) passed`. The ComfyUI provisioning machinery works in serverless.

`imagegen lint --all` → `baseline CLEAN ✓`; 340 tests green across the linter, notification-truth and qa-gate guards.
