### PR TITLE
sglang: --enable-expert-parallel always yields an --ep-size

### DIFF
--- a/external/sglang/README.md
+++ b/external/sglang/README.md
@@ -35,22 +35,20 @@ Pre-built images are available on [DockerHub](https://hub.docker.com/repository/
 strictly, so passing it through is not a harmless no-op — argparse exits with
 `unrecognized arguments` and the server never starts.
 
-The launcher translates it **when it is also choosing the tensor-parallel size for
-you**: the portable flag is removed and sglang's own `--ep-size $GPU_COUNT` added to
-match the `--tensor-parallel-size $GPU_COUNT` it adds. That is the case the flag exists
-for — N has to equal the instance GPU count, which is exactly what a static template
-arg string cannot know.
+The launcher translates it: the portable flag is removed and sglang's own `--ep-size N`
+added. **Setting the flag is enough — a size is always emitted.** N is the
+tensor-parallel size actually in effect: the value you pinned, `$GPU_COUNT` when the
+launcher supplied the TP itself, or 1 when nothing sets one (`AUTO_PARALLEL=false`, or a
+`--data-parallel-size` pin suppressing the automatic one).
 
-**If you pin a parallel size yourself** (either spelling, in `SGLANG_ARGS` or
-`/etc/sglang-args.conf`), or turn `AUTO_PARALLEL` off, the flag is dropped and nothing
-is added in its place — add an explicit `--ep-size N` alongside your pin. This is
-deliberate: sglang derives `moe_tp_size = tp_size / ep_size`, so an `--ep-size` that
-does not divide your tensor-parallel size fails the model load with an arithmetic error
-naming neither flag, and a size we invented against a TP we did not choose can only
-produce that. An `--ep-size` of your own is always left exactly as written, and an
-attached false value (`--enable-expert-parallel=False`) is read as "not requested".
+That matching matters: sglang derives `moe_tp_size = tp_size / ep_size`, so an
+`--ep-size` that does not divide your tensor-parallel size fails the model load with an
+arithmetic error naming neither flag. `ep == tp` always divides.
 
-Whichever branch applies is announced in `/var/log/sglang.log`.
+An `--ep-size` of your own is never touched, and an attached false value
+(`--enable-expert-parallel=False`) is read as "not requested". Flags in
+`/etc/sglang-args.conf` are covered by all of this, and whichever branch applies is
+announced in `/var/log/sglang.log`.
 
 ### Complex Arguments
 For arguments that are difficult to pass via environment variables (JSON strings, special characters, etc.), write them to `/etc/sglang-args.conf`. The contents of this file are appended to `$SGLANG_ARGS` when launching SGLang.

--- a/external/sglang/ROOT/etc/vast_agents/sglang.md
+++ b/external/sglang/ROOT/etc/vast_agents/sglang.md
@@ -47,19 +47,17 @@ supervisorctl restart sglang model-ui
   before concluding a flag was ignored:
   - `--enable-expert-parallel` is *vLLM's* spelling. sglang parses argv strictly, so
     passing it through would exit 2 with `unrecognized arguments` and the server would
-    never start. It is removed, and `--ep-size $GPU_COUNT` added in its place **only
-    when the automatic `--tensor-parallel-size $GPU_COUNT` above was also added**.
-    If you pinned a parallel size yourself, or `AUTO_PARALLEL` is off, the flag is
-    dropped and NOTHING replaces it — add an explicit `--ep-size N` next to your pin.
-    sglang computes `moe_tp_size = tp_size / ep_size`, so an ep that does not divide
-    the tp fails the model load with an arithmetic error naming neither flag; the
-    launcher declines to guess rather than produce it. Your own `--ep-size` is never
-    touched.
+    never start. It is removed and replaced with `--ep-size N`. **Setting the flag is
+    enough — a size is always emitted.** N is the tensor-parallel size actually in
+    effect: what you pinned, else `$GPU_COUNT` when the automatic arg supplied it, else
+    1. sglang computes `moe_tp_size = tp_size / ep_size`, so an ep that does not divide
+    the tp fails the model load with an arithmetic error naming neither flag; `ep == tp`
+    always divides. Your own `--ep-size` is never touched.
   - The auto tensor-parallel arg above.
 
   Both rewrites read **`/etc/sglang-args.conf` as well as `SGLANG_ARGS`**, so a
-  `--tp-size` you put there counts as a pin. The conf is still appended last and still
-  wins on a duplicate flag.
+  `--tp-size` you put there is what the `--ep-size` is sized from. The conf is still
+  appended last and still wins on a duplicate flag.
 
 ### Companion services
 

--- a/external/sglang/ROOT/opt/supervisor-scripts/sglang.sh
+++ b/external/sglang/ROOT/opt/supervisor-scripts/sglang.sh
@@ -65,9 +65,26 @@ if [[ $_all_args =~ parallel-size ]] ||
    [[ $_all_args =~ (^|[[:space:]])--(tp|tp-size|tensor-parallel)[[:space:]=] ]]; then
     _operator_pinned_parallelism=yes
 fi
+# The pinned VALUE, when there is one. --ep-size has to be a number, and the only
+# correct number is whatever tp ends up being, so a boolean is not enough here.
+_pinned_tp=""
+if [[ $_all_args =~ (^|[[:space:]])--(tp|tp-size|tensor-parallel|tensor-parallel-size)[[:space:]=]+([0-9]+) ]]; then
+    _pinned_tp="${BASH_REMATCH[3]}"
+fi
 
 if [[ "${AUTO_PARALLEL,,}" = "true" && -z "$_operator_pinned_parallelism" ]]; then
     AUTO_PARALLEL_ARGS="--tensor-parallel-size $GPU_COUNT"
+fi
+
+# The tensor-parallel size sglang will ACTUALLY run with. Not $GPU_COUNT: that is
+# only the answer when we supplied the arg ourselves. If the operator pinned one it is
+# theirs, and if nothing sets it at all sglang's own default of 1 applies.
+if [[ -n "$_pinned_tp" ]]; then
+    _effective_tp="$_pinned_tp"
+elif [[ -n "$AUTO_PARALLEL_ARGS" ]]; then
+    _effective_tp="$GPU_COUNT"
+else
+    _effective_tp=1
 fi
 
 # Expert parallelism is spelled --ep-size N here. --enable-expert-parallel is vLLM's
@@ -78,20 +95,15 @@ fi
 #   (moe_intermediate_size=640 / moe_tp_size=4) % weight_block_size_n=128 != 0
 # because moe_tp_size is tp_size/ep_size and ep_size defaulted to 1.
 #
-# We translate ONLY when we chose the tensor-parallel size ourselves, and we size N to
-# match it. That is the whole point of the portable flag: N must equal the instance GPU
-# count, which is why it cannot be written into a static template arg string. A
-# template that pins its own tp already knows its shape and can write --ep-size
-# directly.
+# ASKING FOR IT IS ENOUGH. If the flag is set we always emit a size, because the
+# operator asked for expert parallelism and silently dropping it hands them the load
+# failure above with nothing pointing at the cause.
 #
-# Declining in every other case is the deliberate part. sglang derives
+# N is the EFFECTIVE tp, and that is the only safe choice: sglang derives
 # moe_tp_size = tp_size/ep_size, so an ep that does not divide the tp fails the load
-# with an arithmetic error naming neither flag — and an ep we invented against a tp we
-# did not choose is exactly how that happens (tp=2 pinned, ep=$GPU_COUNT=8, moe_tp_size
-# 0.25). Guessing here can only produce that failure; saying so cannot.
-#
-# Every branch SAYS what it did. This is the one place a flag the operator wrote does
-# not reach sglang verbatim, and /var/log/sglang.log is where they will look.
+# with an arithmetic error naming neither flag. ep == tp always divides. Sizing from
+# $GPU_COUNT instead would break the moment the operator pinned a smaller tp — tp=2
+# with ep=8 is moe_tp_size 0.25, the same crash from the other side.
 EP_ARGS=""
 if [[ $_all_args =~ (^|[[:space:]])--enable-expert-parallel ]]; then
     # Strip the flag AND an attached value from BOTH sources. vLLM renders this as a
@@ -110,15 +122,11 @@ if [[ $_all_args =~ (^|[[:space:]])--enable-expert-parallel ]]; then
         echo "sglang: dropped --enable-expert-parallel — a false value was attached, so expert parallelism was NOT requested"
     elif [[ $_all_args =~ (^|[[:space:]])--(ep|ep-size|expert-parallel|expert-parallel-size)[[:space:]=] ]]; then
         echo "sglang: dropped --enable-expert-parallel (vLLM spelling); keeping the expert-parallel size you set yourself"
-    elif [[ -n "$_operator_pinned_parallelism" ]]; then
-        echo "sglang: dropped --enable-expert-parallel (vLLM spelling) — you pinned the parallel size yourself, so add an explicit --ep-size N. It must divide your tensor-parallel size or the model will not load."
-    elif [[ -z "$AUTO_PARALLEL_ARGS" ]]; then
-        echo "sglang: dropped --enable-expert-parallel — AUTO_PARALLEL is off, so nothing sets a tensor-parallel size and there is nothing to spread experts across"
-    elif [[ $GPU_COUNT =~ ^[0-9]+$ ]] && (( GPU_COUNT > 1 )); then
-        EP_ARGS="--ep-size $GPU_COUNT"
-        echo "sglang: translated --enable-expert-parallel (vLLM spelling) to --ep-size $GPU_COUNT"
+    elif [[ $_effective_tp =~ ^[0-9]+$ ]] && (( _effective_tp >= 1 )); then
+        EP_ARGS="--ep-size ${_effective_tp}"
+        echo "sglang: translated --enable-expert-parallel (vLLM spelling) to --ep-size ${_effective_tp} (matching the tensor-parallel size in effect)"
     else
-        echo "sglang: dropped --enable-expert-parallel — tensor-parallel size is ${GPU_COUNT:-unset}, so expert parallelism has nothing to spread across"
+        echo "sglang: could not translate --enable-expert-parallel — the tensor-parallel size is ${_effective_tp:-unset}, which is not a number; passing nothing rather than an --ep-size that cannot be right"
     fi
 fi
 

--- a/tools/imagegen/tests/test_sglang_args_sh.py
+++ b/tools/imagegen/tests/test_sglang_args_sh.py
@@ -12,10 +12,12 @@ $GPU_COUNT, which is correct only when we supplied the tp ourselves — with a
 template-pinned `--tensor-parallel-size 2` on an 8-GPU host it produced ep=8 against
 tp=2 and reintroduced the same crash from the other side.
 
-The launcher therefore translates the portable flag ONLY when it chose the tp itself,
-and declines with a message otherwise. That is the property most of this table pins:
-an --ep-size we invented against a tp we did not choose can only be the crash above,
-so the operator-pinned cases must emit nothing rather than emit a good guess.
+Asking for the flag is enough: the launcher ALWAYS emits a size, because silently
+dropping it hands the operator the load failure above with nothing pointing at the
+cause. The size is the EFFECTIVE tp — pinned value, else $GPU_COUNT when the automatic
+arg supplied it, else sglang's own default of 1. ep == tp always divides, which is what
+makes "always emit" safe; sizing from $GPU_COUNT against a pinned smaller tp is the
+crash above arriving from the other side, and that is what most of this table pins.
 
 Neither direction is reachable by a deploy test on a convenient box: with tp
 unpinned, ep == GPU_COUNT == tp and every arrangement looks identical. Only a table
@@ -151,20 +153,20 @@ def test_other_args_are_left_alone():
         "--mem-fraction-static 0.9 --tensor-parallel-size 4 --ep-size 4"
 
 
-def test_a_pinned_tp_declines_the_translation_rather_than_guessing():
+def test_ep_follows_a_pinned_tp_not_the_host_gpu_count():
     """THE case that broke PR 275. Sizing ep from $GPU_COUNT here gives ep=8 against
-    tp=2 — moe_tp_size 0.25, the crash the translation exists to prevent. We do not
-    guess a better number either: the portable flag exists because N must equal the
-    instance GPU count, and a template that pins its own tp already knows its shape
-    and can write --ep-size directly."""
+    tp=2 — moe_tp_size 0.25, the crash the translation exists to prevent. The operator
+    asked for expert parallelism, so they get it; it is the SIZE that has to follow
+    their pin rather than the host."""
     assert run("--tensor-parallel-size 2 --enable-expert-parallel", gpu_count="8") == \
-        "--tensor-parallel-size 2"
-    assert "add an explicit --ep-size" in \
+        "--tensor-parallel-size 2 --ep-size 2"
+    assert "matching the tensor-parallel size in effect" in \
         says("--tensor-parallel-size 2 --enable-expert-parallel", "8")
 
 
-def test_a_pinned_short_tp_declines_too():
-    assert run("--tp-size 2 --enable-expert-parallel", gpu_count="8") == "--tp-size 2"
+def test_ep_follows_a_pinned_short_tp_too():
+    assert run("--tp-size 2 --enable-expert-parallel", gpu_count="8") == \
+        "--tp-size 2 --ep-size 2"
 
 
 def test_an_explicit_ep_size_is_the_users_own_and_is_kept():
@@ -190,25 +192,26 @@ def test_the_negated_vllm_flag_is_not_treated_as_a_request():
     assert "--ep-size" not in run("--no-enable-expert-parallel", gpu_count="4")
 
 
-def test_no_ep_when_nothing_set_the_tp():
-    """AUTO_PARALLEL=false means NOTHING emits a tensor-parallel size, so sglang runs
-    at its own default of 1. Sizing ep from $GPU_COUNT here would give ep=4 against
-    tp=1 — moe_tp_size 0.25, the original crash with different numbers. At tp=1 there
-    is nothing to spread experts across and the honest output is no flag at all."""
-    assert run("--enable-expert-parallel", gpu_count="4", auto_parallel="false") == ""
-    assert "nothing to spread" in says("--enable-expert-parallel", "4", "false")
+def test_ep_is_one_when_nothing_set_the_tp():
+    """AUTO_PARALLEL=false means NOTHING emits a tensor-parallel size, so sglang runs at
+    its own default of 1. Sizing ep from $GPU_COUNT here would give ep=4 against tp=1 —
+    moe_tp_size 0.25, the original crash with different numbers. ep=1 is the only value
+    that divides, and it is emitted rather than omitted so the log says what happened."""
+    assert run("--enable-expert-parallel", gpu_count="4", auto_parallel="false") == \
+        "--ep-size 1"
 
 
-def test_no_ep_when_the_long_dp_spelling_suppressed_the_tp():
-    """Same hole by a different route: --data-parallel-size suppresses the automatic
-    tp, so tp is again sglang's default of 1 while $GPU_COUNT is 8."""
+def test_ep_is_one_when_the_long_dp_spelling_suppressed_the_tp():
+    """Same route, different flag: --data-parallel-size suppresses the automatic tp, so
+    tp is again sglang's default of 1 while $GPU_COUNT is 8. ep must follow the 1."""
     assert run("--data-parallel-size 2 --enable-expert-parallel", gpu_count="8") == \
-        "--data-parallel-size 2"
+        "--data-parallel-size 2 --ep-size 1"
 
 
-def test_a_pin_declines_with_auto_parallel_off_as_well():
+def test_ep_follows_the_pin_with_auto_parallel_off_as_well():
+    """AUTO_PARALLEL=false disclaims our guess at the tp, not the operator's own pin."""
     assert run("--tp-size 2 --enable-expert-parallel", gpu_count="8",
-               auto_parallel="false") == "--tp-size 2"
+               auto_parallel="false") == "--tp-size 2 --ep-size 2"
 
 
 def test_an_empty_gpu_count_cannot_produce_a_dangling_ep_size():
