### PR TITLE
fix(sglang): the release matrix silently dropped a genuine CUDA 12.9 image

### DIFF
--- a/.github/workflows/build-sglang.yml
+++ b/.github/workflows/build-sglang.yml
@@ -65,12 +65,13 @@ jobs:
             echo "::notice::Skipping - missing secrets: ${missing[*]}"
           fi
 
-      # The nightly step reads the upstream image's config to learn its real CUDA
-      # version. Authenticate first: anonymous manifest reads share a per-IP quota
-      # with every other job on the runner fleet, and a 429 here is indistinguishable
-      # from "no CUDA_VERSION".
+      # BOTH matrix steps -- nightly and release -- read each upstream image's
+      # config to learn its real CUDA version, so authenticate before either runs.
+      # Anonymous manifest reads share a per-IP quota with every other job on the
+      # runner fleet, and a 429 is indistinguishable from "no CUDA_VERSION": it
+      # would drop variants silently instead of failing.
       - name: Log in to Docker Hub
-        if: inputs.SGLANG_VERSION == 'nightly' && steps.secrets.outputs.available == 'true'
+        if: steps.secrets.outputs.available == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -140,37 +141,78 @@ jobs:
           VARIANTS=$(cat /tmp/variants.json)
           echo "Available variants: $VARIANTS"
 
