### PR TITLE
pytorch: add torch 2.14.0 — 3 configs, 3 minis, no multi

### DIFF
--- a/.github/workflows/build-a1111.yml
+++ b/.github/workflows/build-a1111.yml
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-08
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -220,7 +220,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ace-step.yml
+++ b/.github/workflows/build-ace-step.yml
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-01
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-08
         # arm64 is intentionally absent: ACE-Step-1.5's pyproject.toml
         # declares `torchao ; platform_machine == 'aarch64'`, and torchao
         # ships no aarch64 wheels (manylinux_x86_64 only), so the upstream
@@ -239,7 +239,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-01
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-aio-studio-base.yml
+++ b/.github/workflows/build-aio-studio-base.yml
@@ -15,7 +15,7 @@ on:
       PYTORCH_BASE:
         description: "Multi-torch base image"
         required: true
-        default: "vastai/pytorch:multi-210-291-271-2026-09-01"
+        default: "vastai/pytorch:multi-210-291-271-2026-09-08"
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
         required: true

--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -101,8 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-09-01
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-09-08
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -336,8 +336,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
-          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-09-01
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+          - vastai/pytorch:2.10.0-cu130-cuda-13.2-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-fluxgym.yml
+++ b/.github/workflows/build-fluxgym.yml
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-08
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-invokeai.yml
+++ b/.github/workflows/build-invokeai.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-linux-desktop.yml
+++ b/.github/workflows/build-linux-desktop.yml
@@ -94,9 +94,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-08-28
-          - vastai/base-image:cuda-12.9-mini-py312-2026-08-28
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-28
+          - vastai/base-image:cuda-13.2-mini-py312-2026-09-07
+          - vastai/base-image:cuda-12.9-mini-py312-2026-09-07
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-09-07
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -159,9 +159,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/base-image:cuda-13.2-mini-py312-2026-08-28
-          - vastai/base-image:cuda-12.9-mini-py312-2026-08-28
-          - vastai/base-image:stock-ubuntu24.04-py312-2026-08-28
+          - vastai/base-image:cuda-13.2-mini-py312-2026-09-07
+          - vastai/base-image:cuda-12.9-mini-py312-2026-09-07
+          - vastai/base-image:stock-ubuntu24.04-py312-2026-09-07
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-oobabooga.yml
+++ b/.github/workflows/build-oobabooga.yml
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
         # arm64 is intentionally absent: oobabooga's accelerator wheels
         # (exllamav3, flash_attn, xformers, llama_cpp_binaries) are x86_64-only.
         # Re-add the arm64 entry once those gain aarch64 CUDA wheels (and update
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-ostris-ai-toolkit.yml
+++ b/.github/workflows/build-ostris-ai-toolkit.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
         # arm64 is intentionally absent: torchcodec is required at runtime
         # (transitive via torchaudio.load() in toolkit/dataloader_mixins.py)
         # but ships no aarch64 Linux wheels at any version. Re-add when
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-sd-forge.yml
+++ b/.github/workflows/build-sd-forge.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   DEFAULT_DOCKERHUB_REPO: "sd-forge"
-  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-09-01"
+  PYTORCH_BASE: "vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-09-08"
   # 7 days in seconds
   COMMIT_AGE_THRESHOLD: 604800
 

--- a/.github/workflows/build-unsloth-studio.yml
+++ b/.github/workflows/build-unsloth-studio.yml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
         # arm64 is intentionally absent: `torchao` (transitive via
         # unsloth-zoo>=2026.5.3 -> unsloth) only publishes amd64 manylinux
         # wheels as of v0.17.0+cu128. Re-add when upstream torchao ships
@@ -230,7 +230,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-voicebox.yml
+++ b/.github/workflows/build-voicebox.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-wan2gp.yml
+++ b/.github/workflows/build-wan2gp.yml
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08
         # arm64 is intentionally absent: Wan2GP requires onnxruntime-gpu
         # (pulled from the Azure ort-cuda-13-nightly index), which has no
         # aarch64 wheels — and PyPI's stable onnxruntime-gpu is also
@@ -236,7 +236,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-08
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-01
+          - vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-08
 
     steps:
       - name: Checkout

