### PR TITLE
ci(llama-cpp): build every 12 hours, matching the engine images

### DIFF
--- a/.github/workflows/build-llama-cpp.yml
+++ b/.github/workflows/build-llama-cpp.yml
@@ -23,8 +23,17 @@ name: Build Llama.cpp Image
 
 on:
   schedule:
-    # Run weekly on Monday
-    - cron: '0 0 * * 1'
+    # Every 12 hours, matching the four engine images. This was WEEKLY, which was
+    # inherited from the ai-dock era and never revisited when ADR 0033 swapped the
+    # source: unslothai/llama.cpp publishes every one to three days (eight releases in
+    # the eleven days to 2026-09-08), so a Monday-only build picked up roughly one
+    # release in four to eight, and the tree sat on b10698 while upstream reached
+    # b10840.
+    #
+    # RELEASE_AGE_THRESHOLD below MUST track this cron. It is the window in which a
+    # release counts as new: set it shorter than the interval and genuine releases are
+    # skipped between runs, longer and the same release is rebuilt on consecutive runs.
+    - cron: '0 0,12 * * *'
 
   workflow_dispatch:
     inputs:
@@ -41,8 +50,8 @@ on:
 
 env:
   DEFAULT_DOCKERHUB_REPO: "llama-cpp"
-  # 7 days
-  RELEASE_AGE_THRESHOLD: 604800
+  # 12 hours — must equal the cron interval above; see the note there.
+  RELEASE_AGE_THRESHOLD: 43200
 
 jobs:
   preflight:


### PR DESCRIPTION
llama.cpp images stopped appearing. Two causes, one structural and one recent.

## The cadence was set for a different upstream

```
before:  cron '0 0 * * 1'      weekly     RELEASE_AGE_THRESHOLD 604800  (7d)
after:   cron '0 0,12 * * *'   12-hourly  RELEASE_AGE_THRESHOLD  43200  (12h)
```

Weekly was inherited from the ai-dock era and never revisited when ADR 0033 swapped the
source. `unslothai/llama.cpp` publishes every one to three days — eight releases in the
eleven days to 2026-09-08 — so a Monday-only build picked up roughly one release in four
to eight. The tree sat on `b10698` (2026-08-31) while upstream reached `b10840`.

The old pair was *internally* consistent (7 days / weekly), which is why nothing looked
broken. `RELEASE_AGE_THRESHOLD` moves with the cron, and the coupling is now stated
where both are set: it is the window in which a release counts as new, so a threshold
shorter than the interval skips genuine releases and a longer one rebuilds the same
release twice.

All four image workflows now agree at 12 hours / 43200.

## Why nobody noticed it stop

The last scheduled run was 2026-08-31. **Monday 2026-09-07 produced no run at all** —
not a failed one. The block-scalar parse error fixed in #282 landed on 09-02, and GitHub
silently stops scheduling a workflow it cannot parse.

Push-triggered runs that day still show up as failures, so the push path left evidence.
The cron path left none: no run, no failure, no alert. That is a stronger version of the
notification gap #282 already records — worth remembering that "no failing runs" and
"nothing is running" look identical from the Actions list.

## Verification

- Workflow parses; `imagegen lint --all` baseline CLEAN (L095, added in #282, is what
  gates the parse hazard above).
- A catch-up build was dispatched separately off `main` to pull the tree up to `b10840`;
  this PR only changes when the schedule fires.