### PR TITLE
unsloth: stop rebuilding a frontend that ships prebuilt (and survive a missing lockfile)

### DIFF
--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -503,6 +503,24 @@ RUN \
     # so the assertions below fail the build rather than shipping a CPU-only binary.
     export UNSLOTH_LOCAL_LLAMA_CPP_DIR=/opt/llama-cpp && \
     export SKIP_STUDIO_BASE=1 && \
+    # Use the frontend dist the wheel already ships, instead of rebuilding it.
+    # setup.sh's `_packaged_frontend_available` skips the build when three things hold:
+    # STUDIO_LOCAL_INSTALL=0, no pyproject.toml at the repo root, and
+    # frontend/dist/index.html present. Upstream's own install.sh sets that variable for
+    # PyPI installs; we call `unsloth studio setup` directly, so it was never set and
+    # setup fell through to its mtime heuristic — which upstream documents as unreliable
+    # ("wheel extraction mtimes do not preserve build ordering"). We were therefore
+    # rebuilding a frontend that ships prebuilt, on every build of every version.
+    #
+    # 2026.9.3 turned that waste into a hard failure: the wheel dropped the frontend
+    # src/ tree (1368 .ts/.tsx files down to 17, no src/components, no src/features)
+    # while keeping 14 smoke-*.tsx entry points that import it, so `tsc -b` fails with
+    # dozens of TS2307. The dist itself is present and current (717 files), so the built
+    # artifact was never the problem — only our rebuilding of it.
+    #
+    # Declaring 0 is accurate rather than a trick: this IS a pip install. Verified in
+    # both 2026.9.2 and 2026.9.3 that all three conditions hold.
+    export STUDIO_LOCAL_INSTALL=0 && \
     # CONDITIONAL npm workaround, and the condition is the whole point: it applies only
     # while the studio frontend ships WITHOUT its lockfile, so it retires itself the day
     # upstream puts one back. A permanent `legacy-peer-deps` would silently install a

--- a/derivatives/pytorch/derivatives/aio-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/aio-studio/Dockerfile
@@ -503,6 +503,35 @@ RUN \
     # so the assertions below fail the build rather than shipping a CPU-only binary.
     export UNSLOTH_LOCAL_LLAMA_CPP_DIR=/opt/llama-cpp && \
     export SKIP_STUDIO_BASE=1 && \
+    # CONDITIONAL npm workaround, and the condition is the whole point: it applies only
+    # while the studio frontend ships WITHOUT its lockfile, so it retires itself the day
+    # upstream puts one back. A permanent `legacy-peer-deps` would silently install a
+    # dependency tree upstream never tested, forever, for a slip that is probably one
+    # release long.
+    #
+    # unsloth 2026.9.3 shipped studio/frontend/ with no package-lock.json; 2026.9.2 had
+    # one, and the pins in package.json are byte-identical between them. With the lock,
+    # npm replays the recorded tree. Without it, npm re-resolves and hits a conflict that
+    # has been latent since 2026-07-28: @assistant-ui/core@0.1.17 peer-requires BOTH
+    # tap@^0.5.10 and store@^0.2.9, and the newest matching store@0.2.22 peer-requires
+    # tap@^0.9.0, against a project pinning tap@0.5.10 — ERESOLVE, and `unsloth studio
+    # setup` dies at its npm step.
+    #
+    # /venv/unsloth, NOT /venv/main: this image installs unsloth into its own app venv,
+    # which is where the frontend lands. The standalone unsloth-studio image carries the
+    # same block against /venv/main. Scanning the wrong venv would find nothing, take the
+    # else branch, and leave the build failing exactly as it does today.
+    #
+    # npm_config_* is scoped to THIS build step and never written to an .npmrc, so the
+    # shipped image's npm behaves normally. Both outcomes are logged: the day the notice
+    # stops appearing is the day this block can go.
+    _uns_fe="$(find /venv/unsloth/lib -type d -path '*/studio/frontend' -print -quit 2>/dev/null || true)" && \
+    if [[ -n "${_uns_fe}" && ! -f "${_uns_fe}/package-lock.json" ]]; then \
+        echo "NOTICE: ${_uns_fe} ships no package-lock.json — enabling legacy-peer-deps for this build only"; \
+        export npm_config_legacy_peer_deps=true; \
+    else \
+        echo "unsloth frontend lockfile present (or frontend not found at the expected path) — no npm workaround applied"; \
+    fi && \
     unsloth studio setup && \
     # PROVE the reuse branch fired — do not infer it. Two independent facts: the
     # canonical install path resolves to our tree, AND the binary is byte-identical to