--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -289,6 +289,57 @@
         "313",
         "314"
       ]
+    },
+    {
+      "torch": "2.14.0",
+      "key": "cu126",
+      "cuda_ver": "12.6.3-cudnn-devel",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.14.0",
+      "key": "cu130",
+      "cuda_ver": "13.0.3-cudnn-devel",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.14.0",
+      "key": "cu132",
+      "cuda_ver": "13.2.1-cudnn-devel",
+      "backend": "cu132",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
     }
   ],
   "mini": [
@@ -495,6 +546,57 @@
     },
     {
       "torch": "2.13.0",
+      "key": "cu132-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu132",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.14.0",
+      "key": "cu126-mini",
+      "mini_base_tag": "cuda-12.9-mini",
+      "backend": "cu126",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.14.0",
+      "key": "cu130-mini",
+      "mini_base_tag": "cuda-13.2-mini",
+      "backend": "cu130",
+      "arches": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "python_versions": [
+        "310",
+        "311",
+        "312",
+        "313",
+        "314"
+      ]
+    },
+    {
+      "torch": "2.14.0",
       "key": "cu132-mini",
       "mini_base_tag": "cuda-13.2-mini",
       "backend": "cu132",

--- a/derivatives/llama-cpp/Dockerfile
+++ b/derivatives/llama-cpp/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-08-28
+ARG BASE_IMAGE=vastai/base-image:cuda-12.9-mini-py312-2026-09-07
 
 FROM ${BASE_IMAGE}
 ARG BASE_IMAGE

--- a/derivatives/pytorch/Dockerfile.multi-torch
+++ b/derivatives/pytorch/Dockerfile.multi-torch
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   docker buildx build -f Dockerfile.multi-torch \
-#     --build-arg PYTORCH_BASE=vastai/pytorch:2.13.0-cu130-cuda-13.2-mini-py312-2026-09-01 \
+#     --build-arg PYTORCH_BASE=vastai/pytorch:2.13.0-cu130-cuda-13.2-mini-py312-2026-09-08 \
 #     --build-arg PYTORCH_BACKEND=cu130 \
 #     --build-arg EXTRA_TORCH_VERSIONS="2.12.1 2.11.0" \
 #     -t my-multi-torch .

--- a/derivatives/pytorch/Dockerfile.multi-torch
+++ b/derivatives/pytorch/Dockerfile.multi-torch
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   docker buildx build -f Dockerfile.multi-torch \
-#     --build-arg PYTORCH_BASE=vastai/pytorch:2.13.0-cu130-cuda-13.2-mini-py312-2026-08-11 \
+#     --build-arg PYTORCH_BASE=vastai/pytorch:2.13.0-cu130-cuda-13.2-mini-py312-2026-09-01 \
 #     --build-arg PYTORCH_BACKEND=cu130 \
 #     --build-arg EXTRA_TORCH_VERSIONS="2.12.1 2.11.0" \
 #     -t my-multi-torch .

--- a/derivatives/pytorch/derivatives/a1111/Dockerfile
+++ b/derivatives/pytorch/derivatives/a1111/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/ace-step/Dockerfile
+++ b/derivatives/pytorch/derivatives/ace-step/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py311-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile.base
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-06-15
+ARG PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-09-01
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/aio-studio/README.md
+++ b/derivatives/pytorch/derivatives/aio-studio/README.md
@@ -155,7 +155,7 @@ All build arguments have sensible defaults. Override as needed:
 
 ```bash
 docker buildx build \
-    --build-arg PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-04-15 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-09-01 \
     --build-arg COMFYUI_REF=v0.18.1 \
     -t yournamespace/aio-studio .
 ```
@@ -164,7 +164,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:multi-210-291-271-2026-04-15` | PyTorch base image (multi-torch: 2.10, 2.9.1, 2.7.1) |
+| `PYTORCH_BASE` | `vastai/pytorch:multi-210-291-271-2026-09-01` | PyTorch base image (multi-torch: 2.10, 2.9.1, 2.7.1) |
 | `COMFYUI_REPO` | `https://github.com/Comfy-Org/ComfyUI` | ComfyUI repository |
 | `COMFYUI_REF` | `v0.18.1` | ComfyUI git ref |
 | `FORGE_REPO` | `https://github.com/Haoming02/sd-webui-forge-classic` | SD Forge repository |

--- a/derivatives/pytorch/derivatives/aio-studio/README.md
+++ b/derivatives/pytorch/derivatives/aio-studio/README.md
@@ -155,7 +155,7 @@ All build arguments have sensible defaults. Override as needed:
 
 ```bash
 docker buildx build \
-    --build-arg PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-09-01 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:multi-210-291-271-2026-09-08 \
     --build-arg COMFYUI_REF=v0.18.1 \
     -t yournamespace/aio-studio .
 ```
@@ -164,7 +164,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:multi-210-291-271-2026-09-01` | PyTorch base image (multi-torch: 2.10, 2.9.1, 2.7.1) |
+| `PYTORCH_BASE` | `vastai/pytorch:multi-210-291-271-2026-09-08` | PyTorch base image (multi-torch: 2.10, 2.9.1, 2.7.1) |
 | `COMFYUI_REPO` | `https://github.com/Comfy-Org/ComfyUI` | ComfyUI repository |
 | `COMFYUI_REF` | `v0.18.1` | ComfyUI git ref |
 | `FORGE_REPO` | `https://github.com/Haoming02/sd-webui-forge-classic` | SD Forge repository |

--- a/derivatives/pytorch/derivatives/comfyui/Dockerfile
+++ b/derivatives/pytorch/derivatives/comfyui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fluxgym/Dockerfile
+++ b/derivatives/pytorch/derivatives/fluxgym/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/fluxgym/README.md
+++ b/derivatives/pytorch/derivatives/fluxgym/README.md
@@ -83,7 +83,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01` | PyTorch mini base image (Python 3.10) |
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-08` | PyTorch mini base image (Python 3.10) |
 | `FLUXGYM_REPO` | `https://github.com/cocktailpeanut/fluxgym` | Upstream FluxGym repo |
 | `FLUXGYM_REF` | | Git ref (commit/branch) to build |
 | `SD_SCRIPTS_REPO` | `https://github.com/kohya-ss/sd-scripts` | Upstream Kohya sd-scripts repo |

--- a/derivatives/pytorch/derivatives/fluxgym/README.md
+++ b/derivatives/pytorch/derivatives/fluxgym/README.md
@@ -83,7 +83,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-04-15` | PyTorch mini base image (Python 3.10) |
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py310-2026-09-01` | PyTorch mini base image (Python 3.10) |
 | `FLUXGYM_REPO` | `https://github.com/cocktailpeanut/fluxgym` | Upstream FluxGym repo |
 | `FLUXGYM_REF` | | Git ref (commit/branch) to build |
 | `SD_SCRIPTS_REPO` | `https://github.com/kohya-ss/sd-scripts` | Upstream Kohya sd-scripts repo |

--- a/derivatives/pytorch/derivatives/fooocus/Dockerfile
+++ b/derivatives/pytorch/derivatives/fooocus/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/invokeai/Dockerfile
+++ b/derivatives/pytorch/derivatives/invokeai/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
+++ b/derivatives/pytorch/derivatives/kohya_ss/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py311-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/Dockerfile
+++ b/derivatives/pytorch/derivatives/oobabooga/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/oobabooga/README.build.md
+++ b/derivatives/pytorch/derivatives/oobabooga/README.build.md
@@ -16,7 +16,7 @@ example below pins a tag for a reproducible local build; pass any commit/branch/
 ```bash
 docker buildx build \
     --platform linux/amd64 \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08 \
     --build-arg OOBABOOGA_REF=v4.9 \
     . -t repo/image:tag --push
 ```

--- a/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
+++ b/derivatives/pytorch/derivatives/ostris-ai-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/sd-forge/Dockerfile
+++ b/derivatives/pytorch/derivatives/sd-forge/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py311-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/swarmui/Dockerfile
+++ b/derivatives/pytorch/derivatives/swarmui/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
 FROM ${PYTORCH_BASE}
 
 LABEL org.opencontainers.image.source="https://github.com/vastai/"

--- a/derivatives/pytorch/derivatives/unsloth-studio/README.md
+++ b/derivatives/pytorch/derivatives/unsloth-studio/README.md
@@ -78,7 +78,7 @@ The following patches are applied at build time:
 cd base-image/derivatives/pytorch/derivatives/unsloth-studio
 
 docker buildx build \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08 \
     -t yournamespace/unsloth-studio .
 ```
 
@@ -86,7 +86,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08` | PyTorch mini base image |
 
 ## Licenses
 

--- a/derivatives/pytorch/derivatives/unsloth-studio/README.md
+++ b/derivatives/pytorch/derivatives/unsloth-studio/README.md
@@ -78,7 +78,7 @@ The following patches are applied at build time:
 cd base-image/derivatives/pytorch/derivatives/unsloth-studio
 
 docker buildx build \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01 \
     -t yournamespace/unsloth-studio .
 ```
 
@@ -86,7 +86,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-04-15` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
 
 ## Licenses
 

--- a/derivatives/pytorch/derivatives/voicebox/Dockerfile
+++ b/derivatives/pytorch/derivatives/voicebox/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/voicebox/README.md
+++ b/derivatives/pytorch/derivatives/voicebox/README.md
@@ -70,7 +70,7 @@ supervisorctl tail -f voicebox
 cd base-image/derivatives/pytorch/derivatives/voicebox
 
 docker buildx build \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08 \
     --build-arg VOICEBOX_REF=v0.3.1 \
     -t yournamespace/voicebox .
 ```
@@ -79,7 +79,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-08` | PyTorch mini base image |
 | `VOICEBOX_REF` | (required) | Git commit, tag, or branch to build from |
 
 ## Building with GitHub Actions

--- a/derivatives/pytorch/derivatives/voicebox/README.md
+++ b/derivatives/pytorch/derivatives/voicebox/README.md
@@ -70,7 +70,7 @@ supervisorctl tail -f voicebox
 cd base-image/derivatives/pytorch/derivatives/voicebox
 
 docker buildx build \
-    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-03-26 \
+    --build-arg PYTORCH_BASE=vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01 \
     --build-arg VOICEBOX_REF=v0.3.1 \
     -t yournamespace/voicebox .
 ```
@@ -79,7 +79,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-03-26` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.9.1-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
 | `VOICEBOX_REF` | (required) | Git commit, tag, or branch to build from |
 
 ## Building with GitHub Actions

--- a/derivatives/pytorch/derivatives/wan2gp/Dockerfile
+++ b/derivatives/pytorch/derivatives/wan2gp/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/wan2gp/README.md
+++ b/derivatives/pytorch/derivatives/wan2gp/README.md
@@ -77,7 +77,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08` | PyTorch mini base image |
 | `WAN2GP_REPO` | `https://github.com/deepbeepmeep/Wan2GP` | Upstream Wan2GP repository |
 | `WAN2GP_REF` | | Git ref (commit/branch/tag) to build |
 

--- a/derivatives/pytorch/derivatives/wan2gp/README.md
+++ b/derivatives/pytorch/derivatives/wan2gp/README.md
@@ -77,7 +77,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
 | `WAN2GP_REPO` | `https://github.com/deepbeepmeep/Wan2GP` | Upstream Wan2GP repository |
 | `WAN2GP_REF` | | Git ref (commit/branch/tag) to build |
 

--- a/derivatives/pytorch/derivatives/whisper/Dockerfile
+++ b/derivatives/pytorch/derivatives/whisper/Dockerfile
@@ -13,7 +13,7 @@
 # 2.8.0). The UPPER bound is real too — upstream master carries
 # "# 2.9 deprecates used functions" against it — so this is a fixed point, not a
 # floor to raise later: do not move it to 2.9.x without re-reading upstream.
-ARG PYTORCH_BASE=vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-01
+ARG PYTORCH_BASE=vastai/pytorch:2.8.0-cu128-cuda-12.9-mini-py312-2026-09-08
 
 FROM ${PYTORCH_BASE}
 

--- a/derivatives/pytorch/derivatives/whisper/README.md
+++ b/derivatives/pytorch/derivatives/whisper/README.md
@@ -86,7 +86,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-08` | PyTorch mini base image |
 | `WHISPER_REPO` | `https://github.com/jhj0517/Whisper-WebUI` | Upstream repo |
 | `WHISPER_REF` | | Git ref (release tag e.g. `v1.0.8`) to build |
 

--- a/derivatives/pytorch/derivatives/whisper/README.md
+++ b/derivatives/pytorch/derivatives/whisper/README.md
@@ -86,7 +86,7 @@ docker buildx build \
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-04-15` | PyTorch mini base image |
+| `PYTORCH_BASE` | `vastai/pytorch:2.7.1-cu128-cuda-12.9-mini-py312-2026-09-01` | PyTorch mini base image |
 | `WHISPER_REPO` | `https://github.com/jhj0517/Whisper-WebUI` | Upstream repo |
 | `WHISPER_REF` | | Git ref (release tag e.g. `v1.0.8`) to build |
 

--- a/derivatives/pytorch/torch-companions.json
+++ b/derivatives/pytorch/torch-companions.json
@@ -64,7 +64,7 @@
   "2.14.0": {
     "packages": {
       "torchvision": "0.29.0",
-      "torchcodec": "0.15.0"
+      "torchcodec": "0.16.0"
     },
     "amd64_only": []
   }

--- a/derivatives/pytorch/torch-companions.json
+++ b/derivatives/pytorch/torch-companions.json
@@ -60,5 +60,12 @@
       "torchcodec": "0.15.0"
     },
     "amd64_only": []
