### PR TITLE
feat(ci): the serverless QA cell now BLOCKS a promote, on all four engines

### DIFF
--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -293,7 +293,7 @@ jobs:
       # start_server.sh: `[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit`.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
   merge-manifests:
-    # qa-serverless and qa-serverless-detect are in `needs` to ORDER them ahead of the
+    # qa-serverless is in `needs` to ORDER it ahead of the
     # production approval prompt, and absent from the `if` so they cannot BLOCK — the
     # advisory ramp every other engine's serverless cell uses.
     #
@@ -310,6 +310,22 @@ jobs:
       && needs.preflight.outputs.should-run == 'true'
       && needs.build.result == 'success'
       && needs.qa.result == 'success'
+      # GATING as of 2026-09-02, completing ADR 0006 condition 2's ramp. It was
+      # advisory — ordered ahead of the approval prompt so a human never approved
+      # before its evidence existed, but unable to block. The ramp's bar was two
+      # consecutive green runs; every engine cleared it, and the greens were checked
+      # for VACUITY rather than taken at face value: in each cell
+      # `base/85-serverless-services` and the engine's own `20-serverless-pyworker`
+      # both PASSED, and the caddy tests correctly SKIPPED, which only happens when
+      # `is_serverless` is true. A cell that had silently skipped its way to green
+      # would have been the wrong thing to start gating on.
+      # Evidence: comfyui 2026-09-02 (4/4 cells).
+      #
+      # Flipped on all four engines together, not one at a time. Forking a gate rule
+      # per image is the shape ADR 0029 condition 5 was written against — a cell that
+      # blocks on one image and not another means the same defect promotes or does
+      # not depending on which workflow found it.
+      && needs.qa-serverless.result == 'success'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     strategy:
@@ -397,7 +413,12 @@ jobs:
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
   notify:
-    needs: [preflight, build, qa, merge-manifests, collect-tags]
+    # qa-serverless is in `needs` so the headline below can READ its result. A
+    # `needs.<job>` reference that is not in this list evaluates to empty, so the
+    # serverless arm would silently never fire — the failure looks like a headline
+    # that simply never mentions serverless, which is indistinguishable from one
+    # that had nothing to report.
+    needs: [preflight, build, qa, qa-serverless, merge-manifests, collect-tags]
     if: always() && needs.preflight.outputs.should-run == 'true'
     uses: ./.github/workflows/notify-slack.yml
     with:
@@ -414,7 +435,7 @@ jobs:
       # promotion that did not happen. Measured 2026-08-27: three branch dispatches
       # cancelled at the production approval gate, every QA cell green, Slack saying
       # "ComfyUI promoted — live-GPU QA passed" beside a red run card.
-      headline: ${{ (needs.build.result != 'success' && 'ComfyUI build failed') || (needs.qa.result == 'failure' && 'ComfyUI QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'ComfyUI promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'ComfyUI NOT promoted — promotion did not run') || (needs.qa.outputs.gated == 'true' && 'ComfyUI promoted — live-GPU QA passed') || '' }}
+      headline: ${{ (needs.build.result != 'success' && 'ComfyUI build failed') || (needs.qa.result == 'failure' && 'ComfyUI QA FAILED on real GPU — not promoted') || (needs.qa-serverless.result == 'failure' && 'ComfyUI SERVERLESS QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'ComfyUI promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'ComfyUI NOT promoted — promotion did not run') || (needs.qa.outputs.gated == 'true' && 'ComfyUI promoted — live-GPU QA passed') || '' }}
       image-name: "ComfyUI"
       image-ref: ${{ needs.preflight.outputs.comfyui-ref }}
       image-tags: ${{ needs.collect-tags.outputs.all-tags }}

--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -474,6 +474,22 @@ jobs:
       && needs.preflight.outputs.should-run == 'true'
       && needs.build.result == 'success'
       && needs.qa.result == 'success'
+      # GATING as of 2026-09-02, completing ADR 0006 condition 2's ramp. It was
+      # advisory — ordered ahead of the approval prompt so a human never approved
+      # before its evidence existed, but unable to block. The ramp's bar was two
+      # consecutive green runs; every engine cleared it, and the greens were checked
+      # for VACUITY rather than taken at face value: in each cell
+      # `base/85-serverless-services` and the engine's own `20-serverless-pyworker`
+      # both PASSED, and the caddy tests correctly SKIPPED, which only happens when
+      # `is_serverless` is true. A cell that had silently skipped its way to green
+      # would have been the wrong thing to start gating on.
+      # Evidence: llama-cpp 2026-08-31.
+      #
+      # Flipped on all four engines together, not one at a time. Forking a gate rule
+      # per image is the shape ADR 0029 condition 5 was written against — a cell that
+      # blocks on one image and not another means the same defect promotes or does
+      # not depending on which workflow found it.
+      && needs.qa-serverless.result == 'success'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     strategy:
@@ -582,7 +598,7 @@ jobs:
       # and does not reach the build-* callers, so the same defect still sits in
       # build-vllm.yml, build-sglang.yml and build-comfyui.yml, which share this
       # expression verbatim. Fixed here; the shared guard is the real fix.