--- a/derivatives/pytorch/derivatives/aio-studio/ROOT/LICENSES.md
+++ b/derivatives/pytorch/derivatives/aio-studio/ROOT/LICENSES.md
@@ -66,6 +66,14 @@ as the canonical source for the license text.
   (frontend and related tooling under `studio/`) is separately licensed under
   AGPL-3.0.
 
+  While upstream ships `studio/frontend/` WITHOUT a `package-lock.json` (2026.9.3
+  does not; 2026.9.2 did), the build sets `npm_config_legacy_peer_deps` for that
+  install only. This is a resolver setting, not a change to the AGPL work: no file
+  under `studio/` is altered, and the versions declared in the frontend's own
+  `package.json` are installed exactly as pinned. Recorded for transparency about
+  how the conveyed frontend was built. It applies only while the lockfile is absent
+  and lapses when upstream restores one.
+
 ## Whisper WebUI
 
 - **License:** Apache-2.0

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -265,6 +265,24 @@ RUN \
     # so the assertions below fail the build rather than shipping a CPU-only binary.
     export UNSLOTH_LOCAL_LLAMA_CPP_DIR=/opt/llama-cpp && \
     export SKIP_STUDIO_BASE=1 && \
+    # Use the frontend dist the wheel already ships, instead of rebuilding it.
+    # setup.sh's `_packaged_frontend_available` skips the build when three things hold:
+    # STUDIO_LOCAL_INSTALL=0, no pyproject.toml at the repo root, and
+    # frontend/dist/index.html present. Upstream's own install.sh sets that variable for
+    # PyPI installs; we call `unsloth studio setup` directly, so it was never set and
+    # setup fell through to its mtime heuristic — which upstream documents as unreliable
+    # ("wheel extraction mtimes do not preserve build ordering"). We were therefore
+    # rebuilding a frontend that ships prebuilt, on every build of every version.
+    #
+    # 2026.9.3 turned that waste into a hard failure: the wheel dropped the frontend
+    # src/ tree (1368 .ts/.tsx files down to 17, no src/components, no src/features)
+    # while keeping 14 smoke-*.tsx entry points that import it, so `tsc -b` fails with
+    # dozens of TS2307. The dist itself is present and current (717 files), so the built
+    # artifact was never the problem — only our rebuilding of it.
+    #
+    # Declaring 0 is accurate rather than a trick: this IS a pip install. Verified in
+    # both 2026.9.2 and 2026.9.3 that all three conditions hold.
+    export STUDIO_LOCAL_INSTALL=0 && \
     # CONDITIONAL npm workaround, and the condition is the whole point: it applies only
     # while the studio frontend ships WITHOUT its lockfile, so it retires itself the day
     # upstream puts one back. A permanent `legacy-peer-deps` would silently install a

--- a/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
+++ b/derivatives/pytorch/derivatives/unsloth-studio/Dockerfile
@@ -265,6 +265,30 @@ RUN \
     # so the assertions below fail the build rather than shipping a CPU-only binary.
     export UNSLOTH_LOCAL_LLAMA_CPP_DIR=/opt/llama-cpp && \
     export SKIP_STUDIO_BASE=1 && \
+    # CONDITIONAL npm workaround, and the condition is the whole point: it applies only
+    # while the studio frontend ships WITHOUT its lockfile, so it retires itself the day
+    # upstream puts one back. A permanent `legacy-peer-deps` would silently install a
+    # dependency tree upstream never tested, forever, for a slip that is probably one
+    # release long.
+    #
+    # unsloth 2026.9.3 shipped studio/frontend/ with no package-lock.json; 2026.9.2 had
+    # one, and the pins in package.json are byte-identical between them. With the lock,
+    # npm replays the recorded tree. Without it, npm re-resolves and hits a conflict that
+    # has been latent since 2026-07-28: @assistant-ui/core@0.1.17 peer-requires BOTH
+    # tap@^0.5.10 and store@^0.2.9, and the newest matching store@0.2.22 peer-requires
+    # tap@^0.9.0, against a project pinning tap@0.5.10 — ERESOLVE, and `unsloth studio
+    # setup` dies at its npm step.
+    #
+    # npm_config_* is scoped to THIS build step and never written to an .npmrc, so the
+    # shipped image's npm behaves normally. Both outcomes are logged: the day the notice
+    # stops appearing is the day this block can go.
+    _uns_fe="$(find /venv/main/lib -type d -path '*/studio/frontend' -print -quit 2>/dev/null || true)" && \
+    if [[ -n "${_uns_fe}" && ! -f "${_uns_fe}/package-lock.json" ]]; then \
+        echo "NOTICE: ${_uns_fe} ships no package-lock.json (unsloth ${UNSLOTH_VERSION:-latest}) — enabling legacy-peer-deps for this build only"; \
+        export npm_config_legacy_peer_deps=true; \
+    else \
+        echo "unsloth frontend lockfile present (or frontend not found at the expected path) — no npm workaround applied"; \
+    fi && \
     unsloth studio setup && \
     # PROVE the reuse branch fired — do not infer it. Two independent facts: the
     # canonical install path resolves to our tree, AND the binary is byte-identical to