+  },
+  "2.14.0": {
+    "packages": {
+      "torchvision": "0.29.0",
+      "torchcodec": "0.15.0"
+    },
+    "amd64_only": []
   }
 }


### PR DESCRIPTION
torch **2.14.0** is the current PyPI release; the table stopped at 2.13.0. Its shape is identical to 2.13.0, which is what makes this low-risk:

| | |
|---|---|
| backends | `cu126`, `cu130`, `cu132` |
| python | 310, 311, 312, 313, 314 |
| arches | linux/amd64, linux/arm64 |

Backends were **probed**, not assumed — `cu128`, `cu129`, `cu131` and `cu133` carry no 2.14.0 on `download.pytorch.org`. All **30** declared combinations (3 backends x 5 pythons x 2 arches) were confirmed to have real wheels.

## No multi, deliberately

A multi-torch base earns its place when a derivative needs several torch lines in one image. **Nothing needs 2.14: no derivative pins above 2.10.**

Worth recording while looking: of the three multis already published, only `multi-210-291-271` has a consumer (aio-studio). `multi-2130-2121-2110` and `multi-2130-2121` appear nowhere but a comment explaining that aio-studio does *not* use them — built and published each cycle for nobody. A `2140` multi would have been a third. **That pre-existing question is left alone here**, but it's worth a decision separately.

