### PR TITLE
chore(derivatives): move every pin to the base carrying the instance-test audit fixes

### DIFF
--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -220,7 +220,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-01
         # arm64 is intentionally absent: ACE-Step-1.5's pyproject.toml
         # declares `torchao ; platform_machine == 'aarch64'`, and torchao
         # ships no aarch64 wheels (manylinux_x86_64 only), so the upstream
@@ -239,7 +239,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-aio-studio-base.yml
+++ b/.github/workflows/build-aio-studio-base.yml
@@ -15,7 +15,7 @@ on:
       PYTORCH_BASE:
         description: "Multi-torch base image"
         required: true
-        default: "vastai/pytorch:multi-210-291-271-2026-08-26"
+        default: "vastai/pytorch:multi-210-291-271-2026-09-01"
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
         required: true

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -101,8 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-09-01
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -316,8 +316,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-08-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-linux-desktop.yml
+++ b/.github/workflows/build-linux-desktop.yml
@@ -94,9 +94,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-08-26
-          - vastai/base-image:cuda-12.9-mini-py312-2026-08-26
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-26
+          - vastai/base-image:cuda-13.2-mini-py312-2026-08-28
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-28
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-28
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -159,9 +159,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-08-26
-          - vastai/base-image:cuda-12.9-mini-py312-2026-08-26
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-26
+          - vastai/base-image:cuda-13.2-mini-py312-2026-08-28
+          - vastai/base-image:cuda-12.9-mini-py312-2026-08-28
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-28
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -159,14 +159,14 @@ jobs:
           [
             {
               "cuda": "12.9",
-              "base_tag": "cuda-12.9-mini-py312-2026-08-26",
+              "base_tag": "cuda-12.9-mini-py312-2026-08-28",
               "bundle": "cuda12-portable",
               "driver_floor": "12.9",
               "arches": ["amd64"]
             },
             {
               "cuda": "13.2",
-              "base_tag": "cuda-13.2-mini-py312-2026-08-26",
+              "base_tag": "cuda-13.2-mini-py312-2026-08-28",
               "bundle": "cuda13-portable",
               "driver_floor": "13.2",
               "arches": ["amd64", "arm64"]

--- a/.github/workflows/build-oobabooga.yml
+++ b/.github/workflows/build-oobabooga.yml
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
         # arm64 is intentionally absent: oobabooga's accelerator wheels
         # (exllamav3, flash_attn, xformers, llama_cpp_binaries) are x86_64-only.
         # Re-add the arm64 entry once those gain aarch64 CUDA wheels (and update
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
         # arm64 is intentionally absent: torchcodec is required at runtime
         # (transitive via torchaudio.load() in toolkit/dataloader_mixins.py)
         # but ships no aarch64 Linux wheels at any version. Re-add when
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   DEFAULT_DOCKERHUB_REPO: "sd-forge"
-  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-26"
+  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-09-01"
   # 7 days in seconds
   COMMIT_AGE_THRESHOLD: 604800
 

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
         # arm64 is intentionally absent: `torchao` (transitive via
         # unsloth-zoo>=2026.5.3 -> unsloth) only publishes amd64 manylinux
         # wheels as of v0.17.0+cu128. Re-add when upstream torchao ships
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-voicebox.yml
+++ b/.github/workflows/build-voicebox.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
         # arm64 is intentionally absent: Wan2GP requires onnxruntime-gpu
         # (pulled from the Azure ort-cuda-13-nightly index), which has no
         # aarch64 wheels — and PyPI's stable onnxruntime-gpu is also
@@ -236,7 +236,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-01
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-26
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-01
 
     steps:
       - name: Checkout

--- a/derivatives/llama-cpp/Dockerfile
+++ b/derivatives/llama-cpp/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-08-26
+ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-08-28
 
 FROM ${BASE_IMAGE}
 ARG BASE_IMAGE

--- a/derivatives/pytorch/derivatives/a1111/Dockerfile
+++ b/derivatives/pytorch/derivatives/a1111/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/comfyui/Dockerfile
+++ b/derivatives/pytorch/derivatives/comfyui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fluxgym/Dockerfile
+++ b/derivatives/pytorch/derivatives/fluxgym/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fooocus/Dockerfile
+++ b/derivatives/pytorch/derivatives/fooocus/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/invokeai/Dockerfile
+++ b/derivatives/pytorch/derivatives/invokeai/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
+++ b/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/Dockerfile
+++ b/derivatives/pytorch/derivatives/oobabooga/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/README.build.md
+++ b/derivatives/pytorch/derivatives/oobabooga/README.build.md
@@ -16,7 +16,7 @@ example below pins a tag for a reproducible local build; pass any commit/branch/
 ```bash
 docker buildx build \
     --platform linux/amd64 \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01 \
     --build-arg OOBABOOGA_REF=v4.9 \
     . -t repo/image:tag --push
 ```

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/sd-forge/Dockerfile
+++ b/derivatives/pytorch/derivatives/sd-forge/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/swarmui/Dockerfile
+++ b/derivatives/pytorch/derivatives/swarmui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
 FROM ${PYTORCH_BASE}
 
 LABEL org.opencontainers.image.source="https://github.com/vastai/"

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/wan2gp/Dockerfile
+++ b/derivatives/pytorch/derivatives/wan2gp/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/whisper/Dockerfile
+++ b/derivatives/pytorch/derivatives/whisper/Dockerfile
@@ -13,7 +13,7 @@
 # 2.8.0). The UPPER bound is real too — upstream master carries
 # "# 2.9 deprecates used functions" against it — so this is a fixed point, not a
 # floor to raise later: do not move it to 2.9.x without re-reading upstream.
-ARG PYTORCH_BASE=vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-08-26
+ARG PYTORCH_BASE=vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-01
 
 FROM ${PYTORCH_BASE}
 


### PR DESCRIPTION
50 references across 32 files. Pure date substitution — no other change.

## Why

Every derivative pins a **dated** base or pytorch tag, in its Dockerfile `ARG` and again in its build workflow. Those pins sat on `2026-08-26` — the base from *before* the instance-test audit (#263). A scheduled autobuild of any derivative would have rebuilt it against tests that could pass an image they never exercised.

## Two families, two dates

This is the part that matters, and conflating them would have pinned tags that do not exist:

| family | new date | source |
|---|---|---|
| `vastai/base-image:*` | **2026-08-28** | the base promote — 20/20 QA cells |
| `vastai/pytorch:*` | **2026-09-01** | pytorch's own promote date |

The pytorch images **are** built on base `2026-08-28` — that is what `BASE_DATE` did — but they carry their own date suffix. pytorch has `2026-08-26` and `2026-09-01` and **nothing between**, so a blanket substitution to `2026-08-28` would have named ten tags that were never published, failing at `docker build` per image, hours later. The substitution is anchored on the repository name to keep the two apart.

## Verification

All 13 distinct pins were checked against the registry **before** the edit and again after, paginating the tag list rather than reading the first page — the same check that mattered in #259, and the same pagination whose omission produced a false "missing" verdict there.

Two bare `base_tag` values in `build-llama-cpp.yml` carry no `vastai/base-image:` prefix, so the repo-anchored substitution could not see them; they are base tags and were bumped separately.

## Deliberately not touched

- **`vastai/aio-studio:base-2026-04-15`** in `build-aio-studio.yml` — a different family (aio-studio's own base). It can only move once `aio-studio-base` is rebuilt on the pytorch pin this PR bumps. Chained, not stale.
- **Dated examples in six derivative READMEs** and a comment in `Dockerfile.multi-torch`. Prose, not pins — one names a tag that no longer exists, which is why the verification above reports on active pins rather than on every string that looks like one.

## What this unblocks

This is what finally exercises the **corrected group-1 predicate** from the audit. Five derivative QA templates omit a Syncthing or Tensorboard portal entry, and those are precisely the cells that would have hard-failed under the first version of that fix. `base-qa` and `pytorch-qa` list every entry, so neither could ever have caught it — the derivative builds are the real test.

## Checks

`imagegen lint --all` → `baseline CLEAN ✓` across 27 images; 733 tests green.
