### PR TITLE
fix(vllm-omni): five published tags say cuda-12.9 and contain 13.0.2 (ADR 0035)

### DIFF
--- a/.github/workflows/build-vllm-omni.yml
+++ b/.github/workflows/build-vllm-omni.yml
@@ -91,6 +91,20 @@ jobs:
           trigger: ${{ github.event_name }}
           manual-version: ${{ inputs.VLLM_OMNI_VERSION }}
 
+      # The matrix step reads each upstream image's config to learn its real CUDA
+      # version. Authenticate first: anonymous manifest reads share a per-IP quota
+      # with every other job on the runner fleet, and a 429 here would look like
+      # "no CUDA_VERSION" and silently drop variants.
+      - name: Log in to Docker Hub
+        if: >-
+          inputs.VLLM_OMNI_VERSION != 'nightly'
+          && steps.release-check.outputs.new-release == 'true'
+          && steps.secrets.outputs.available == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build matrix from variant tags
         id: build-matrix
         if: inputs.VLLM_OMNI_VERSION != 'nightly' && steps.release-check.outputs.new-release == 'true'
@@ -107,25 +121,61 @@ jobs:
           VARIANTS=$(cat /tmp/variants.json)
           echo "Available variants: $VARIANTS"
 
-          # Convert variant tags to build matrix
-          # Base tag (v0.14.0) is CUDA 12.9, -cu130 is CUDA 13.0
-          MATRIX=$(echo "$VARIANTS" | jq -c --arg ver "$VERSION" '
-            map(
-              # Skip arch-specific tags (we use multi-arch builds)
-              select(test("-(x86_64|aarch64)") | not)
-            )
-            | map(
-              if . == $ver then
-                {tag: ., cuda: "12.9"}
-              elif endswith("-cu130") then
-                {tag: ., cuda: "13.0"}
-              elif endswith("-cu128") then
-                {tag: ., cuda: "12.8"}
-              else
-                empty
-              end
-            )
+          # Select only the tags this version owns: the bare tag and its
+          # explicit -cuNNN variants. Anchored on both ends, so neighbouring
+          # families (v0.28.0rc1, v0.26.0post1.*) and arch-specific tags
+          # (-x86_64/-aarch64/-arm64, and upstream's typo spellings) cannot
+          # leak in. Same shape as build-sglang.yml's selection.
+          CANDIDATES=$(echo "$VARIANTS" | jq -r --arg ver "$VERSION" '
+            .[] | select(test("^" + $ver + "(-cu[0-9]+)?$"))
           ')
+
+          # Read the CUDA version out of the ARTIFACT, never off the tag name.
+          # Upstream changed what the bare tag MEANS -- 12.9 before v0.20.0,
+          # 13.0 from v0.20.0 -- without changing how it is spelled, and it
+          # publishes no -cu130 here to disambiguate. A name-based rule was
+          # therefore wrong for one era or the other, and shipped five tags
+          # labelled cuda-12.9 that contain CUDA 13.0.2 (ADR 0035).
+          MATRIX="[]"
+          while IFS= read -r tag; do
+              [[ -n "$tag" ]] || continue
+              # `|| true` on both stages: an unreadable tag must reach the guard
+              # below, not abort the step. Without it this line is one `shell: bash`
+              # away from dying on pipefail instead of warning.
+              config=$(docker buildx imagetools inspect \
+                  --format '{{ json .Image }}' "vllm/vllm-omni:${tag}" 2>/dev/null || true)
+              # An index reports one config per platform. Take the distinct set: if
+              # the platforms disagree there is no single right answer, so fail
+              # rather than pick one.
+              mapfile -t cuda_seen < <(printf '%s' "$config" \
+                  | jq -r '[.. | objects | select(has("Env")) | .Env[]?
+                            | select(startswith("CUDA_VERSION="))] | unique | .[]' 2>/dev/null \
+                  | cut -d= -f2 || true)
+              if (( ${#cuda_seen[@]} > 1 )); then
+                  echo "::error::${tag}: platforms report different CUDA versions (${cuda_seen[*]}); refusing to label this image"
+                  exit 1
+              fi
+              cuda_full="${cuda_seen[0]:-}"
+              if [[ -z "$cuda_full" ]]; then
+                  echo "::warning::${tag}: image config reports no CUDA_VERSION; refusing to guess, skipping this variant"
+                  continue
+              fi
+              # 13.0.2 -> 13.0
+              cuda="${cuda_full%.*}"
+              echo "  ${tag} -> CUDA ${cuda} (image reports ${cuda_full})"
+              MATRIX=$(echo "$MATRIX" | jq -c --arg t "$tag" --arg c "$cuda" '. + [{tag: $t, cuda: $c}]')
+          done <<< "$CANDIDATES"
+
+          # Two variants resolving to the same CUDA version would publish to one
+          # output tag, and the loser would be silently overwritten.
+          COLLISIONS=$(echo "$MATRIX" | jq -r '
+            group_by(.cuda) | map(select(length > 1)) | .[]
+            | "CUDA " + .[0].cuda + ": " + (map(.tag) | join(", "))
+          ')
+          if [[ -n "$COLLISIONS" ]]; then
+              echo "::error::Variants collide on one output tag: ${COLLISIONS}"
+              exit 1
+          fi
 
           echo "Build matrix: $MATRIX"
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT

--- a/docs/adr/0035-cuda-label-comes-from-the-artifact.md
+++ b/docs/adr/0035-cuda-label-comes-from-the-artifact.md
@@ -1,0 +1,116 @@
+# ADR 0035 — A published image's CUDA label comes from the artifact, not the tag name
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Decision owner:** Rob Ballantyne
+
+## Context
+
+`build-vllm-omni.yml` derived the CUDA version of each build from the shape of the
+upstream tag: the bare tag was hardcoded to CUDA 12.9, `-cu130` to 13.0, `-cu128` to
+12.8. That was true when it was written. Upstream later changed what the bare tag
+*means* — 12.9 before `v0.20.0`, 13.0 from `v0.20.0` onward — without changing how it
+is spelled, and `vllm/vllm-omni` publishes no `-cu130` tag that would reveal the shift.
+
+The rule kept reporting 12.9. Five published tags carry a CUDA version they do not
+contain:
+
+| tag | label says | actually contains |
+|---|---|---|
+| `vastai/vllm-omni:v0.14.0-cuda-12.9` | 12.9 | 12.9.1 |
+| `vastai/vllm-omni:v0.16.0-cuda-12.9` | 12.9 | 12.9.1 |
+| `vastai/vllm-omni:v0.18.0-cuda-12.9` | 12.9 | 12.9.1 |
+| `vastai/vllm-omni:v0.20.0-cuda-12.9` | 12.9 | **13.0.2** |
+| `vastai/vllm-omni:v0.22.0-cuda-12.9` | 12.9 | **13.0.2** |
+| `vastai/vllm-omni:v0.24.0-cuda-12.9` | 12.9 | **13.0.2** |
+| `vastai/vllm-omni:v0.26.0-cuda-12.9` | 12.9 | **13.0.2** |
+| `vastai/vllm-omni:v0.28.0-cuda-12.9` | 12.9 | **13.0.2** |
+
+The CUDA minor is customer-facing: it is how a renter's host driver is matched to an
+image. A tag that understates its CUDA requirement can be scheduled onto a host whose
+driver cannot run it. Separately, the genuine CUDA 12.9 build (`minimax-h3-cu129`,
+12.9.1, a distinct upstream image) was never built at all, because the mapper had no
+`-cu129` branch.
+
+`build-vllm.yml` had already met the same upstream change and answered it with a
+heuristic: treat the bare tag as 13.0 *only when* no explicit `-cu130` variant exists
+(`build-vllm.yml:122-131`). That works for `vllm/vllm-openai`, which publishes
+`-cu130`. It cannot work for `vllm-omni`, which never has — applying it there labels
+the genuinely-12.9 `v0.14.0`-through-`v0.18.0` images as 13.0. Copying it would have
+swapped one mislabel for its mirror image.
+
+The root problem is not which suffix table is right. It is that the label was being
+inferred from a name whose meaning is controlled by someone else and is not stable
+over time.
+
+## Options considered
+
+**A. Port `build-vllm.yml`'s `$has_cu130` heuristic to omni.** The smallest diff, and
+it fixes every currently-shipping tag. Rejected: verified against live tags, it
+relabels `v0.14.0`/`v0.16.0`/`v0.18.0` — which really are 12.9.1 — as 13.0. It trades
+a wrong answer for the new era against a wrong answer for the old one, and it leaves
+the next silent upstream re-meaning to be discovered the same way this one was.
+
+**B. Pin a cutover version — bare means 13.0 at or above `v0.20.0`, 12.9 below.**
+Correct for every tag today. Rejected: it encodes a fact about upstream's history in
+our CI, where nothing will ever re-check it, and it needs a hand edit the next time
+upstream moves. It is the same class of defect as the rule it replaces, with a longer
+fuse.
+
+**C. Extend the suffix table (add `-cu129`, keep bare hardcoded).** Rejected: builds
+the missing genuine 12.9 image but leaves the bare tag — the one that is actually
+wrong on five published tags — untouched.
+
+**D. Read `CUDA_VERSION` from the upstream image config (chosen).** One
+`docker buildx imagetools inspect` per candidate tag in preflight. Costs a handful of
+authenticated registry reads and makes preflight depend on the registry being
+reachable. It has no vocabulary to maintain and cannot drift, because it observes the
+artifact instead of predicting it.
+
+## Decision
+
+Take D. The CUDA version of a build is read from the upstream image's own
+`CUDA_VERSION` environment variable and truncated to `major.minor`. If a candidate
+image reports no `CUDA_VERSION`, the variant is skipped with a warning — the build
+never guesses a label it cannot substantiate.
+
+Variant *selection* is separately anchored to `^<version>(-cu[0-9]+)?$`, matching
+`build-sglang.yml:118`. This is what makes reading the artifact safe: without it,
+`startswith` admits neighbouring families (`v0.28.0rc1`, `v0.26.0post1.*`) whose configs
+would resolve to a real CUDA version and enter the matrix as duplicates.
+
+Two variants resolving to the same CUDA version now fail the build rather than
+publishing to one output tag and silently overwriting each other.
+
+This ADR states the general invariant, not the omni-specific fix: **a published
+image's CUDA label is derived from the artifact it was built from, never inferred
+from an upstream tag's spelling.** `build-vllm.yml` still infers, and is a known
+exception pending the same treatment.
+
+## Binding conditions
+
+- Preflight authenticates to Docker Hub before inspecting. Anonymous manifest reads
+  share a per-IP quota across the runner fleet, and a rate-limit response is
+  indistinguishable from "no `CUDA_VERSION`" — it would silently drop variants rather
+  than fail.
+- A variant whose CUDA cannot be read is skipped, never defaulted. If that empties the
+  matrix, the existing hard error stands.
+
+## Consequences
+
+- The five mislabelled tags above are corrected on the next build of each version.
+  Already-published tags are not rewritten by this change; relabelling or withdrawing
+  them is a separate decision.
+- `minimax-h3` now yields two images — `-cu129` at 12.9 and the bare tag at 13.0 —
+  where it previously yielded one, mislabelled.
+- Preflight gains a registry dependency. A registry outage now fails preflight rather
+  than producing a wrong matrix, which is the intended direction.
+- Arch-specific tags stop being excluded by a denylist of suffixes and are excluded by
+  the anchor instead, so upstream's typo spellings (`-x86-64`, `-aarc64`, `-aarch`,
+  observed live) can no longer leak in.
+
+## What would reverse this
+
+Upstream ceasing to set `CUDA_VERSION` in the image config, which would make the
+artifact no longer self-describing and force a different observation point (for
+example, the CUDA runtime package version in the image's package database).

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -941,6 +941,39 @@ QA cell has ever proved that worker status REACHES the autoscaler, and none can 
 require POSTing fabricated status to production with a fake token. The cells now decline to
 imply otherwise rather than quietly doing the real thing.
 
+### A CUDA label is read off the ARTIFACT, never inferred from the tag name — ADR 0035
+
+An upstream tag's spelling is not a stable statement about its contents, because we do
+not control the vocabulary and upstream can re-point a name without renaming it.
+
+`vllm/vllm-omni` did exactly that: the bare tag meant CUDA 12.9 up to `v0.18.0` and
+CUDA 13.0 from `v0.20.0`, with no `-cu130` variant published to signal the change.
+`build-vllm-omni.yml` hardcoded bare -> 12.9, so five published tags
+(`v0.20.0` through `v0.28.0`, `-cuda-12.9`) contain CUDA **13.0.2**. The CUDA minor
+drives host driver matching, so an understated label can place an image on a host whose
+driver cannot run it. The genuine 12.9 image (`minimax-h3-cu129`) was never built,
+because the mapper had no `-cu129` branch.
+
+The trap worth recording: `build-vllm.yml` had already met this change and answered it
+with `$has_cu130` — treat the bare tag as 13.0 only when no explicit `-cu130` exists.
+Copying that to omni looks like the obvious fix and is wrong, because omni has never
+published `-cu130`; verified against live tags, it relabels the genuinely-12.9
+`v0.14.0`/`v0.16.0`/`v0.18.0` images as 13.0. **A heuristic that is correct for one
+upstream is not correct for another that spells things differently.**
+
+So: read `CUDA_VERSION` from the upstream image config, truncate to `major.minor`, and
+skip any variant whose CUDA cannot be read rather than defaulting it. Selection is
+anchored to `^<version>(-cu[0-9]+)?$` (as `build-sglang.yml:118` already does), which is
+what makes reading the artifact safe — `startswith` alone admits `v0.28.0rc1` and
+`v0.26.0post1.*`, whose configs resolve to a real CUDA and would enter the matrix as
+duplicates.
+
+**Not yet gated, and deliberately so.** The natural rule — no workflow assigns a literal
+CUDA version to an upstream bare tag — would fire on `build-vllm.yml:131`, which still
+uses the `$has_cu130` heuristic. That is a known exception, not an oversight: it is
+correct for `vllm/vllm-openai` today. Gating this means converting that workflow too, and
+per the Bug -> Invariant protocol the baseline must be clean before the rule lands.
+
 ### A Slack headline may claim a promotion only where the promotion SUCCEEDED — **GATED (test_promote_notification_truth.py)**
 
 The rule is one sentence: **enumerate the way it goes RIGHT, never the ways it goes wrong.**


### PR DESCRIPTION
## The defect

`build-vllm-omni.yml` inferred each build's CUDA version from the shape of the upstream tag — bare tag hardcoded to 12.9, `-cu130` to 13.0, `-cu128` to 12.8. That was true when it was written. Upstream then changed what the bare tag *means* — 12.9 up to `v0.18.0`, 13.0 from `v0.20.0` — without changing how it is spelled, and `vllm/vllm-omni` publishes no `-cu130` that would have revealed the shift.

Five published tags carry a CUDA version they do not contain:

| tag | label says | actually contains |
|---|---|---|
| `vastai/vllm-omni:v0.14.0-cuda-12.9` | 12.9 | 12.9.1 |
| `vastai/vllm-omni:v0.16.0-cuda-12.9` | 12.9 | 12.9.1 |
| `vastai/vllm-omni:v0.18.0-cuda-12.9` | 12.9 | 12.9.1 |
| `vastai/vllm-omni:v0.20.0-cuda-12.9` | 12.9 | **13.0.2** |
| `vastai/vllm-omni:v0.22.0-cuda-12.9` | 12.9 | **13.0.2** |
| `vastai/vllm-omni:v0.24.0-cuda-12.9` | 12.9 | **13.0.2** |
| `vastai/vllm-omni:v0.26.0-cuda-12.9` | 12.9 | **13.0.2** |
| `vastai/vllm-omni:v0.28.0-cuda-12.9` | 12.9 | **13.0.2** |

The CUDA minor drives host driver matching, so an understated label can place an image on a host whose driver cannot run it. Separately, the genuine CUDA 12.9 build (`minimax-h3-cu129`, 12.9.1, a distinct upstream image) was never built at all — the mapper had no `-cu129` branch.

## Why not just copy `build-vllm.yml`

`build-vllm.yml` already met this same upstream change and answered it with a heuristic: treat the bare tag as 13.0 *only when* no explicit `-cu130` variant exists (`build-vllm.yml:122-131`). Copying that here looks like the obvious one-line fix and is wrong — omni has never published `-cu130`, so verified against live tags the heuristic relabels the genuinely-12.9 `v0.14.0`/`v0.16.0`/`v0.18.0` images as 13.0. It swaps one mislabel for its mirror image.

The root problem is not which suffix table is right. It is that the label was inferred from a name whose meaning is controlled by someone else and is not stable over time.

## The fix

Read `CUDA_VERSION` out of the upstream image config and truncate to `major.minor`. Nothing to maintain and nothing to drift, because it observes the artifact rather than predicting it. A variant whose CUDA cannot be read is skipped with a warning, never defaulted.

Selection is separately anchored to `^<version>(-cu[0-9]+)?$`, matching `build-sglang.yml:118`. That is what makes reading the artifact safe: `startswith` alone admits `v0.28.0rc1` and `v0.26.0post1.*`, whose configs resolve to a real CUDA version and would enter the matrix as duplicates. It also retires the arch denylist, which could not have been completed anyway — upstream has shipped `-x86-64`, `-aarc64` and `-aarch` alongside the spellings the denylist knew about.

Two variants resolving to the same CUDA version now fail the build rather than publishing to one output tag and silently overwriting each other.

Preflight authenticates to Docker Hub first. Anonymous manifest reads share a per-IP quota across the runner fleet, and a rate-limit response is indistinguishable from "no `CUDA_VERSION`" — it would silently drop variants rather than fail.

## Evidence

Ran the step's shell, extracted from the YAML itself, against live tags under `-e -o pipefail`:

```
v0.28.0     -> CUDA 13.0 (image reports 13.0.2)     was mislabelled 12.9
v0.18.0     -> CUDA 12.9 (image reports 12.9.1)     the $has_cu130 port would have broken this
minimax-h3  -> minimax-h3-cu129 CUDA 12.9 (12.9.1)  never built before
               minimax-h3      CUDA 13.0 (13.0.2)
cosmos3     -> CUDA 13.0 (image reports 13.0.2)     was mislabelled 12.9
```

Both failure paths exercised: an unreadable tag warns and then hard-errors on the empty matrix; a forced duplicate CUDA trips the collision guard with exit 1.

`imagegen lint --all` baseline CLEAN (27 images, 0 errors). Full suite 1041 passed, 9 skipped.

## Scope

Already-published tags are **not** rewritten by this change — they are corrected on the next build of each version. Relabelling or withdrawing the five bad tags is a separate decision.

Recorded as ADR 0035, with the invariant in `docs/invariants.md`. Not gated by a linter rule: the natural rule (no workflow assigns a literal CUDA version to an upstream bare tag) would fire on `build-vllm.yml:131`, which still uses the `$has_cu130` heuristic and is correct for `vllm/vllm-openai` today. Gating means converting that workflow too, and the baseline must be clean before the rule lands.

Found while reviewing #264.