## No retirement

The ADR 0022 support floor is derived from real pins and sits at **2.7** (a1111, fluxgym, invokeai, wan2gp). Adding a version above it doesn't move it, so nothing is retired and `test_no_pinned_version_is_retired` stays satisfied.

Current consumption: 2.7 (10 refs), 2.8 (2), 2.9 (8), 2.10 (8) — and nothing on 2.11, 2.12 or 2.13. This makes **four** consecutive minors ahead of consumption. Defensible if these bases are a product customers pick directly (the floor policy governs the bottom, deliberately, not the top) — but flagging it, because nothing in the repo states an intent for the top end.

## Companions

The second file is not optional: every built torch version needs an entry in `torch-companions.json`, or the build dies late with `jq: error: version not found` after pulling the base image, pointing at nothing. A test enforces it, and it's the reason the first pass at this change was incomplete.

- **torchvision 0.29.0** — its own metadata declares `torch==2.14.0`. Authoritative pairing, not extrapolated from `2.13.0 -> 0.28.0`.
- **torchaudio omitted** — checked rather than copied from the neighbouring entries: torchaudio 2.12.1, 2.13.0 and 2.14.0 all 404 on PyPI, and the latest release is 2.11.0. Upstream stopped shipping it.
- **torchcodec 0.16.0** — see below.
- **`amd64_only: []`** — justified rather than copied: torchcodec ships aarch64 wheels for every python in the matrix.

