### PR TITLE
docs(tests): name the clock that makes the supervisor timeout test flake

### DIFF
--- a/tools/imagegen/tests/test_instance_test_lib_sh.py
+++ b/tools/imagegen/tests/test_instance_test_lib_sh.py
@@ -77,6 +77,33 @@ def test_a_socket_that_arrives_late_is_waited_for(tmp_path):
 
 
 def test_a_socket_that_never_arrives_times_out_and_reports_failure(tmp_path):
+    """IF THIS FAILS IN CI WITH `took ~2.0s`, IT IS THE RUNNER'S CLOCK, NOT A REGRESSION.
+
+    `wait_for_supervisor` budgets with bash's SECONDS (lib.sh:131,139), which is
+    derived from CLOCK_REALTIME. This test measures with time.monotonic(). An NTP
+    step forward mid-wait moves the first and not the second, so the budget is
+    spent in less wall-clock time than it declares and `elapsed` lands under the
+    lower bound. Reproduced deterministically (12/12 at exactly 2.0s) with an
+    LD_PRELOAD shim applying a 1s forward step to time()/gettimeofday()/
+    clock_gettime(CLOCK_REALTIME); unstepped it is 3.02s every run, and load can
+    only make it longer, never shorter.
+
+    Deliberately NOT fixed, 2026-09-01. The fix is a monotonic source
+    (/proc/uptime, CLOCK_BOOTTIME, unsteppable) and it works — but it would touch
+    23 SECONDS-based budgets across lib.sh, 25-caddy-proxy, 67-service-functionality
+    and 13-provisioner-selftest, which is high-consequence readiness code gating
+    every image. Production exposure does not justify it: instance tests run in
+    containers, which inherit the host clock and cannot step it without
+    CAP_SYS_TIME, and a synced host slews rather than steps. The exposure is CI,
+    where runners are fresh VMs.
+
+    So: re-run it. If it starts costing more than a re-run, the contained fix is a
+    _mono helper used by wait_for_supervisor and wait_for_port only.
+
+    Do not "fix" this by relaxing the lower bound — it is what proves the budget is
+    wall-clock rather than a count of sleeps, which is the defect this file exists
+    to catch (see test_the_budget_is_WALL_CLOCK_not_a_count_of_sleeps).
+    """
     p, elapsed, _ = _run(tmp_path, ["4"], 'wait_for_supervisor 3 || echo GAVEUP')
     assert "GAVEUP" in p.stdout
     assert 3 <= elapsed < 12, f"budget is wall-clock seconds, took {elapsed:.1f}s"


### PR DESCRIPTION
## Why

`test_a_socket_that_never_arrives_times_out_and_reports_failure` failed CI on #267 (an unrelated vllm-omni workflow change) with:

```
AssertionError: budget is wall-clock seconds, took 2.0s
```

Every obvious reading is wrong. It is not load — load lengthens sleeps, and unstepped the run is 3.02s every single time. It is not the change under test — #267 touched a workflow and two docs. And it is not simply "flaky": it passed 12/12 in isolation locally and only that one CI run went red.

## Cause

`wait_for_supervisor` budgets with bash's `SECONDS` (`lib.sh:131,139`), which is derived from **CLOCK_REALTIME**. The test measures with `time.monotonic()`. An NTP step forward mid-wait moves the first and not the second, so the budget is spent in less wall-clock time than it declares.

Reproduced deterministically with an `LD_PRELOAD` shim applying a one-off 1s forward step to `time()`/`gettimeofday()`/`clock_gettime(CLOCK_REALTIME)` and leaving CLOCK_MONOTONIC alone (no system clock touched):

```
original + step        {2.0: 12}   under-budget: 12/12
monotonic + step       {3.0: 12}   under-budget:  0/12
monotonic, no step     {3.0: 12}   under-budget:  0/12
```

12/12 land on CI's exact 2.0s.

## Why this is a note and not a fix

The fix works — `/proc/uptime` is CLOCK_BOOTTIME and cannot be stepped — but applying it means touching **23** `SECONDS`-based budgets across `lib.sh`, `25-caddy-proxy.sh`, `67-service-functionality.sh` and `13-provisioner-selftest.sh`: high-consequence readiness code gating every image.

Production does not justify that. Instance tests run in containers, which inherit the host clock namespace and cannot step it without `CAP_SYS_TIME`, and a synced host slews rather than steps. The real exposure is CI, where runners are fresh VMs — a re-run's worth of cost.

If it starts costing more than a re-run, the contained fix is a `_mono` helper used by `wait_for_supervisor` and `wait_for_port` only — one file, two call sites.

## What the note protects against

The tempting wrong fix is relaxing the lower bound. That bound is what proves the budget is wall-clock rather than a count of sleeps — the exact defect this file exists to catch (`test_the_budget_is_WALL_CLOCK_not_a_count_of_sleeps`). The docstring says so explicitly.

Comment only, no behaviour change. 27 passed locally.