### PR TITLE
Add GLiNER2 derivative image

### DIFF
--- a/derivatives/pytorch/derivatives/gliner/Dockerfile
+++ b/derivatives/pytorch/derivatives/gliner/Dockerfile
@@ -13,27 +13,37 @@ LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
 # Copy Supervisor configuration, startup scripts and the vendored server
 COPY ./ROOT /
 
+# Required or we will not build. The image tag is DERIVED from this version, so an
+# unpinned install would publish a tag that does not describe its own contents.
+ARG GLINER2_VERSION
+
 RUN \
     set -euo pipefail && \
+    [[ -n "${GLINER2_VERSION}" ]] || { echo "Must specify GLINER2_VERSION" && exit 1; } && \
     . /venv/main/bin/activate && \
-    # Record pre-install PyTorch version
-    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # Snapshot the base's torch ecosystem.
+    torch_versions_pre="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
     # gliner2's [local] extra carries torch, transformers, safetensors and peft.
     # Without it the library installs with no runtime at all and can load no model
     # -- the plain "gliner2" package moved those out of the default install in
     # 2.0.0. The base image is the source of truth for torch, so the assertion
     # below catches any attempt by the extra to move it.
+    #
+    # NOTE: this install DOWNGRADES huggingface-hub (1.30.0 -> 0.36.2 against the
+    # 2026-09-08 base), because transformers 4.57.6 caps it below 1.0. That is
+    # upstream's constraint, not a choice here, and the torch assertion does not
+    # cover it. GLiNER is the only consumer in this image, so nothing else depends
+    # on the newer hub API -- but it is stated rather than left to be discovered.
     uv pip install --no-cache-dir \
-        'gliner2[local]>=2.0.0' \
+        "gliner2[local]==${GLINER2_VERSION}" \
         protobuf \
         sentencepiece \
         'fastapi>=0.100.0' \
         'uvicorn>=0.23.0' \
         'pydantic>=2.0.0' && \