-      headline: ${{ (needs.build.result != 'success' && 'llama.cpp build failed') || (needs.qa.result == 'failure' && 'llama.cpp QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'llama.cpp promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'llama.cpp NOT promoted — promotion did not run') || (needs.qa-serverless.result == 'failure' && 'llama.cpp promoted — but the ADVISORY serverless cell FAILED (not gating yet)') || (needs.qa.outputs.gated == 'true' && 'llama.cpp promoted — live-GPU QA passed') || '' }}
+      headline: ${{ (needs.build.result != 'success' && 'llama.cpp build failed') || (needs.qa.result == 'failure' && 'llama.cpp QA FAILED on real GPU — not promoted') || (needs.qa-serverless.result == 'failure' && 'llama.cpp SERVERLESS QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'llama.cpp promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'llama.cpp NOT promoted — promotion did not run') || (needs.qa.outputs.gated == 'true' && 'llama.cpp promoted — live-GPU QA passed') || '' }}
       image-name: "Llama.cpp"
       image-ref: ${{ needs.preflight.outputs.llama-cpp-version }}
       image-tags: ${{ needs.collect-tags.outputs.all-tags }}

--- a/.github/workflows/build-sglang.yml
+++ b/.github/workflows/build-sglang.yml
@@ -490,6 +490,22 @@ jobs:
       && needs.preflight.outputs.should-run == 'true'
       && needs.build.result == 'success'
       && needs.qa.result == 'success'
+      # GATING as of 2026-09-02, completing ADR 0006 condition 2's ramp. It was
+      # advisory — ordered ahead of the approval prompt so a human never approved
+      # before its evidence existed, but unable to block. The ramp's bar was two
+      # consecutive green runs; every engine cleared it, and the greens were checked
+      # for VACUITY rather than taken at face value: in each cell
+      # `base/85-serverless-services` and the engine's own `20-serverless-pyworker`
+      # both PASSED, and the caddy tests correctly SKIPPED, which only happens when
+      # `is_serverless` is true. A cell that had silently skipped its way to green
+      # would have been the wrong thing to start gating on.
+      # Evidence: sglang 2026-09-01.
+      #
+      # Flipped on all four engines together, not one at a time. Forking a gate rule
+      # per image is the shape ADR 0029 condition 5 was written against — a cell that
+      # blocks on one image and not another means the same defect promotes or does
+      # not depending on which workflow found it.
+      && needs.qa-serverless.result == 'success'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     strategy:
@@ -590,7 +606,7 @@ jobs:
       # promotion that did not happen. Measured 2026-08-27: three branch dispatches
       # cancelled at the production approval gate, every QA cell green, Slack saying
       # "SGLang promoted — live-GPU QA passed" beside a red run card.
-      headline: ${{ (needs.build.result != 'success' && 'SGLang build failed') || (needs.qa.result == 'failure' && 'SGLang QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'SGLang promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'SGLang NOT promoted — promotion did not run') || (needs.qa-serverless.result == 'failure' && 'SGLang promoted — but the ADVISORY serverless cell FAILED (not gating yet)') || (needs.qa.outputs.gated == 'true' && 'SGLang promoted — live-GPU QA passed') || '' }}
+      headline: ${{ (needs.build.result != 'success' && 'SGLang build failed') || (needs.qa.result == 'failure' && 'SGLang QA FAILED on real GPU — not promoted') || (needs.qa-serverless.result == 'failure' && 'SGLang SERVERLESS QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'SGLang promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'SGLang NOT promoted — promotion did not run') || (needs.qa.outputs.gated == 'true' && 'SGLang promoted — live-GPU QA passed') || '' }}
       image-name: "SGLang"
       image-ref: ${{ needs.preflight.outputs.sglang-version }}
       image-tags: ${{ needs.collect-tags.outputs.all-tags }}

--- a/.github/workflows/build-vllm.yml
+++ b/.github/workflows/build-vllm.yml
@@ -525,6 +525,22 @@ jobs:
       && needs.preflight.outputs.should-run == 'true'
       && needs.build.result == 'success'
       && needs.qa.result == 'success'