## torchcodec was measured on a GPU, not guessed

torchcodec declares **no torch dependency** in its metadata, so no resolver catches a mismatch. The first pass pinned 0.15.0 on a consistency argument, which is a guess. Tested instead on a Blackwell box (RTX PRO 6000, sm_120, driver 580.95.05), through the exact path the image build uses:

```
uv pip install torch==2.14.0 torchvision==0.29.0 torchcodec==<V> --torch-backend cu132

0.15.0 -> torch=2.14.0+cu132  torchvision=0.29.0+cu132  torchcodec=0.15.0+cu132
          cpu decode OK   cuda decode OK
0.16.0 -> torch=2.14.0+cu132  torchvision=0.29.0+cu132  torchcodec=0.16.0+cu132
          cpu decode OK   cuda decode OK
```

Both **decode**, not merely import — 20 frames from a real mp4, shape `(3,240,320)`, CUDA path returning tensors on `cuda:0`. An ABI mismatch against libtorch surfaces as an undefined symbol at import, or at the first decoder call; neither appeared. `uv` resolved both without moving torch off `2.14.0+cu132`.

**The first test run was itself wrong**, and that is the useful part: it used plain `pip install torchcodec==X`, which pulls the PyPI wheel and resolved `+cu130` against a `+cu132` torch — a different artifact from the one we ship. The image routes torch-family packages through `--torch-backend`, so the rerun pinned the backend index, where both versions exist for cu126, cu130 and cu132.