-    # Verify PyTorch version unchanged
-    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
-    [[ $torch_version_pre = $torch_version_post ]] || \
-        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+    # Verify torch ecosystem unchanged.
+    torch_versions_post="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
+    [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem version drift:"; diff <(echo "$torch_versions_pre") <(echo "$torch_versions_post"); exit 1; }
 
 # Defend against environment clashes when syncing to volume
 RUN \

--- a/derivatives/pytorch/derivatives/gliner/Dockerfile
+++ b/derivatives/pytorch/derivatives/gliner/Dockerfile
@@ -1,0 +1,41 @@
+# GLiNER2 is a pip library plus HuggingFace weights -- upstream (Fastino) publishes
+# no server and no Docker image, so unlike its siblings there is no repository to
+# clone. The FastAPI server is vendored in ROOT/opt/workspace-internal/gliner/.
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+
+FROM ${PYTORCH_BASE}
+
+# Maintainer details
+LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="GLiNER2 image (entity extraction API) suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
+
+# Copy Supervisor configuration, startup scripts and the vendored server
+COPY ./ROOT /
+
+RUN \
+    set -euo pipefail && \
+    . /venv/main/bin/activate && \
+    # Record pre-install PyTorch version
+    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # gliner2's [local] extra carries torch, transformers, safetensors and peft.
+    # Without it the library installs with no runtime at all and can load no model
+    # -- the plain "gliner2" package moved those out of the default install in
+    # 2.0.0. The base image is the source of truth for torch, so the assertion
+    # below catches any attempt by the extra to move it.
+    uv pip install --no-cache-dir \
+        'gliner2[local]>=2.0.0' \
+        protobuf \
+        sentencepiece \
+        'fastapi>=0.100.0' \
+        'uvicorn>=0.23.0' \
+        'pydantic>=2.0.0' && \
+    # Verify PyTorch version unchanged
+    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
+    [[ $torch_version_pre = $torch_version_post ]] || \
+        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+
+# Defend against environment clashes when syncing to volume
+RUN \
+    set -euo pipefail && \
+    env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/gliner/README.md
+++ b/derivatives/pytorch/derivatives/gliner/README.md
@@ -40,10 +40,20 @@ The FastAPI server is therefore vendored in this directory at `ROOT/opt/workspac
 | `WORKSPACE` | `/workspace` | Directory the server is synced to |
 | `GLINER_MODEL` | `fastino/gliner2.5-base-v1` | HuggingFace checkpoint to serve |
 | `GLINER_API_KEY` | *(unset)* | Bearer token. **If unset the API is unauthenticated** |
-| `GLINER_HOST` | `0.0.0.0` | Bind address |
-| `GLINER_PORT` | `8000` | Bind port |
+| `GLINER_HOST` | `127.0.0.1` | Bind address. Loopback by default — Caddy fronts it |
+| `GLINER_PORT` | `18000` | Bind port. The portal maps external `8000` to it |
 
 Set `HF_TOKEN` if HuggingFace rate-limits anonymous weight downloads.
+
+The server binds loopback and is reached through Caddy on `8000`, like every other
+service in these images. Do not point `GLINER_HOST` at `0.0.0.0` — that publishes the
+extraction endpoint directly, bypassing the proxy, and the instance test asserts
+against it.
+
+### Weights
+
+Weights are **not baked into the image**; they are downloaded on first boot, so the
+first start is slower than a restart and needs working HuggingFace egress.
 
 ## API
 
@@ -88,6 +98,19 @@ curl -X POST http://<IP>:<PORT>/extract \
 }
 ```
 
+## QA
+
+`templates/gliner-qa/` is the live-GPU gate template, exercised by `build-gliner.yml`.
+`ROOT/opt/instance-tools/tests/gliner.d/10-gliner-serving.sh` asserts the service is
+up, `/health` reports a **GPU** (not a silent CPU fallback), `/extract` returns real
+entities, a wrong bearer token gets a 401, and the listener is on loopback.
+
 ## Notes
 
-The DeBERTa-v3 encoder has no SDPA implementation in transformers, so the model runs with eager attention. This is expected and logged at startup as a `RuntimeWarning`; it is not an error.
+The DeBERTa-v3 encoder has no SDPA implementation in transformers, so the model runs
+with eager attention. This is expected and logged at startup as a `RuntimeWarning`; it
+is not an error.
+
+The dependency install downgrades `huggingface-hub` from the base image's version,
+because `transformers` caps it below 1.0. GLiNER is the only consumer in this image.
+The Dockerfile's assertion covers the torch ecosystem, not this.

--- a/derivatives/pytorch/derivatives/gliner/README.md
+++ b/derivatives/pytorch/derivatives/gliner/README.md
@@ -1,0 +1,93 @@
+# GLiNER2 Image
+
+A [GLiNER2](https://github.com/fastino-ai/GLiNER2) image derived from the Vast.ai [PyTorch image](../../README.md). GLiNER2 performs zero-shot entity extraction: entity types are supplied per-request, so no retraining is needed to extract a new type.
+
+This image ships a FastAPI server exposing the model over HTTP, managed as a Supervisor service, along with all features from the Vast.ai base image.
+
+For detailed documentation on Instance Portal, Supervisor, environment variables, and other features, see the [base image README](../../../../README.md).
+
+## Why the server is vendored
+
+Every sibling derivative clones an upstream application repository. GLiNER2 has none to clone: Fastino ships it as a pip library plus HuggingFace weights, and their own serving story is a commercial hosted API. There is no upstream Docker image and no upstream server.
+
+The FastAPI server is therefore vendored in this directory at `ROOT/opt/workspace-internal/gliner/server.py`, rather than cloned during the build.
+
+## Models
+
+`AutoExtractor` dispatches on the checkpoint architecture, so `GLINER_MODEL` accepts both GLiNER 2.5 and GLiNER 2.0 checkpoints.
+
+| Model | Params | Notes |
+|-------|--------|-------|
+| `fastino/gliner2.5-small-v1` | 73.9M | Smallest |
+| `fastino/gliner2.5-base-v1` | 193.6M | **Default** |
+| `fastino/gliner2.5-multi-v1` | 287.4M | Multilingual |
+| `fastino/gliner2-base-v1` | 205M | Previous generation; loads via `SpanExtractor` |
+
+2.5 checkpoints are self-contained. The 2.0 checkpoint declares an external encoder and pulls a second repository at load time, so it is slower to start.
+
+## Configuration
+
+### Services
+
+| Service | Description |
+|---------|-------------|
+| `gliner` | FastAPI server (`python server.py`) |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE` | `/workspace` | Directory the server is synced to |
+| `GLINER_MODEL` | `fastino/gliner2.5-base-v1` | HuggingFace checkpoint to serve |
+| `GLINER_API_KEY` | *(unset)* | Bearer token. **If unset the API is unauthenticated** |
+| `GLINER_HOST` | `0.0.0.0` | Bind address |
+| `GLINER_PORT` | `8000` | Bind port |
+
+Set `HF_TOKEN` if HuggingFace rate-limits anonymous weight downloads.
+
+## API
+
+### `GET /health`
+
+```json
+{
+  "status": "running",
+  "model": "fastino/gliner2.5-base-v1",
+  "device": "cuda:0",
+  "gpu_available": true,
+  "gpu_name": "NVIDIA GeForce RTX 3090"
+}
+```
+
+### `POST /extract`
+
+Requires `Authorization: Bearer <GLINER_API_KEY>` when the key is set.
+
+```bash
+curl -X POST http://<IP>:<PORT>/extract \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GLINER_API_KEY" \
+  -d '{
+    "text": "Apple CEO Tim Cook announced iPhone 15 in Cupertino for $999.",
+    "labels": ["person", "company", "product", "location", "price"],
+    "threshold": 0.3
+  }'
+```
+
+```json
+{
+  "entities": {
+    "person": ["Tim Cook"],
+    "company": ["Apple"],
+    "product": ["iPhone 15"],
+    "location": ["Cupertino"],
+    "price": ["$999"]
+  },
+  "inference_time": 0.0167,
+  "device": "cuda:0"
+}
+```
+
+## Notes
+
+The DeBERTa-v3 encoder has no SDPA implementation in transformers, so the model runs with eager attention. This is expected and logged at startup as a `RuntimeWarning`; it is not an error.

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/supervisor/conf.d/gliner.conf
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/supervisor/conf.d/gliner.conf
@@ -1,0 +1,17 @@
+[program:gliner]
+environment=PROC_NAME="%(program_name)s"
+command=/opt/supervisor-scripts/gliner.sh
+autostart=true
+autorestart=unexpected
+exitcodes=0
+startsecs=0
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
+stopwaitsecs=10
+# This is necessary for Vast logging to work alongside the Portal logs (Must output to /dev/stdout)
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+stdout_events_enabled=true
+stdout_logfile_maxbytes=0
+stdout_logfile_backups=0

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_capabilities.d/50-gliner.yaml
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_capabilities.d/50-gliner.yaml
@@ -1,0 +1,5 @@
+# GLiNER derivative — image identity (overrides the base image block).
+image:
+  name: GLiNER2
+  readme: https://github.com/vast-ai/base-image/tree/main/derivatives/pytorch/derivatives/gliner
+  preinstalled: PyTorch + GLiNER2 (zero-shot entity extraction)

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/instance-tools/tests/gliner.d/10-gliner-serving.sh
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/instance-tools/tests/gliner.d/10-gliner-serving.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Test: the GLiNER API serves real inference on the GPU.
+#
+# A green `docker build` cannot see any of the properties below: the model is
+# downloaded at first boot, not baked, so "the image built" and "the API answers"
+# are separated by a HuggingFace fetch that can stall or 401.
+# TEST_TIMEOUT=900
+source "$(dirname "$0")/../lib.sh"
+
+GLINER_INTERNAL_PORT=18000        # gliner.sh binds this on localhost
+GLINER_LOG="/var/log/portal/gliner.log"
+API_KEY="${GLINER_API_KEY:-gliner-qa-key}"
+
+# ── The service ──────────────────────────────────────────────────────
+# Readiness through the supervisord SOCKET, never `pgrep`: presence is satisfied the
+# instant supervisord forks, and the gap to usable is a model download here (L069).
+assert_service_running gliner
+
+# ── The listener ─────────────────────────────────────────────────────
+# First boot downloads ~774MB of weights before uvicorn binds, so this is slow.
+if ! wait_for_port "${GLINER_INTERNAL_PORT}" "${GLINER_READY_TIMEOUT:-600}"; then
+    [[ -f "${GLINER_LOG}" ]] && tail -40 "${GLINER_LOG}"
+    test_fail "GLiNER is not listening on ${GLINER_INTERNAL_PORT} after ${GLINER_READY_TIMEOUT:-600}s"
+fi
+echo "  gliner: port ${GLINER_INTERNAL_PORT} listening"
+
+# ── It reports a GPU ─────────────────────────────────────────────────
+# The whole point of the image. The server falls back to CPU when torch cannot see a
+# device and still serves correctly, so a CPU regression is invisible to any check that
+# only asks whether the API answers -- this is the ADR 0016 failure class.
+_health=$(curl -s --max-time "${HTTP_CHECK_MAX_TIME:-20}" \
+          "http://127.0.0.1:${GLINER_INTERNAL_PORT}/health" 2>/dev/null)
+[[ -n "${_health}" ]] || test_fail "GLiNER /health returned nothing (connection failed)"
+
+echo "${_health}" | grep -q '"gpu_available":true' || {
+    echo "  health: ${_health}"
+    test_fail "GLiNER reports gpu_available=false -- the model fell back to CPU"
+}
+echo "  gliner: /health reports GPU ($(echo "${_health}" | sed -n 's/.*"gpu_name":"\([^"]*\)".*/\1/p'))"
+
+# ── It extracts ──────────────────────────────────────────────────────
+# Assert on a returned entity, not on HTTP 200. The endpoint returns 200 with an empty
+# entity map when the model loads but scores nothing, which is a real regression class
+# and indistinguishable from success at the status-code level.
+_out=$(curl -s --max-time "${HTTP_CHECK_MAX_TIME:-60}" \
+       -X POST "http://127.0.0.1:${GLINER_INTERNAL_PORT}/extract" \
+       -H "Content-Type: application/json" \
+       -H "Authorization: Bearer ${API_KEY}" \
+       -d '{"text":"Apple CEO Tim Cook announced iPhone 15 in Cupertino for $999.","labels":["person","company","product","location","price"],"threshold":0.3}' 2>/dev/null)
+
+echo "${_out}" | grep -q '"Tim Cook"' || {
+    echo "  response: ${_out}"
+    test_fail "GLiNER /extract did not return the expected person entity"
+}
+echo "  gliner: /extract returned the expected entities"
+
+# ── Auth is enforced ─────────────────────────────────────────────────
+# The server leaves the API OPEN when GLINER_API_KEY is unset. A regression that
+# dropped the key would publish an unauthenticated extraction endpoint, so assert the
+# rejection rather than trusting the template to have set it.
+_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "${HTTP_CHECK_MAX_TIME:-20}" \
+        -X POST "http://127.0.0.1:${GLINER_INTERNAL_PORT}/extract" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer definitely-not-the-key" \
+        -d '{"text":"x","labels":["person"]}' 2>/dev/null)
+_code="${_code:-000}"
+case "${_code}" in
+    401) echo "  gliner: rejects a wrong bearer token (401)" ;;
+    000) test_fail "GLiNER did not answer the auth probe (connection failed)" ;;
+    *)   fail_later "gliner-auth" "GLiNER answered a WRONG bearer token with ${_code}, not 401 -- the endpoint is unauthenticated" ;;
+esac
+
+# ── The bind is loopback ─────────────────────────────────────────────
+# This endpoint has a bearer token but must still sit behind Caddy like everything
+# else. `ss` reports the LISTENER, which is the only thing that matters -- a template
+# port entry is not what exposes it.
+# listener_is_public lives in BASE's lib.sh and is inherited from the pinned pytorch
+# base, not this repo. Without this guard a missing function returns 127, `if` takes
+# the ELSE branch, and the check PASSES having tested nothing.
+declare -F listener_is_public >/dev/null 2>&1 || \
+    test_fail "this image's lib.sh predates listener_is_public -- the bind check cannot run; rebuild base + pytorch and bump this image's PYTORCH_BASE pin"
+
+if listener_is_public "${GLINER_INTERNAL_PORT}"; then
+    listener_local_addr "${GLINER_INTERNAL_PORT}"
+    fail_later "gliner-bind" "GLiNER is bound to a PUBLIC interface on ${GLINER_INTERNAL_PORT}, not loopback"
+else
+    echo "  gliner: bound to loopback ($(listener_local_addr "${GLINER_INTERNAL_PORT}"))"
+fi
+
+test_pass

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/supervisor-scripts/gliner.sh
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/supervisor-scripts/gliner.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+utils=/opt/supervisor-scripts/utils
+. "${utils}/logging.sh"
+. "${utils}/cleanup_generic.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh" "GLiNER API"
+
+echo "Starting GLiNER API"
+
+. /venv/main/bin/activate
+
+# Wait for provisioning to complete
+while [ -f "/.provisioning" ]; do
+    echo "$PROC_NAME startup paused until instance provisioning has completed (/.provisioning present)"
+    sleep 10
+done
+
+cd "${WORKSPACE}/gliner"
+
+pty python server.py 2>&1

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
@@ -1,0 +1,153 @@
+"""
+GLiNER2 FastAPI Server - entity extraction API with Bearer token authentication.
+
+Environment Variables:
+    GLINER_API_KEY: API key for authentication (unsecured if unset)
+    GLINER_MODEL:   Model to use (default: fastino/gliner2.5-base-v1)
+    GLINER_HOST:    Bind address (default: 0.0.0.0)
+    GLINER_PORT:    Bind port (default: 8000)
+"""
+
+import os
+import time
+from typing import Dict, List, Optional
+
+import torch
+import uvicorn
+from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from gliner2 import AutoExtractor
+from pydantic import BaseModel
+
+# Configuration
+MODEL_NAME = os.environ.get("GLINER_MODEL", "fastino/gliner2.5-base-v1")
+API_KEY = os.environ.get("GLINER_API_KEY")
+HOST = os.environ.get("GLINER_HOST", "0.0.0.0")
+PORT = int(os.environ.get("GLINER_PORT", "8000"))
+
+app = FastAPI(
+    title="GLiNER2 API",
+    description="GPU-accelerated zero-shot entity extraction with GLiNER2",
+    version="2.5.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+security = HTTPBearer()
+
+if not API_KEY:
+    print("WARNING: GLINER_API_KEY not set. API will be unsecured!")
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Security(security)):
+    """Verify the Bearer token"""
+    if not API_KEY:
+        return True
+    if credentials.credentials != API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return True
+
+
+# Global model state
+model = None
+device = None
+
+
+class ExtractRequest(BaseModel):
+    text: str
+    labels: List[str]
+    threshold: Optional[float] = 0.3
+
+
+class ExtractResponse(BaseModel):
+    entities: Dict[str, List[str]]
+    inference_time: float
+    device: str
+
+
+class HealthResponse(BaseModel):
+    status: str
+    model: str
+    device: str
+    gpu_available: bool
+    gpu_name: Optional[str] = None
+
+
+@app.on_event("startup")
+async def load_model():
+    """Load the GLiNER2 model on startup.
+
+    AutoExtractor dispatches on the checkpoint's architecture: a 2.5 checkpoint
+    yields a BoundaryExtractor, a 2.0 checkpoint a SpanExtractor. Both are
+    nn.Module, so .to()/.eval() apply to either, and users pinning GLINER_MODEL
+    to a 2.0 checkpoint keep working.
+    """
+    global model, device
+
+    print(f"Loading GLiNER2 model: {MODEL_NAME}")
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+
+    model = AutoExtractor.from_pretrained(MODEL_NAME)
+    model = model.to(device)
+    model.eval()
+
+    print(f"Model loaded on {device} ({type(model).__name__})")
+    if torch.cuda.is_available():
+        gpu_name = torch.cuda.get_device_name(0)
+        gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1e9
+        print(f"GPU: {gpu_name} ({gpu_memory:.1f} GB)")
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health():
+    """Health check endpoint"""
+    gpu_name = torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+    return HealthResponse(
+        status="running",
+        model=MODEL_NAME,
+        device=device,
+        gpu_available=torch.cuda.is_available(),
+        gpu_name=gpu_name,
+    )
+
+
+@app.get("/", response_model=HealthResponse)
+async def root():
+    """Alias for the health check"""
+    return await health()
+
+
+@app.post("/extract", response_model=ExtractResponse)
+async def extract_entities(
+    request: ExtractRequest,
+    authorized: bool = Depends(verify_token),
+):
+    """Extract entities from text. Requires Bearer token authentication."""
+    try:
+        start_time = time.time()
+        result = model.extract_entities(
+            request.text,
+            request.labels,
+            threshold=request.threshold,
+        )
+        inference_time = time.time() - start_time
+
+        return ExtractResponse(
+            entities=result.get("entities", {}),
+            inference_time=inference_time,
+            device=device,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT, log_level="info")

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
@@ -4,8 +4,8 @@ GLiNER2 FastAPI Server - entity extraction API with Bearer token authentication.
 Environment Variables:
     GLINER_API_KEY: API key for authentication (unsecured if unset)
     GLINER_MODEL:   Model to use (default: fastino/gliner2.5-base-v1)
-    GLINER_HOST:    Bind address (default: 0.0.0.0)
-    GLINER_PORT:    Bind port (default: 8000)
+    GLINER_HOST:    Bind address (default: 127.0.0.1 -- Caddy fronts it)
+    GLINER_PORT:    Bind port (default: 18000 -- portal maps 8000 to it)
 """
 
 import os
@@ -23,8 +23,8 @@ from pydantic import BaseModel
 # Configuration
 MODEL_NAME = os.environ.get("GLINER_MODEL", "fastino/gliner2.5-base-v1")
 API_KEY = os.environ.get("GLINER_API_KEY")
-HOST = os.environ.get("GLINER_HOST", "0.0.0.0")
-PORT = int(os.environ.get("GLINER_PORT", "8000"))
+HOST = os.environ.get("GLINER_HOST", "127.0.0.1")
+PORT = int(os.environ.get("GLINER_PORT", "18000"))
 
 app = FastAPI(
     title="GLiNER2 API",

--- a/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
+++ b/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
@@ -1,0 +1,53 @@
+# GLiNER QA template (ADR 0005 live-GPU QA gate).
+#
+# Mirrors the production launch path — runtype jupyter, Instance Portal, the API
+# fronted on 8000 — because the point is to exercise what a customer gets.
+#
+# GLINER_API_KEY is set here deliberately. The server leaves the API unauthenticated
+# when it is unset, so a gate that omitted it would never exercise the auth path and
+# a regression that dropped the 401 would promote green.
+name: "GLiNER QA — entity extraction serving smoke"
+image: vastai/gliner
+tag: latest                       # CI overrides with the staging tag
+private: true
+readme_visible: false
+onstart: entrypoint.sh
+runtype: jupyter                  # production launch mode
+jup_direct: true
+ssh_direct: true
+use_ssh: true
+use_jupyter_lab: false
+ports:
+  - "1111:1111"                   # Instance Portal
+  - "8080:8080"                   # Jupyter
+  - "8000:8000"                   # GLiNER API (Caddy front; the server binds 18000)
+env:
+  OPEN_BUTTON_PORT: "1111"
+  OPEN_BUTTON_TOKEN: "1"
+  JUPYTER_DIR: "/"
+  DATA_DIRECTORY: "/workspace/"
+  GLINER_API_KEY: "gliner-qa-key"
+  PORTAL_CONFIG: "localhost:1111:11111:/:Instance Portal|localhost:8000:18000:/docs:GLiNER API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+  # Required-pass gate (ADR 0019). The GPU trio self-skips when nvidia-smi or libcuda
+  # never came up, so without naming them a GPU-less draw would report the suite green
+  # and promote an image whose entire purpose is GPU inference.
+  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries gliner.d/10-gliner-serving"
+# QA gate floors (ADR 0005): smallest viable box that still exercises the real path.
+extra_filters:
+  compute_cap:
+    gte: 750                      # DeBERTa-v3 encoder; no SASS floor above Turing
+  cuda_max_good:
+    gte: 12.9                     # matches the cu128 torch in the base
+  # gliner2.5-base is ~774MB of F32 weights and uses under 1.2GB of VRAM in practice.
+  # The floor is headroom for the CUDA context, not model size.
+  gpu_ram:
+    gte: 8192
+  reliability2:
+    gte: 0.95                     # excludes the flaky tail; see templates/base-qa
+  inet_down:
+    gte: 500                      # Mbps — bounds the image pull inside the launch window
+  direct_port_count:
+    gte: 64                       # see templates/base-qa for the measurement
+  disk_space:
+    gte: 40                       # L058: must match recommended_disk_space or the rent fails late
+recommended_disk_space: 40.0      # pytorch base + gliner2 deps + downloaded weights


### PR DESCRIPTION
Adds GLiNER2 as a pytorch derivative: `derivatives/pytorch/derivatives/gliner/`, serving a FastAPI entity-extraction endpoint under Supervisor, with a live-GPU QA gate.

GLiNER2 does zero-shot entity extraction — entity types are supplied per request, so a new type needs no retraining. Weights and library are Apache-2.0.

**Draft for one reason: `.github/workflows/build-gliner.yml` is missing.** It is written and ready, but the token available to me lacks GitHub's `workflow` scope, so it could not be pushed. Everything it depends on is here. See the last section.

## Why the server is vendored

Every sibling derivative clones an upstream app repo. GLiNER2 has none to clone. Fastino ships it as a pip library plus HuggingFace weights; there is no upstream Docker image, no Dockerfile anywhere in the `fastino-ai` org, and their own serving story is a commercial hosted API. So the FastAPI server is vendored at `ROOT/opt/workspace-internal/gliner/server.py` instead of cloned at build time.

Flagging it since it departs from the pattern — if you'd rather it came from a repo you control, say where and I'll move it.

## The `[local]` extra is deliberate

`gliner2` 2.0.0 moved torch, transformers, safetensors and peft **out** of the default install and into a `[local]` extra. Installing plain `gliner2` yields a library with no runtime that can load no model at all.

The base stays the source of truth for torch and the pre/post assertion covers it. **One thing the assertion does not cover:** this install downgrades `huggingface-hub` (1.30.0 → 0.36.2 against the 2026-09-08 base), because `transformers` 4.57.6 caps it below 1.0. That is upstream's constraint rather than a choice here, and GLiNER is the only consumer in this image — but it is stated in the Dockerfile rather than left to be discovered.

`protobuf` and `sentencepiece` are required by the DeBERTa-v3 tokenizer path and are not pulled in transitively.

## Checkpoint compatibility

`AutoExtractor` dispatches on checkpoint architecture, so `GLINER_MODEL` takes both generations — 2.5 yields a `BoundaryExtractor`, 2.0 a `SpanExtractor`. Both are `nn.Module`. Default is `fastino/gliner2.5-base-v1`.

## QA gate

`templates/gliner-qa/template.yml` plus `gliner.d/10-gliner-serving.sh`, wired advisory per the ADR 0006 ramp, matching how unsloth-studio introduced its gate.

A green `docker build` cannot see this image's two main failure modes: weights are downloaded at **first boot** rather than baked, and the server falls back to CPU and still answers correctly when torch sees no device. So "the model never downloaded" and "it is serving on CPU" both look like a successful build. The test asserts `gpu_available` is true, that `/extract` returns real entities rather than a 200 with an empty map, that a wrong bearer token gets a 401, and that the listener is on loopback.

## Verification

Built and run on amd64 (RTX 3090, Docker 28.1.1), cold with no HF cache mount:

| Check | Result |
| -- | -- |
| Build on `vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08` | passes, 13.3 GB |
| torch ecosystem assertion | holds — base torch untouched |
| `GLINER2_VERSION` omitted | fails with `Must specify GLINER2_VERSION` |
| `GET /health` | 200, `cuda:0`, GPU reported |
| `POST /extract` | 200 — `person: Tim Cook`, `company: Apple`, `product: iPhone 15`, `location: Cupertino`, `price: $999` |
| Wrong bearer token | 401 |
| 2.0 checkpoint | dispatches to `SpanExtractor`, extracts correctly |
| Warm inference | 16.7 ms median, n=10 |

**Caveat:** the endpoint results above were measured against a `pytorch/pytorch:2.4.0` build of the same server and dependency set. The `vastai/pytorch` image here is confirmed to **build**, but its endpoints have not been exercised — that is exactly what the QA gate is for, and it needs the workflow to run.

## The missing workflow

`build-gliner.yml` is written, YAML-valid, and modelled on `build-unsloth-studio.yml`. One thing in it is not a copy:

**Release detection is PyPI, not a GitHub repo.** Every sibling watches an upstream repository for release tags. GLiNER has none. So it uses this repo's own `check-pypi-release` against the `gliner2` package, with `version-pattern` excluding pre-releases — gliner2 published 1.3.x betas alongside stable 1.2.x, so an unfiltered resolver could pick a pre-release as latest.

The **model** is deliberately not part of the trigger: weights are fetched at first boot and chosen per-instance via `GLINER_MODEL`, so a new checkpoint on HuggingFace does not change this image and must not rebuild it.

Both arches are in the matrix — every dependency added on top of the base publishes aarch64 wheels, and torch comes from the base.

Tell me how you want it delivered: I can paste the file in a comment, or it can be pushed by anyone whose token carries `workflow` scope.

## Open question

`vastai/gliner2-server` already exists on Docker Hub (475 pulls, last pushed 2025-12-31) as a standalone non-derivative image. Should this land as `vastai/gliner`, or a new tag on the existing repo? That sets `DEFAULT_DOCKERHUB_REPO` in the workflow.