### PR TITLE
Fix two checks that fail healthy Qwen3.8-Flash-Next instances

### DIFF
--- a/external/sglang/ROOT/opt/supervisor-scripts/sglang.sh
+++ b/external/sglang/ROOT/opt/supervisor-scripts/sglang.sh
@@ -28,9 +28,24 @@ cd ${WORKSPACE}
 AUTO_PARALLEL_ARGS=""
 # Rewrite var name
 AUTO_PARALLEL="${AUTO_PARALLEL:-true}"
+
+# Expert parallelism is spelled --ep-size N here; --enable-expert-parallel is
+# vLLM's spelling and does nothing on this server. Because N must equal the
+# instance GPU count it cannot be written into a static template arg string, so
+# translate the portable flag into the sized one and drop the original.
+# Without it Qwen3.8-Flash-Next-FP8 will not load: sglang reports
+#   (moe_intermediate_size=640 / moe_tp_size=4) % weight_block_size_n=128 != 0
+# because moe_tp_size is tp_size/ep_size and ep_size defaulted to 1.
+EP_ARGS=""
+if [[ $SGLANG_ARGS =~ --enable-expert-parallel ]]; then
+    SGLANG_ARGS="${SGLANG_ARGS//--enable-expert-parallel/}"
+    [[ $SGLANG_ARGS =~ --ep-size ]] || EP_ARGS="--ep-size $GPU_COUNT"
+fi
+
 if [[ "${AUTO_PARALLEL,,}" = "true" ]] && ! [[ $SGLANG_ARGS =~ parallel-size ]]; then
     AUTO_PARALLEL_ARGS="--tensor-parallel-size $GPU_COUNT"
 fi
+AUTO_PARALLEL_ARGS="${AUTO_PARALLEL_ARGS} ${EP_ARGS}"
 
 # Force Caches to be written in workspace (vols)
 export HOME=${WORKSPACE}

--- a/external/vllm/ROOT/opt/instance-tools/tests/vllm.d/10-vllm-serving.sh
+++ b/external/vllm/ROOT/opt/instance-tools/tests/vllm.d/10-vllm-serving.sh
@@ -234,7 +234,7 @@ if [[ -f "$VLLM_LOG" ]]; then
     echo "  vllm log: ${log_size}B"
 fi
 
-check_log_errors "vllm" "$VLLM_LOG" "torch\.distributed|CUDAGraph|deprecat"
+check_log_errors "vllm" "$VLLM_LOG" "torch\.distributed|CUDAGraph|deprecat|is part of .* but not documented|__vast_contract_no_such_model__"
 check_log_errors "ray" "$RAY_LOG"
 
 # ── Port exposure check ─────────────────────────────────────────────


### PR DESCRIPTION
Two fixes for the Qwen3.8-Flash-Next model-library templates. Both are load-bearing: without them, three of the nine templates cannot pass a deploy test.

## 1. sglang.sh — translate `--enable-expert-parallel` into `--ep-size $GPU_COUNT`

`--enable-expert-parallel` is vLLM's spelling. sglang wants `--ep-size N`, and N must equal the instance GPU count, so it cannot be written into a static template arg string.

Without expert parallelism the FP8 checkpoint does not load. sglang reports `(moe_intermediate_size=640 / moe_tp_size=4) % weight_block_size_n=128 != 0`, because `moe_tp_size` is `tp_size / ep_size` and `ep_size` defaults to 1.

The supervisor script now strips the portable flag and adds the sized one. A user-supplied `--ep-size` is left alone. The existing TP guard (`$SGLANG_ARGS =~ parallel-size`) is unaffected — `--ep-size` does not match it.

Blocks: Qwen3.8-Flash-Next-FP8 on sglang.

## 2. 10-vllm-serving.sh — exclude two benign lines from the error grep

Two things land in the vLLM log at ERROR level on a healthy instance:

- Qwen3-VL processors emit `<kwarg> is part of Qwen3VLVideoProcessorInitKwargs, but not documented` on every start.
- `contract_check.py`'s own NO_SUCH_MODEL probe writes the `__vast_contract_no_such_model__` sentinel by design.

Both fail the check on an instance that is serving correctly. Added to the existing exclusion list next to `torch.distributed`, `CUDAGraph` and `deprecat`.

Blocks: Qwen3.8-Flash-Next on vLLM, both BF16 and FP8.

## What I need

An image build carrying this patch so I can deploy-test it — a throwaway tag is fine. The templates run `vastai/sglang:qwen38flashnext-cuda-13.0` and `vastai/vllm:qwen38-flash-next-cuda-13.0`.

Once those exist I'll run deploy tests on Qwen FP8 sglang, Qwen BF16 sglang, Qwen BF16 vLLM and Qwen FP8 vLLM, and report back here.