**So there is no compatibility basis to choose between them, and that is the finding.** 0.16.0 is taken because it is the current release and a new torch line has no reason to ship an older companion once the newer is proven on our own install path. The table already carries a different torchcodec per line (0.5, 0.7.0, 0.9.1, 0.10.0, 0.11.0, 0.15.0), so this follows the pattern rather than departing from it. 0.15.0 would be equally valid — say so and it is a one-line change.

## Every pytorch line rebuilt and repinned

The original scope was "add 2.14". It grew, deliberately: the whole table was rebuilt on the new `2026-09-07` base and promoted, so **every** torch line moved, not just the new one.

That matters because of what the first pin pass could not do. It stopped at `2026-09-01`, since the pytorch build had been filtered to 2.14 and the other seven lines had no newer tag — and the consequence was that derivatives pinning pytorch would **not** inherit the serverless-bridge removal that went out earlier. Rebuilding every line on the new base closes that.

Final pin state:

| | date | why |
|---|---|---|
| 11 pytorch coordinates, 37 files | `2026-09-08` | rebuilt and promoted today |
| 3 base-image coordinates | `2026-09-07` | base was not rebuilt; this is genuinely its newest |

Two verifications, because a wrong pin doesn't fail now — it fails a derivative build days later:

- **No coordinate set lost or invented.** 11 re-dated, nothing else, so no image quietly changed the torch it builds against.
- **All 14 pins queried individually against the prod registry.** Not inferred from "the promote succeeded" — the 2.14-only promote proves those two facts can differ per coordinate.

## Infrastructure faults, for the record

Neither was a defect, both passed on re-run, and both are noted because the failure modes are worth recognising:

- **Build:** one cell lost to `The runner has received a shutdown signal` (2.12.1 / cu130 / arm64). Its skip cascaded to `merge-manifests`, so the multi-arch tags were checked **at the registry** afterwards rather than assumed — the affected tag resolves to `amd64, arm64`.
- **Promote:** one cell hit the 2400s live-test timeout on a bad host (`mini-2.10.0-cu130-mini-py311`), killed mid-step with teardown and evidence upload never reached. `qa-summary` failed as a cascade so `promote` never ran — the gate behaving correctly. The QA reaper ran twice afterwards, which is what cleans an instance whose teardown never executed.

## Evidence

```
pytorch lifecycle + config table   42 passed, 9 skipped
imagegen                           641 passed, 9 skipped
lint --all                         27 images, baseline CLEAN
```

The one failure in the full run was `test_a_socket_that_never_arrives_times_out`, the documented wall-clock flake, which passes on three consecutive re-runs and whose test and `lib.sh` this branch touches neither of. Worth noting it has now failed twice today (once in CI on #277); its own docstring says that if it starts costing more than a re-run, the contained fix is a `_mono` helper.

Config edit is purely additive: 102 insertions, no reformatting churn.

