### PR TITLE
fix(sglang): every published nightly said cuda-12.9 and carried CUDA 13

### DIFF
--- a/.github/workflows/build-sglang.yml
+++ b/.github/workflows/build-sglang.yml
@@ -65,14 +65,51 @@ jobs:
             echo "::notice::Skipping - missing secrets: ${missing[*]}"
           fi
 
+      # The nightly step reads the upstream image's config to learn its real CUDA
+      # version. Authenticate first: anonymous manifest reads share a per-IP quota
+      # with every other job on the runner fleet, and a 429 here is indistinguishable
+      # from "no CUDA_VERSION".
+      - name: Log in to Docker Hub
+        if: inputs.SGLANG_VERSION == 'nightly' && steps.secrets.outputs.available == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Handle nightly build
         id: nightly-check
         if: inputs.SGLANG_VERSION == 'nightly'
         run: |
+          set -uo pipefail
           echo "is-nightly=true" >> $GITHUB_OUTPUT
           echo "version=nightly-$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          echo 'matrix=[{"tag":"dev","cuda":"12.9"}]' >> $GITHUB_OUTPUT
-          echo "Nightly build requested - using upstream 'dev' tag"
+
+          # Read the CUDA version off the ARTIFACT, never off the tag name (ADR 0035).
+          # This was hardcoded to 12.9. Upstream moved `dev` to CUDA 13 without
+          # renaming it -- on 2026-09-01 lmsysorg/sglang:dev reported 13.0.3 -- so
+          # every nightly we published as -cuda-12.9 carried CUDA 13. The genuine
+          # 12.9 line moved to the `dev-cu12` tag, which this path does not build.
+          config=$(docker buildx imagetools inspect \
+              --format '{{ json .Image }}' lmsysorg/sglang:dev 2>/dev/null || true)
+          # An index reports one config per platform; if they disagree there is no
+          # single right answer, so fail rather than pick one.
+          mapfile -t cuda_seen < <(printf '%s' "$config" \
+              | jq -r '[.. | objects | select(has("Env")) | .Env[]?
+                        | select(startswith("CUDA_VERSION="))] | unique | .[]' 2>/dev/null \
+              | cut -d= -f2 || true)
+          if (( ${#cuda_seen[@]} > 1 )); then
+              echo "::error::lmsysorg/sglang:dev reports different CUDA versions per platform (${cuda_seen[*]}); refusing to label it"
+              exit 1
+          fi
+          cuda_full="${cuda_seen[0]:-}"
+          if [[ -z "$cuda_full" ]]; then
+              echo "::error::could not read CUDA_VERSION from lmsysorg/sglang:dev; refusing to guess a label"
+              exit 1
+          fi
+          # 13.0.3 -> 13.0
+          CUDA="${cuda_full%.*}"
+          echo "matrix=[{\"tag\":\"dev\",\"cuda\":\"${CUDA}\"}]" >> $GITHUB_OUTPUT
+          echo "Nightly build requested - upstream 'dev' reports CUDA ${cuda_full}, labelling ${CUDA}"
 
       - name: Check release and resolve version
         id: release-check


### PR DESCRIPTION
## The defect

`build-sglang.yml`'s nightly path hardcoded its CUDA label:

```
matrix=[{"tag":"dev","cuda":"12.9"}]
```

Upstream moved `dev` to CUDA 13 without renaming it:

```
lmsysorg/sglang:dev        CUDA 13.0.3     <- what we build, labelled 12.9
lmsysorg/sglang:dev-cu12   CUDA 12.9.2     <- the genuine 12.9, never built
lmsysorg/sglang:dev-cu13   CUDA 13.0.3
```

So every nightly published as `vastai/sglang:nightly-<date>-cuda-12.9` contains CUDA 13. The most recent is `nightly-2026-04-20-cuda-12.9`; how far back the mislabel goes depends on when upstream flipped, which I have not dated.

The CUDA minor drives host driver matching, so an understated label can place an image on a host whose driver cannot run it.

## Same class as ADR 0035

This is the third instance today of one defect: a CUDA label asserted from a tag name we do not control. ADR 0035 recorded it for `build-vllm-omni.yml` (five tags saying `cuda-12.9`, containing 13.0.2); this is the same fix applied to the second place it bites, so it is an application of that decision rather than a new one.

Read `CUDA_VERSION` off the artifact and truncate to `major.minor`. A variant whose CUDA cannot be read is now an **error**, not a default — confidently labelling something it had not checked was the original problem. Platforms disagreeing is also an error rather than an arbitrary pick.

Preflight authenticates to Docker Hub first: anonymous manifest reads share a per-IP quota across the runner fleet, and a 429 is indistinguishable from "no `CUDA_VERSION`".

## Evidence

Ran the step's own shell, extracted from the YAML rather than retyped:

```
Nightly build requested - upstream 'dev' reports CUDA 13.0.3, labelling 13.0
matrix=[{"tag":"dev","cuda":"13.0"}]        valid JSON, exit 0
```

Failure path, against an unreadable image:

```
::error::could not read CUDA_VERSION from lmsysorg/sglang:...; refusing to guess a label
exit=1, no matrix line emitted
```

`imagegen lint --all` baseline CLEAN (27 images, 0 errors); 125 workflow/notification tests pass.

## Scope

Already-published nightly tags are not rewritten — they correct on the next nightly build.

**Not fixed here.** The release path's bare-tag rule (`$tag == $ver and ($has_cu130 | not)` → 13.0) is the same shape of inference. It is correct today only because sglang releases publish explicit `-cuNNN` variants — which is precisely the condition that did not hold for omni. Worth converting, but it is a different code path and deserves its own change.

Found while pre-checking a routine nightly dispatch.