+      # GATING as of 2026-09-02, completing ADR 0006 condition 2's ramp. It was
+      # advisory — ordered ahead of the approval prompt so a human never approved
+      # before its evidence existed, but unable to block. The ramp's bar was two
+      # consecutive green runs; every engine cleared it, and the greens were checked
+      # for VACUITY rather than taken at face value: in each cell
+      # `base/85-serverless-services` and the engine's own `20-serverless-pyworker`
+      # both PASSED, and the caddy tests correctly SKIPPED, which only happens when
+      # `is_serverless` is true. A cell that had silently skipped its way to green
+      # would have been the wrong thing to start gating on.
+      # Evidence: vllm 2026-09-01.
+      #
+      # Flipped on all four engines together, not one at a time. Forking a gate rule
+      # per image is the shape ADR 0029 condition 5 was written against — a cell that
+      # blocks on one image and not another means the same defect promotes or does
+      # not depending on which workflow found it.
+      && needs.qa-serverless.result == 'success'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     strategy:
@@ -628,7 +644,7 @@ jobs:
       # promotion that did not happen. Measured 2026-08-27: three branch dispatches
       # cancelled at the production approval gate, every QA cell green, Slack saying
       # "vLLM promoted — live-GPU QA passed" beside a red run card.
-      headline: ${{ (needs.build.result != 'success' && 'vLLM build failed') || (needs.qa.result == 'failure' && 'vLLM QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'vLLM promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'vLLM NOT promoted — promotion did not run') || (needs.qa-serverless.result == 'failure' && 'vLLM promoted — but the ADVISORY serverless cell FAILED (not gating yet)') || (needs.qa.outputs.gated == 'true' && 'vLLM promoted — live-GPU QA passed') || '' }}
+      headline: ${{ (needs.build.result != 'success' && 'vLLM build failed') || (needs.qa.result == 'failure' && 'vLLM QA FAILED on real GPU — not promoted') || (needs.qa-serverless.result == 'failure' && 'vLLM SERVERLESS QA FAILED on real GPU — not promoted') || (needs.merge-manifests.result == 'failure' && 'vLLM promotion (manifest merge) failed') || (needs.merge-manifests.result != 'success' && 'vLLM NOT promoted — promotion did not run') || (needs.qa.outputs.gated == 'true' && 'vLLM promoted — live-GPU QA passed') || '' }}
       image-name: "vLLM"
       image-ref: ${{ needs.preflight.outputs.vllm-version }}
       image-tags: ${{ needs.collect-tags.outputs.all-tags }}


### PR DESCRIPTION
Completes ADR 0006 condition 2's ramp for `comfyui`, `vllm`, `sglang` and `llama-cpp`.

The cell was **advisory**: named in `needs` so it was ordered ahead of the production approval prompt — a human never approved before its evidence existed — but absent from the `if`, so a red cell alerted without blocking.

## The evidence, checked for vacuity

The ramp's bar was two consecutive green runs. Every engine clears it:

| engine | last green | |
|---|---|---|
| comfyui | 2026-09-02 | 4/4 cells |
| vllm | 2026-09-01 | |
| sglang | 2026-09-01 | |
| llama-cpp | 2026-08-31 | |

Those greens were **not taken at face value**. In each cell, `base/85-serverless-services` and the engine's own `20-serverless-pyworker` both **passed**, and the Caddy tests correctly **skipped** — which only happens when `is_serverless` is true, so detection ran and exported. Gating on a cell that had skipped its way to green would have been worse than leaving it advisory, and skip-as-pass is a hole this repo has been bitten by before.

## Flipped on all four together

Forking a gate rule per image is the shape ADR 0029 condition 5 was written against: a cell that blocks on one image and not another means the same defect promotes or doesn't depending on which workflow found it.

## Two things the one-line change would have left broken

**Three headlines were about to lie.** vllm, sglang and llama-cpp each carried:

```
'<engine> promoted — but the ADVISORY serverless cell FAILED (not gating yet)'
```

Once the cell gates, a failed cell blocks the promote — so that text can never be true. It also sat *after* the generic `merge-manifests.result != 'success'` arm, so it could never have fired even before this change: dead code carrying a false claim. Replaced with a blocking arm placed **before** the generic one, so a red cell says which cell:

```
'<engine> SERVERLESS QA FAILED on real GPU — not promoted'
```

**ComfyUI's notify job couldn't read the result.** Its `needs` omitted `qa-serverless`. A `needs.<job>` reference to a job not in that list evaluates to empty, so the arm added here would have **silently never fired** — presenting as a headline that simply never mentions serverless, indistinguishable from one with nothing to report. Fixed, with the reason recorded inline.

## Deadlock check

`qa-serverless` and `merge-manifests` share the same `should-run` condition, so whenever the promote is eligible the cell has run. `!cancelled()` is present in all four, which is precisely why naming the result explicitly is the mechanism rather than relying on the implicit skip-if-a-need-failed.

## Also

Clears a stale comment in `build-comfyui.yml` still referring to a `qa-serverless-detect` job that was consolidated away.

`imagegen lint --all` baseline CLEAN (27 images). Full suite 1049 passed, 9 skipped; the 125 workflow/notification tests — including `test_promote_notification_truth.py`, which walks every `notify-slack.yml` caller — pass.