@@ -256,9 +259,7 @@ def test_a_tp_pinned_in_the_conf_file_is_seen(tmp_path):
     translation exists to prevent, arriving through the other documented channel.
     The conf is a pin like any other, so it declines."""
     assert run("--enable-expert-parallel", gpu_count="8",
-               conf="--tp-size 2", tmp=tmp_path) == "--tp-size 2"
-    assert "add an explicit --ep-size" in \
-        says("--enable-expert-parallel", "8", conf="--tp-size 2", tmp=tmp_path)
+               conf="--tp-size 2", tmp=tmp_path) == "--ep-size 2 --tp-size 2"
 
 
 def test_a_tp_pinned_in_the_conf_file_suppresses_the_automatic_one(tmp_path):
@@ -291,13 +292,12 @@ def test_a_missing_conf_file_changes_nothing():
 
 # ── abbreviations and negations ──────────────────────────────────────
 
-def test_an_abbreviated_tp_pin_is_recognised_as_a_pin():
+def test_an_abbreviated_tp_pin_is_recognised_and_its_value_used():
     """argparse resolves `--tensor-parallel 2` to the tp dest. Seeing only the full
     spellings meant appending our own $GPU_COUNT-sized tp after it, so the operator's
-    2 silently became 8 — the same two-values-for-one-setting defect in a new coat.
-    Recognition is all that is needed: the value is never read."""
+    2 silently became 8 — the same two-values-for-one-setting defect in a new coat."""
     assert run("--tensor-parallel 2 --enable-expert-parallel", gpu_count="8") == \