--- a/derivatives/pytorch/derivatives/unsloth-studio/ROOT/LICENSES.md
+++ b/derivatives/pytorch/derivatives/unsloth-studio/ROOT/LICENSES.md
@@ -33,3 +33,11 @@ as the canonical source for the license text.
 - **Notes:** The Unsloth core library is Apache-2.0. The Studio component
   (frontend and related tooling under `studio/`) is separately licensed under
   AGPL-3.0.
+
+  While upstream ships `studio/frontend/` WITHOUT a `package-lock.json` (2026.9.3
+  does not; 2026.9.2 did), the build sets `npm_config_legacy_peer_deps` for that
+  install only. This is a resolver setting, not a change to the AGPL work: no file
+  under `studio/` is altered, and the versions declared in the frontend's own
+  `package.json` are installed exactly as pinned. Recorded for transparency about
+  how the conveyed frontend was built. It applies only while the lockfile is absent
+  and lapses when upstream restores one.

--- a/tools/imagegen/tests/test_linter.py
+++ b/tools/imagegen/tests/test_linter.py
@@ -3919,3 +3919,41 @@ def test_L092_wget_is_not_in_scope(tmp_path):
     that does not exist."""
     df = 'FROM scratch\nRUN wget -O /tmp/x https://example.invalid/x\n'
     assert "L092" not in errs(make(tmp_path, df=df), tmp_path)
+
+
+# ---- the unsloth npm lockfile workaround is conditional, and scoped to the right venv ----
+
+
+_UNSLOTH_IMAGES = ["unsloth-studio", "aio-studio"]
+
+
+@pytest.mark.parametrize("name", _UNSLOTH_IMAGES)
+def test_unsloth_npm_workaround_is_conditional_on_the_missing_lockfile(name):
+    """unsloth 2026.9.3 shipped studio/frontend with no package-lock.json, so npm
+    re-resolved and hit an ERESOLVE that had been latent since 2026-07-28, killing
+    `unsloth studio setup` at its npm step.
+
+    The workaround must stay CONDITIONAL on the lockfile being absent. Made
+    unconditional it would install a dependency tree upstream never tested, forever,
+    for what is most likely a one-release packaging slip — and nobody would notice it
+    had stopped being needed."""
+    _, img = _real(name)
+    code = L.code_text(L.parse(img.text))
+    assert "npm_config_legacy_peer_deps" in code, "no npm workaround present"
+    assert re.search(r"!\s*-f\s+\"?\$\{_uns_fe\}/package-lock\.json", code), \
+        "the workaround is not guarded by the missing-lockfile test"
+
+
+@pytest.mark.parametrize("name,venv", [("unsloth-studio", "/venv/main"),
+                                       ("aio-studio", "/venv/unsloth")])
+def test_unsloth_npm_workaround_scans_the_venv_unsloth_lives_in(name, venv):
+    """The two images install unsloth into DIFFERENT venvs, the same split that made
+    the GGUF converter assertion wrong once already (L089). Scanning the wrong venv
+    finds no frontend, takes the else branch, and leaves the build failing exactly as
+    it does today — a silent no-op rather than a loud error, which is why it is pinned
+    here rather than left to review."""
+    _, img = _real(name)
+    code = L.code_text(L.parse(img.text))
+    m = re.search(r"find (/venv/[a-z]+)/lib -type d -path '\*/studio/frontend'", code)
+    assert m, "no frontend lookup found"
+    assert m.group(1) == venv, f"{name} scans {m.group(1)} but installs unsloth into {venv}"


### PR DESCRIPTION
The scheduled unsloth-studio build failed on 2026-09-09. Not our pytorch bump, and not the new base it built on — unsloth **2026.9.3** is a broken release in two ways, and chasing the first one uncovered a defect of our own that had been costing us on every build.

## What actually failed

**Symptom 1 — no lockfile.** 2026.9.3 shipped `studio/frontend/` without `package-lock.json` (2026.9.2 had one; the pins in `package.json` are byte-identical). Without the lock npm re-resolves and hits a conflict latent since 2026-07-28: `@assistant-ui/core@0.1.17` peer-requires both `tap@^0.5.10` and `store@^0.2.9`, while the newest matching `store@0.2.22` demands `tap@^0.9.0`. `ERESOLVE`, and `unsloth studio setup` dies at its npm step.

**Symptom 2 — no frontend source.** With npm unblocked, `npm run build` then failed with dozens of `TS2307`. The wheel had **dropped the frontend source tree**: 1368 `.ts/.tsx` files down to **17**, no `src/components`, no `src/features` — while still shipping 14 `smoke-*.tsx` entry points that import them.

## The real fix, and the defect it exposed

The prebuilt `dist/` is present and current (717 files, up from 703). **The built artifact was never the problem — only our rebuilding of it.**

`setup.sh`'s `_packaged_frontend_available()` skips the build when `STUDIO_LOCAL_INSTALL=0`, there is no `pyproject.toml` at the repo root, and `frontend/dist/index.html` exists. Upstream's `install.sh` sets that variable for PyPI installs. We call `unsloth studio setup` **directly**, so it was never set, and setup fell through to an mtime heuristic that upstream's own comment calls unreliable:

> "wheel extraction mtimes do not preserve build ordering, so source files can appear newer than the release-built dist even though both came from the same wheel"

So every build of every version has been rebuilding a frontend that ships prebuilt. 2026.9.3 turned that long-standing waste into a hard failure.

`export STUDIO_LOCAL_INSTALL=0` is accurate rather than a trick: this **is** a pip install. Verified against both sdists that all three conditions hold in 2026.9.2 and 2026.9.3, so it is version-agnostic rather than tuned to the broken release.

## The npm workaround is kept, as a backstop

Conditional on the lockfile being **absent**, so it retires itself the day upstream restores one. A permanent `legacy-peer-deps` would install a tree upstream never tested, forever, for a probably-one-release slip — and nobody would notice it had stopped being needed. `npm_config_*` is scoped to the build step, never written to an `.npmrc`.

With the frontend build now skipped it will not matter; if a future release stops shipping `dist/`, the rebuild path returns and the ERESOLVE risk with it.

**Both images, different venvs:** unsloth-studio installs unsloth into `/venv/main`, aio-studio into `/venv/unsloth`. Scanning the wrong one finds no frontend, takes the else branch, and leaves the build failing exactly as before — a *silent no-op*, not a loud error. Same per-image venv split that made the GGUF converter assertion wrong on its first attempt (L089), so two tests pin it, both mutation-proved (swap aio-studio to `/venv/main` → fails; replace the guard with `if true` → fails).

## Verified on the real thing

Built and QA'd on **the same 2026.9.3 that failed twice**:

```
NOTICE: /venv/main/.../studio/frontend ships no package-lock.json (unsloth 2026.9.3)
frontend   bundled (pip install)
npm run build occurrences: 0
```

Both mechanisms fired as designed, and the llama.cpp reuse assertion passed — reached for the first time, since setup died before it on both earlier attempts, so nothing else was hiding behind the frontend failure.

Promoted: `vastai/unsloth-studio:2026.9.3-cuda-12.9-py312`.

## Licence

No modification notice is owed: the copyleft invariant triggers on the Dockerfile **patching** AGPL upstream (`sed -i` / `patch` / `git apply`), and this patches nothing — no file under `studio/` is altered. A **Notes** entry is added to both images' `LICENSES.md` recording how the conveyed frontend was built, because a reader auditing the artifact would reasonably want to know.

Worth flagging separately: that copyleft rule is marked *proposed* and is **not enforced** — no linter rule or test references `LICENSES.md`, across five images that ship AGPL code.

## Not addressed here

aio-studio carries both fixes but is deliberately unbuilt. The missing lockfile and missing `src/` are upstream packaging slips worth reporting to unslothai; a fix there retires our backstop automatically.

```
imagegen  646 passed, 9 skipped     lint --all  27 images, baseline CLEAN
```