-          # Convert variant tags to build matrix.
-          # Upstream tag scheme (v0.5.11+): multi-arch manifests, no -amd64 suffix.
-          # SGLang flipped the default CUDA from 12.9 to 13.0 in v0.5.11, so
-          # the bare <ver> tag now IS the CUDA 13.0 image (and is published
-          # alongside an explicit -cu130 alias). Prefer explicit -cuNNN
-          # suffixes; treat the bare $VERSION tag as CUDA 13.0 only when no
-          # -cu130 variant exists, so releases that ship both don't produce
-          # a duplicate CUDA 13.0 build (and the bare doesn't get mistagged
-          # as 12.9, clobbering the real -cu129 image at push time).
-          # Exclude rocm/xeon/cann/runtime variants by exact-matching
-          # ^<VERSION>(-cu[0-9]+)?$.
-          MATRIX=$(echo "$VARIANTS" | jq -c --arg ver "$VERSION" '
-            map(select(test("^" + $ver + "(-cu[0-9]+)?$")))
-            | . as $variants
-            | ($variants | any(endswith("-cu130"))) as $has_cu130
-            | $variants
-            | map(
-                . as $tag
-                | if $tag | endswith("-cu130") then
-                    {tag: $tag, cuda: "13.0"}
-                  elif $tag | endswith("-cu129") then
-                    {tag: $tag, cuda: "12.9"}
-                  elif $tag | endswith("-cu128") then
-                    {tag: $tag, cuda: "12.8"}
-                  elif $tag == $ver and ($has_cu130 | not) then
-                    {tag: $tag, cuda: "13.0"}
-                  else
-                    empty
-                  end
-              )
+          # Select only the tags this version owns: the bare tag and its explicit
+          # -cuNNN variants. Anchored on BOTH ends, so rocm/xeon/cann/runtime and
+          # neighbouring families cannot leak in.
+          #
+          # ORDER MATTERS: explicit -cuNNN first. Upstream publishes the same image
+          # under two names (v0.5.18 and v0.5.18-cu130 are one digest), and the
+          # dedup below keeps whichever it meets first -- the descriptive one.
+          CANDIDATES=$(echo "$VARIANTS" | jq -r --arg ver "$VERSION" '
+            [ .[] | select(test("^" + $ver + "(-cu[0-9]+)?$")) ]
+            | sort_by(test("-cu[0-9]+$") | not)
+            | .[]
           ')
+
+          # Read the CUDA version out of the ARTIFACT, never off the tag name
+          # (ADR 0035). The rule this replaces inferred it from the suffix and
+          # treated a bare tag as 13.0 whenever no -cu130 existed. That encoded one
+          # era of upstream's tagging: before v0.5.11 the bare tag WAS the 12.9
+          # image (lmsysorg/sglang:v0.5.8 reports CUDA 12.9.1 today), published
+          # alongside -cu130 and no -cu129 -- a shape under which the old rule
+          # silently DROPPED the genuine 12.9 image rather than mislabelling it.
+          # Reading the artifact is correct in both eras without having to know
+          # which one it is looking at.
+          MATRIX="[]"
+          seen_digests=""
+          while IFS= read -r tag; do
+              [[ -n "$tag" ]] || continue
+              ref="lmsysorg/sglang:${tag}"
+              # `|| true` on each: an unreadable tag must reach the guards below
+              # rather than abort the step under pipefail.
+              digest=$(docker buildx imagetools inspect \
+                  --format '{{ json .Manifest }}' "$ref" 2>/dev/null \
+                  | jq -r '.digest // empty' 2>/dev/null || true)
+              config=$(docker buildx imagetools inspect \
+                  --format '{{ json .Image }}' "$ref" 2>/dev/null || true)
+              # An index reports one config per platform. Take the distinct set: if
+              # the platforms disagree there is no single right answer.
+              mapfile -t cuda_seen < <(printf '%s' "$config" \
+                  | jq -r '[.. | objects | select(has("Env")) | .Env[]?
+                            | select(startswith("CUDA_VERSION="))] | unique | .[]' 2>/dev/null \
+                  | cut -d= -f2 || true)
+              if (( ${#cuda_seen[@]} > 1 )); then
+                  echo "::error::${tag}: platforms report different CUDA versions (${cuda_seen[*]}); refusing to label this image"
+                  exit 1
+              fi
+              cuda_full="${cuda_seen[0]:-}"
+              if [[ -z "$cuda_full" ]]; then
+                  echo "::warning::${tag}: image config reports no CUDA_VERSION; refusing to guess, skipping this variant"
+                  continue
+              fi
+              # Upstream aliases the bare tag onto an explicit one. Same digest is
+              # the same image, so build it once, under the explicit name.
+              if [[ -n "$digest" && " $seen_digests " == *" $digest "* ]]; then
+                  echo "  ${tag}: same image as an already-selected tag (${digest:0:19}); skipping the alias"
+                  continue
+              fi
+              seen_digests="$seen_digests $digest"
+              # 13.0.3 -> 13.0
+              cuda="${cuda_full%.*}"
+              echo "  ${tag} -> CUDA ${cuda} (image reports ${cuda_full})"
+              MATRIX=$(echo "$MATRIX" | jq -c --arg t "$tag" --arg c "$cuda" '. + [{tag: $t, cuda: $c}]')
+          done <<< "$CANDIDATES"
+
+          # Two DIFFERENT images resolving to one CUDA version would publish to a
+          # single output tag, and the loser would be silently overwritten.
+          COLLISIONS=$(echo "$MATRIX" | jq -r '
+            group_by(.cuda) | map(select(length > 1)) | .[]
+            | "CUDA " + .[0].cuda + ": " + (map(.tag) | join(", "))
+          ')
+          if [[ -n "$COLLISIONS" ]]; then
+              echo "::error::Variants collide on one output tag: ${COLLISIONS}"
+              exit 1
+          fi
 
           echo "Build matrix: $MATRIX"
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -968,11 +968,30 @@ what makes reading the artifact safe — `startswith` alone admits `v0.28.0rc1` 
 `v0.26.0post1.*`, whose configs resolve to a real CUDA and would enter the matrix as
 duplicates.
 
+**A second failure mode, found converting `build-sglang.yml`'s release path
+(2026-09-02).** The same inference can DROP an image rather than mislabel one, which is
+quieter still. That rule read "treat the bare tag as 13.0 only when no `-cu130` exists",
+so for the pre-v0.5.11 shape — bare plus `-cu130`, no `-cu129` — the bare tag matched no
+branch and fell through to `empty`. `lmsysorg/sglang:v0.5.8` reports CUDA 12.9.1 today,
+so rebuilding it would have silently produced ONE image instead of two, losing the 12.9
+build with no error anywhere. Reading the artifact is correct in both eras without
+knowing which one it is looking at.
+
+That conversion also has to keep an alias from becoming a duplicate: upstream publishes
+the bare tag and `-cuNNN` as the SAME digest (`v0.5.18` and `v0.5.18-cu130` are one
+image). Dedupe on **digest**, preferring the explicit name, and reserve the hard error
+for two DIFFERENT digests landing on one CUDA label. A blanket collision error — correct
+for `vllm-omni`, which has no aliases — would fail every sglang release build.
+
 **Not yet gated, and deliberately so.** The natural rule — no workflow assigns a literal
-CUDA version to an upstream bare tag — would fire on `build-vllm.yml:131`, which still
-uses the `$has_cu130` heuristic. That is a known exception, not an oversight: it is
-correct for `vllm/vllm-openai` today. Gating this means converting that workflow too, and
-per the Bug -> Invariant protocol the baseline must be clean before the rule lands.
+CUDA version to an upstream bare tag — would fire on `build-vllm.yml:128-134`, which still
+uses the `$has_cu130` heuristic, and on `build-vllm-omni.yml:80`, whose NIGHTLY path
+hardcodes 12.9 while `vllm/vllm-omni:nightly` reports 13.0.2 (missed when that file's
+release path was converted). Those are the two known holdouts. Gating means converting
+both, and per the Bug -> Invariant protocol the baseline must be clean before the rule
+lands. Note the rule must not fire on `build-comfyui.yml`'s `{cuda: "12.9", py: "py312"}`
+matrix: that selects OUR pytorch base and is a build input we control, not a claim about
+someone else's artifact.
 
 ### A Slack headline may claim a promotion only where the promotion SUCCEEDED — **GATED (test_promote_notification_truth.py)**
 


### PR DESCRIPTION
## The defect

The release path inferred each build's CUDA version from the shape of the upstream tag — `-cu130` → 13.0, `-cu129` → 12.9, `-cu128` → 12.8, and the bare `<version>` tag → 13.0 **but only when no `-cu130` variant existed**.

That last clause encoded one era of upstream's tagging. Before v0.5.11 the bare tag *was* the 12.9 image, published alongside `-cu130` and no `-cu129` at all. Under that shape the bare tag matches no branch and falls through to `empty` — so the 12.9 image is not mislabelled, it is **dropped**, with no error anywhere.

Verified against live upstream images:

```
lmsysorg/sglang:v0.5.8          CUDA 12.9.1   distinct digest
lmsysorg/sglang:v0.5.8-cu130    CUDA 13.0.1   distinct digest
```

Rebuilding `v0.5.8` today yields one image where it should yield two. We published both historically (`v0.5.8-cuda-12.9` and `-cuda-13.0`, both verified correct), so this is a regression under upstream's later tag changes rather than a longstanding gap.

This path runs on **schedule daily**, so it is live code.

## The fix

Read `CUDA_VERSION` off the artifact (ADR 0035, third site). Correct in both eras without having to know which one it is looking at, and no suffix vocabulary to keep current.

**One thing differs from the vllm-omni conversion and is load-bearing.** Upstream publishes the bare tag and an explicit one as the *same digest* — `v0.5.18` and `v0.5.18-cu130` are one image. Omni has no aliases, so a blanket "two variants on one CUDA label is an error" was right there; here it would fail **every** release build. So this dedupes on **digest**, preferring the explicit name, and reserves the hard error for two *different* digests landing on one label — the case that would actually overwrite an image at push time.

## Evidence

Ran the step's own shell, extracted from the YAML rather than retyped, against the live registry under `-e -o pipefail`:

| input | result |
|---|---|
| v0.5.11 / v0.5.12 / v0.5.17 / v0.5.18 | **byte-identical** to the old rule (`-cu129`→12.9, `-cu130`→13.0, bare skipped as alias) |
| v0.5.8 / v0.5.10.post1 | both images recovered, correctly labelled 12.9 and 13.0 |
| full `v0.5.18*` family (13 tags) | rocm/xeon/cann/runtime still excluded |
| empty candidate set | exit 1, unchanged |
| unreadable tag | warns and skips, never guesses |
| forced duplicate CUDA | collision guard fires, exit 1 |

`imagegen lint --all` baseline CLEAN (27 images, 0 errors). Full suite 1041 passed, 9 skipped.

## Also here

The Docker Hub login added for the nightly path now covers both matrix steps, since both read upstream image configs. Anonymous manifest reads share a per-IP quota across the runner fleet, and a 429 is indistinguishable from "no `CUDA_VERSION`" — it would drop variants silently instead of failing.

## Not fixed here

Two holdouts remain in this defect class, both worth a follow-up:

- **`build-vllm-omni.yml:80`** hardcodes its **nightly** matrix to `12.9` while `vllm/vllm-omni:nightly` reports **13.0.2**. Missed when that file's release path was converted in #267 — a live mislabel waiting on the next omni nightly dispatch.
- **`build-vllm.yml:128-134`** still uses the `$has_cu130` heuristic.

The linter rule the invariant wants cannot land until both are converted and the baseline is clean. Note the rule must not fire on `build-comfyui.yml`'s `{cuda: "12.9", py: "py312"}` matrix — that selects our own pytorch base and is a build input we control, not a claim about someone else's artifact.

Already-published tags are unaffected; 28 of 29 were already correct.