### PR TITLE
fix(build-vllm): let a dispatch raise the QA selection floors

### DIFF
--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -31,6 +31,12 @@ on:
       CUSTOM_IMAGE_TAG:
         description: "Custom tag (Auto default)"
         required: false
+      QA_SET_FILTERS:
+        description: "Raise QA selection floors, space-separated KEY.OP=VALUE (e.g. 'compute_cap.gte=1000' for a Blackwell-only model)"
+        required: false
+      QA_MAX_PRICE:
+        description: "QA offer price ceiling in $/hr (default 2.00) - raise when the floors above only match expensive cards"
+        required: false
 
 env:
   DEFAULT_DOCKERHUB_REPO: "vllm"
@@ -289,6 +295,25 @@ jobs:
       # A real defect still blocks — it fails every draw — and each failed attempt
       # records its machine and excludes it from the next.
       retries: 2
+      # Per-model selection floors. The template's compute_cap floor is the generic
+      # vLLM one (sm_80 — external/vllm/templates/vllm-qa/template.yml), which is
+      # right for most models and wrong for a Blackwell-only build: offers are
+      # searched cheapest-first, so the gate draws an Ampere card and the engine dies
+      # with "no kernel image is available for execution on the device". It then
+      # redraws onto another cheap card and fails identically, which reads as a
+      # reproducible image defect and is not one — the image was never run on a GPU
+      # it has kernels for. Observed on hy4-preview: three draws, A10 / RTX 3080 /
+      # RTX 4000 Ada (cc 860, 860, 890), same error each time.
+      #
+      # RAISE-ONLY: create.py rejects an override that would widen selection, so this
+      # cannot loosen the linted floors, and an empty value (every scheduled run, and
+      # every dispatch that does not set it) leaves them exactly as they are.
+      set_filters: ${{ inputs.QA_SET_FILTERS }}
+      # Companion to the above rather than an independent knob. Raising compute_cap
+      # without raising the ceiling can empty the offer pool, and the gate's response
+      # to an empty pool is to wait and redraw — so the run burns its retries on
+      # "no offers matched the floors" instead of reporting a verdict.
+      max_price: ${{ inputs.QA_MAX_PRICE || '2.00' }}
     secrets:
       VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
       DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
@@ -410,6 +435,12 @@ jobs:
         INSTANCE_TEST_REQUIRE_PASS=base/15-boot-markers base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services vllm.d/10-vllm-serving vllm.d/12-vllm-contract vllm.d/20-serverless-pyworker
       require_tests: "base/15-boot-markers base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries base/85-serverless-services vllm.d/10-vllm-serving vllm.d/12-vllm-contract vllm.d/20-serverless-pyworker"
       retries: 2
+      # Same floors as the standard cell, for the same reason — see the note there.
+      # These must not fork: a Blackwell-only image that the standard cell refuses to
+      # draw an Ampere card for would still draw one here, and the run would carry one
+      # red cell that means nothing about the image.
+      set_filters: ${{ inputs.QA_SET_FILTERS }}
+      max_price: ${{ inputs.QA_MAX_PRICE || '2.00' }}
     secrets:
       VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
       DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}


### PR DESCRIPTION
## Problem

`external/vllm/templates/vllm-qa/template.yml` declares the generic vLLM selection floor:

```yaml
extra_filters:
  compute_cap:
    gte: 800        # sm_80 — matches the production vLLM floor (vLLM kernels)
```

That is correct for almost every vLLM build. It is wrong for one whose kernels are compiled for a newer architecture, because offers are searched cheapest-first: the gate rents an Ampere card, and the engine dies before serving.

```
torch.AcceleratorError: CUDA error: no kernel image is available for execution on the device
RuntimeError: Engine core initialization failed.
```

The redraw then makes it worse rather than better. It excludes the failed machine and draws again from the same pool, so it lands on another card the image has no kernels for and fails identically. Per ADR 0029 the discriminator between an image defect and a bad host is reproducibility — "an image defect fails every draw" — and this failure is reproducible for a reason that has nothing to do with the image. The gate reports the build broken without ever having run it on hardware it supports.

### Measured

`hy4-preview`, run [33509520098](https://github.com/vast-ai/base-image/actions/runs/33509520098) — a Blackwell-targeted model:

| Draw | Offer | GPU | Compute cap | Price |
|------|-------|-----|-------------|-------|
| 1 | 47574078 | A10 | 860 | $0.243/hr |
| 2 | 49411012 | RTX 3080 | 860 | $0.123/hr |
| 3 | 31921484 | RTX 4000 Ada | 890 | $0.164/hr |

Same error on every draw, on both CUDA variants. The rest of the suite was green — `24 passed, 2 failed, 3 skipped`, and the only failures were `vllm.d/10-vllm-serving` and `vllm.d/12-vllm-contract`. `base/60-gpu-cuda`, `base/61-cuda-compute` and `base/62-gpu-libraries` all passed, because the driver and CUDA userland were fine; it was only ever the kernels.

## Change

`qa-gate.yml` already has the input for this — `set_filters`, raise-only, rejected by `create.py` if an override would widen selection. `promote-base-image.yml`, `promote-pytorch.yml` and `build-llama-cpp.yml` all use it for their per-config driver floors. It was just never plumbed through `build-vllm.yml`, so a vLLM dispatch had no way to say "this build needs Blackwell".

Two new `workflow_dispatch` inputs, passed to **both** QA cells:

```yaml
QA_SET_FILTERS:   # e.g. compute_cap.gte=1000
QA_MAX_PRICE:     # e.g. 12.00
```

**Both cells, not one.** A floor the standard cell honours and the serverless cell ignores would leave every run of such an image carrying one red cell that says nothing about the image — the same misreading this PR exists to remove, just narrower.

**`max_price` is not an independent knob.** Raising `compute_cap` can empty the offer pool, and the gate's response to an empty pool is to wait and redraw. Without a matching ceiling the override trades a wrong-GPU red for a run that spends its retries on `no offers matched the floors` and reports no verdict at all.

## Blast radius

None by default. Scheduled runs, and dispatches that set neither input, pass an empty `set_filters` and the same `2.00` ceiling `qa-gate.yml` already defaulted to. `set_filters` is raise-only, so a dispatch cannot loosen the linted floors even deliberately.

`imagegen lint --all`: `27 images | 0 errors`, baseline clean.

## Using it

```
build-vllm.yml
  VLLM_VERSION=nightly
  CUSTOM_IMAGE_TAG=hy4-preview
  QA_SET_FILTERS=compute_cap.gte=1000
  QA_MAX_PRICE=<ceiling that reaches a Blackwell card>
```

Two things this PR deliberately does not decide:

- **The right floor for hy4.** `1000` is sm_100; if its kernels are sm_120-only then an RTX 5090 is required and `1200` is the floor. Worth confirming against the upstream build before the re-run.
- **The right ceiling.** A 5090 fits comfortably under $2/hr; a B200 does not. If hy4 turns out to need sm_100 specifically, the ceiling has to clear datacentre Blackwell pricing or the pool is empty.

Neither is knowable from the failed run, since it never reached a card in that class.

## Not addressed here

`vastai/vllm:hy4-preview-cuda-13.0` and `-cuda-12.9` are published and currently unverified — the manifests merged from a run whose QA never tested them meaningfully. They are not known-bad; they are untested. Re-running the gate with a real floor is what settles that, and that is a dispatch rather than a code change.