-        "--tensor-parallel 2"
+        "--tensor-parallel 2 --ep-size 2"
 
 
 def test_an_abbreviated_ep_pin_is_kept():


### PR DESCRIPTION
Follow-up to #281, and a correction to it.

#281 translated the portable flag **only** when the launcher had also chosen the
tensor-parallel size, and dropped it with a log line otherwise. So a template that pins
its own tp and passes `--enable-expert-parallel` got no expert parallelism at all —
which hands the operator exactly the load failure the translation exists to prevent:

```
(moe_intermediate_size=640 / moe_tp_size=4) % weight_block_size_n=128 != 0
```

Qwen3.8-Flash-Next-FP8 does not load without expert parallelism actually enabled, so
dropping the flag is the worst of the available outcomes.

**Asking for the flag is now enough — a size is always emitted**, and it is the
EFFECTIVE tensor-parallel size:

| config | emitted |
|---|---|
| no pin, auto on (8 GPU) | `--tensor-parallel-size 8 --ep-size 8` |
| `--tp-size 2` pinned (8 GPU) | `--tp-size 2 --ep-size 2` |
| `AUTO_PARALLEL=false`, no pin | `--ep-size 1` |
| tp pinned in `/etc/sglang-args.conf` | `--ep-size 2 --tp-size 2` |
| operator set their own `--ep-size` | theirs, untouched |
| `--enable-expert-parallel=False` | nothing — not requested |
| dp-attention recipe | `--enable-dp-attention --dp-size 8 --tensor-parallel-size 8 --ep-size 8` |

Sizing to the effective tp is what makes "always emit" safe rather than reckless:
sglang derives `moe_tp_size = tp_size / ep_size`, and `ep == tp` always divides. Sizing
from `$GPU_COUNT` instead is the defect this series started with — tp=2 pinned against
ep=8 is `moe_tp_size 0.25`, the same crash from the other side.

This restores the pinned-value read that an earlier commit in #281 cut back to a
boolean. The boolean was enough to decide *whether* to translate; it was never enough
to decide *what size*, and the size is the point.

Unchanged from #281: the operator's own `--ep-size` still wins, an attached false value
still means off, `/etc/sglang-args.conf` is still read, and the auto-parallel guard
still does **not** match `--dp-size` — widening it breaks `--enable-dp-attention`, which
asserts `tp % dp == 0`.

**Evidence:** 35 cases, verified to bite against five mutations — sizing from
`$GPU_COUNT`, falling back to `$GPU_COUNT` when nothing set the tp, reverting to
declining on a pin, re-widening the guard to dp, and un-reading the conf file.
`imagegen lint --all` baseline CLEAN.

This should land before the `qwen38flashnext` / `qwen38-flash-next` images are rebuilt,
or those images ship the dropping behaviour.