### PR TITLE
fix(build-vllm): drop -arm64 tags from the variant matrix

### DIFF
--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -113,8 +113,10 @@ jobs:
           # that still ship both don't produce duplicate CUDA 13.0 builds.
           MATRIX=$(echo "$VARIANTS" | jq -c --arg version "$VERSION" '
             map(
-              # Skip arch-specific tags (we use multi-arch builds)
-              select(test("-(x86_64|aarch64)") | not)
+              # Skip arch-specific tags (we use multi-arch builds).
+              # Releases suffix -x86_64/-aarch64; per-model dev tags
+              # (e.g. glm53-flash-arm64-cu130) use -arm64 instead.
+              select(test("-(x86_64|aarch64|arm64)") | not)
               # Skip ubuntu2404 (and any other non-CUDA) variants
               | select(test("-ubuntu") | not)
             )


### PR DESCRIPTION
## Problem

The variant filter in `build-vllm.yml` skips arch-specific tags with `test("-(x86_64|aarch64)")`. That covers vLLM's **release** tags (`v0.28.0-aarch64`), but its **per-model dev** tags use `-arm64`, so they pass the filter and reach the build matrix.

Resolved against live Docker Hub tags today, `VLLM_VERSION=glm53-flash` gives:

| tag | mapped CUDA | problem |
|---|---|---|
| `glm53-flash-cu129` | 12.9 | fine — multi-arch |
| `glm53-flash-arm64-cu129` | 12.9 | arm64-only, and **collides** with the row above on the `-cuda-12.9` output tag |
| `glm53-flash-arm64-cu130` | 13.0 | arm64-only — the `ubuntu-latest` amd64 build job cannot pull it |

So the dispatch either fails pulling an arm64-only base on the amd64 runner, or the arm64 build wins and clobbers a good multi-arch image at the shared output tag.

`qwen38-flash-next` is worse — the surviving matrix is arm64-only, so there is nothing buildable at all. `hy4-preview` behaves like `glm53-flash`.

## Fix

Add `arm64` to the alternation so those tags are dropped the same way the release arch tags already are.

## Result

| `VLLM_VERSION` | before | after |
|---|---|---|
| `qwen38-flash-next` | `-arm64-cu130` → 13.0, `-arm64-cu129` → 12.9 | `qwen38-flash-next` → 13.0 |
| `glm53-flash` | `-cu129` → 12.9, `-arm64-cu130` → 13.0, `-arm64-cu129` → 12.9 | `glm53-flash` → 13.0, `-cu129` → 12.9 |
| `hy4-preview` | `-cu129` → 12.9, `-arm64-cu130` → 13.0, `-arm64-cu129` → 12.9 | `hy4-preview` → 13.0, `-cu129` → 12.9 |

## No effect on release builds

I ran the workflow's jq before and after against the live tag list for `v0.28.0`, `v0.27.1` and `v0.27.0`. The matrix is byte-identical in all three cases — the change only removes tags the release path never selected.

## One note

`build-vllm-omni.yml:115` carries the same filter. I deliberately left it alone: `vllm/vllm-omni`'s dev tags (e.g. `cosmos3-arm64`) have no `-cuNNN` suffix, so they already fall through to `empty` and the bug doesn't manifest there. Happy to fold it in as hardening if you'd rather have both consistent.
