### PR TITLE
Add GLiNER2 derivative image

### DIFF
--- a/derivatives/pytorch/derivatives/gliner/Dockerfile
+++ b/derivatives/pytorch/derivatives/gliner/Dockerfile
@@ -13,27 +13,32 @@ LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
 # Copy Supervisor configuration, startup scripts and the vendored server
 COPY ./ROOT /
 
+# Siblings pin the app to a git ref they clone; this one has nothing to clone, so
+# the PyPI version is the equivalent pin. Defaulted rather than required because
+# there is no build workflow to supply it -- a bare ARG would make the directory
+# unbuildable by hand. 2.0.0 is the version validated against the 2.5 checkpoints.
+ARG GLINER2_VERSION=2.0.0
+
 RUN \
     set -euo pipefail && \
     . /venv/main/bin/activate && \
-    # Record pre-install PyTorch version
-    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # Snapshot the base's full torch ecosystem (torch + torchvision + torchaudio + torchcodec).
+    torch_versions_pre="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
     # gliner2's [local] extra carries torch, transformers, safetensors and peft.
     # Without it the library installs with no runtime at all and can load no model
     # -- the plain "gliner2" package moved those out of the default install in
     # 2.0.0. The base image is the source of truth for torch, so the assertion
     # below catches any attempt by the extra to move it.
     uv pip install --no-cache-dir \
-        'gliner2[local]>=2.0.0' \
+        "gliner2[local]==${GLINER2_VERSION}" \
         protobuf \
         sentencepiece \
         'fastapi>=0.100.0' \
         'uvicorn>=0.23.0' \
         'pydantic>=2.0.0' && \
-    # Verify PyTorch version unchanged
-    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
-    [[ $torch_version_pre = $torch_version_post ]] || \
-        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+    # Verify torch ecosystem unchanged.
+    torch_versions_post="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
+    [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem version drift:"; diff <(echo "$torch_versions_pre") <(echo "$torch_versions_post"); exit 1; }
 
 # Defend against environment clashes when syncing to volume
 RUN \

--- a/derivatives/pytorch/derivatives/gliner/Dockerfile
+++ b/derivatives/pytorch/derivatives/gliner/Dockerfile
@@ -1,0 +1,41 @@
+# GLiNER2 is a pip library plus HuggingFace weights -- upstream (Fastino) publishes
+# no server and no Docker image, so unlike its siblings there is no repository to
+# clone. The FastAPI server is vendored in ROOT/opt/workspace-internal/gliner/.
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+
+FROM ${PYTORCH_BASE}
+
+# Maintainer details
+LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="GLiNER2 image (entity extraction API) suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
+
+# Copy Supervisor configuration, startup scripts and the vendored server
+COPY ./ROOT /
+
+RUN \
+    set -euo pipefail && \
+    . /venv/main/bin/activate && \
+    # Record pre-install PyTorch version
+    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # gliner2's [local] extra carries torch, transformers, safetensors and peft.
+    # Without it the library installs with no runtime at all and can load no model
+    # -- the plain "gliner2" package moved those out of the default install in
+    # 2.0.0. The base image is the source of truth for torch, so the assertion
+    # below catches any attempt by the extra to move it.
+    uv pip install --no-cache-dir \
+        'gliner2[local]>=2.0.0' \
+        protobuf \
+        sentencepiece \
+        'fastapi>=0.100.0' \
+        'uvicorn>=0.23.0' \
+        'pydantic>=2.0.0' && \
+    # Verify PyTorch version unchanged
+    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
+    [[ $torch_version_pre = $torch_version_post ]] || \
+        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+
+# Defend against environment clashes when syncing to volume
+RUN \
+    set -euo pipefail && \
+    env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/gliner/README.md
+++ b/derivatives/pytorch/derivatives/gliner/README.md
@@ -1,0 +1,93 @@
+# GLiNER2 Image
+
+A [GLiNER2](https://github.com/fastino-ai/GLiNER2) image derived from the Vast.ai [PyTorch image](../../README.md). GLiNER2 performs zero-shot entity extraction: entity types are supplied per-request, so no retraining is needed to extract a new type.
+
+This image ships a FastAPI server exposing the model over HTTP, managed as a Supervisor service, along with all features from the Vast.ai base image.
+
+For detailed documentation on Instance Portal, Supervisor, environment variables, and other features, see the [base image README](../../../../README.md).
+
+## Why the server is vendored
+
+Every sibling derivative clones an upstream application repository. GLiNER2 has none to clone: Fastino ships it as a pip library plus HuggingFace weights, and their own serving story is a commercial hosted API. There is no upstream Docker image and no upstream server.
+
+The FastAPI server is therefore vendored in this directory at `ROOT/opt/workspace-internal/gliner/server.py`, rather than cloned during the build.
+
+## Models
+
+`AutoExtractor` dispatches on the checkpoint architecture, so `GLINER_MODEL` accepts both GLiNER 2.5 and GLiNER 2.0 checkpoints.
+
+| Model | Params | Notes |
+|-------|--------|-------|
+| `fastino/gliner2.5-small-v1` | 73.9M | Smallest |
+| `fastino/gliner2.5-base-v1` | 193.6M | **Default** |
+| `fastino/gliner2.5-multi-v1` | 287.4M | Multilingual |
+| `fastino/gliner2-base-v1` | 205M | Previous generation; loads via `SpanExtractor` |
+
+2.5 checkpoints are self-contained. The 2.0 checkpoint declares an external encoder and pulls a second repository at load time, so it is slower to start.
+
+## Configuration
+
+### Services
+
+| Service | Description |
+|---------|-------------|
+| `gliner` | FastAPI server (`python server.py`) |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE` | `/workspace` | Directory the server is synced to |
+| `GLINER_MODEL` | `fastino/gliner2.5-base-v1` | HuggingFace checkpoint to serve |
+| `GLINER_API_KEY` | *(unset)* | Bearer token. **If unset the API is unauthenticated** |
+| `GLINER_HOST` | `0.0.0.0` | Bind address |
+| `GLINER_PORT` | `8000` | Bind port |
+
+Set `HF_TOKEN` if HuggingFace rate-limits anonymous weight downloads.
+
+## API
+
+### `GET /health`
+
+```json
+{
+  "status": "running",
+  "model": "fastino/gliner2.5-base-v1",
+  "device": "cuda:0",
+  "gpu_available": true,
+  "gpu_name": "NVIDIA GeForce RTX 3090"
+}
+```
+
+### `POST /extract`
+
+Requires `Authorization: Bearer <GLINER_API_KEY>` when the key is set.
+
+```bash
+curl -X POST http://<IP>:<PORT>/extract \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GLINER_API_KEY" \
+  -d '{
+    "text": "Apple CEO Tim Cook announced iPhone 15 in Cupertino for $999.",
+    "labels": ["person", "company", "product", "location", "price"],
+    "threshold": 0.3
+  }'
+```
+
+```json
+{
+  "entities": {
+    "person": ["Tim Cook"],
+    "company": ["Apple"],
+    "product": ["iPhone 15"],
+    "location": ["Cupertino"],
+    "price": ["$999"]
+  },
+  "inference_time": 0.0167,
+  "device": "cuda:0"
+}
+```
+
+## Notes
+
+The DeBERTa-v3 encoder has no SDPA implementation in transformers, so the model runs with eager attention. This is expected and logged at startup as a `RuntimeWarning`; it is not an error.

--- a/derivatives/pytorch/derivatives/gliner/ROOT/LICENSES.md
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/LICENSES.md
@@ -1,0 +1,44 @@
+# Third-Party Licenses
+
+This image bundles the following vendor application(s). Each is the property of
+its respective authors and is distributed under the license shown below. Where
+the vendor's source or LICENSE file is shipped inside this image at a known
+location, the path is given. Otherwise, the upstream repository is referenced
+as the canonical source for the license text.
+
+## PyTorch
+
+- **License:** BSD-3-Clause
+- **Upstream:** https://github.com/pytorch/pytorch
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/torch-*.dist-info/LICENSE`
+
+## GLiNER2
+
+- **License:** Apache-2.0
+- **Upstream:** https://github.com/fastino-ai/GLiNER2
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/gliner2-*.dist-info/LICENSE`
+
+## Transformers
+
+- **License:** Apache-2.0
+- **Upstream:** https://github.com/huggingface/transformers
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/transformers-*.dist-info/LICENSE`
+- **Note:** Installed as part of the `gliner2[local]` extra; it supplies the
+  DeBERTa-v3 encoder runtime every GLiNER2 checkpoint loads.
+
+## GLiNER2 model weights
+
+The server downloads checkpoints from the Hugging Face Hub at runtime
+(`GLINER_MODEL`, default `fastino/gliner2.5-base-v1`). Weights are **not** baked
+into this image and carry their own licenses, declared per-repository on the Hub.
+Check the license of any checkpoint you point `GLINER_MODEL` at before
+redistributing its outputs.
+
+## Server
+
+The FastAPI server at `ROOT/opt/workspace-internal/gliner/server.py` is part of
+this repository, not a vendored third-party application. Upstream ships no
+server to clone.

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/supervisor/conf.d/gliner.conf
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/supervisor/conf.d/gliner.conf
@@ -1,0 +1,17 @@
+[program:gliner]
+environment=PROC_NAME="%(program_name)s"
+command=/opt/supervisor-scripts/gliner.sh
+autostart=true
+autorestart=unexpected
+exitcodes=0
+startsecs=0
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
+stopwaitsecs=10
+# This is necessary for Vast logging to work alongside the Portal logs (Must output to /dev/stdout)
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+stdout_events_enabled=true
+stdout_logfile_maxbytes=0
+stdout_logfile_backups=0

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_agents/gliner.md
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_agents/gliner.md
@@ -1,0 +1,69 @@
+## GLiNER2 (this image)
+
+The PyTorch image plus a preinstalled **GLiNER2** (upstream `fastino-ai/GLiNER2`) for
+zero-shot entity extraction. Everything in base.md and pytorch.md applies unchanged
+(torch is in `/venv/main`); this file covers what GLiNER adds. **One** service — get its
+externally callable URL + token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # direct_url + state
+```
+
+### gliner — programmatic entity extraction
+
+A **FastAPI** server (`python server.py`), supervisor service **`gliner`**, internal
+`0.0.0.0:8000`. This is the only service in the image.
+
+**It is NOT OpenAI-compatible — do not call `/v1/chat/completions` or any `/v1/...`
+route.** The extraction endpoint is **`POST /extract`**. The full schema is the source
+of truth at **`/docs`** (the OpenAPI page on the same port).
+
+**The label contract is the thing to get right.** GLiNER is *zero-shot*: the entity types
+are not baked into the model and there is no default set. You pass them per request in
+**`labels`**, a required list of strings, and you get back only those types. Inventing a
+new type needs no retraining — just a different `labels` value.
+
+```
+curl -X POST http://<host>:8000/extract \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${GLINER_API_KEY}" \
+  -d '{"text": "Apple CEO Tim Cook announced iPhone 15 in Cupertino for $999.",
+       "labels": ["person", "company", "product", "location", "price"],
+       "threshold": 0.3}'
+```
+
+Response is `{"entities": {<label>: [<string>, ...]}, "inference_time": <float>,
+"device": "<device>"}`. **Every label you request comes back as a key**, and a label that
+matched nothing is an **empty list** rather than a missing key — so test
+`if not entities["price"]`, not `if "price" in entities`. An unknown or nonsensical label
+is not an error either; it simply returns `[]`. `threshold` (default `0.3`) trades recall
+for precision; lower it if short or unusual spans are being missed.
+
+### Auth
+
+`Authorization: Bearer $GLINER_API_KEY`, enforced on `/extract` only. **If
+`GLINER_API_KEY` is unset the API is completely unauthenticated** — the server prints a
+warning at startup and accepts every request. `/health` and `/` are never authenticated.
+
+### Models & provisioning
+
+Runs from `${WORKSPACE}/gliner` in `/venv/main`. The checkpoint is selected by
+**`GLINER_MODEL`** (default `fastino/gliner2.5-base-v1`); `AutoExtractor` dispatches on
+the checkpoint's architecture, so 2.5 checkpoints load as `BoundaryExtractor` and 2.0
+checkpoints as `SpanExtractor` — both work, and pinning `GLINER_MODEL` to a 2.0
+checkpoint is supported. A 2.0 checkpoint declares an external encoder and pulls a
+**second** repository at load time, so it starts noticeably slower than a 2.5 one.
+
+**Weights download on first startup**, so the first boot is slow — that is expected, not
+a hang. Set `HF_TOKEN` if the Hub rate-limits anonymous downloads. The service **waits
+for provisioning (`/.provisioning`) to finish before starting**, so during boot it may be
+intentionally down — check that flag before assuming a fault.
+
+### Two things that look like faults and are not
+
+- At startup the DeBERTa-v3 encoder logs a `RuntimeWarning` that it rejected
+  `attn_implementation='sdpa'` and fell back to `'eager'`. transformers has no SDPA path
+  for this architecture. Expected; not an error.
+- If the model **failed** to load, `GET /health` does not report unhealthy — it raises a
+  500 from a response-validation error, because `device` is still unset. A 500 from
+  `/health` therefore means "model never loaded", not "health check is broken". The
+  startup log has the real cause.

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_capabilities.d/50-gliner.yaml
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_capabilities.d/50-gliner.yaml
@@ -1,0 +1,5 @@
+# GLiNER derivative — image identity (overrides the base image block).
+image:
+  name: GLiNER2
+  readme: https://github.com/vast-ai/base-image/tree/main/derivatives/pytorch/derivatives/gliner
+  preinstalled: PyTorch + GLiNER2 (zero-shot entity extraction)

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/supervisor-scripts/gliner.sh
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/supervisor-scripts/gliner.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+utils=/opt/supervisor-scripts/utils
+. "${utils}/logging.sh"
+. "${utils}/cleanup_generic.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh" "GLiNER API"
+
+echo "Starting GLiNER API"
+
+. /venv/main/bin/activate
+
+# Wait for provisioning to complete
+while [ -f "/.provisioning" ]; do
+    echo "$PROC_NAME startup paused until instance provisioning has completed (/.provisioning present)"
+    sleep 10
+done
+
+cd "${WORKSPACE}/gliner"
+
+pty python server.py 2>&1

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
@@ -1,0 +1,153 @@
+"""
+GLiNER2 FastAPI Server - entity extraction API with Bearer token authentication.
+
+Environment Variables:
+    GLINER_API_KEY: API key for authentication (unsecured if unset)
+    GLINER_MODEL:   Model to use (default: fastino/gliner2.5-base-v1)
+    GLINER_HOST:    Bind address (default: 0.0.0.0)
+    GLINER_PORT:    Bind port (default: 8000)
+"""
+
+import os
+import time
+from typing import Dict, List, Optional
+
+import torch
+import uvicorn
+from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from gliner2 import AutoExtractor
+from pydantic import BaseModel
+
+# Configuration
+MODEL_NAME = os.environ.get("GLINER_MODEL", "fastino/gliner2.5-base-v1")
+API_KEY = os.environ.get("GLINER_API_KEY")
+HOST = os.environ.get("GLINER_HOST", "0.0.0.0")
+PORT = int(os.environ.get("GLINER_PORT", "8000"))
+
+app = FastAPI(
+    title="GLiNER2 API",
+    description="GPU-accelerated zero-shot entity extraction with GLiNER2",
+    version="2.5.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+security = HTTPBearer()
+
+if not API_KEY:
+    print("WARNING: GLINER_API_KEY not set. API will be unsecured!")
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Security(security)):
+    """Verify the Bearer token"""
+    if not API_KEY:
+        return True
+    if credentials.credentials != API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return True
+
+
+# Global model state
+model = None
+device = None
+
+
+class ExtractRequest(BaseModel):
+    text: str
+    labels: List[str]
+    threshold: Optional[float] = 0.3
+
+
+class ExtractResponse(BaseModel):
+    entities: Dict[str, List[str]]
+    inference_time: float
+    device: str
+
+
+class HealthResponse(BaseModel):
+    status: str
+    model: str
+    device: str
+    gpu_available: bool
+    gpu_name: Optional[str] = None
+
+
+@app.on_event("startup")
+async def load_model():
+    """Load the GLiNER2 model on startup.
+
+    AutoExtractor dispatches on the checkpoint's architecture: a 2.5 checkpoint
+    yields a BoundaryExtractor, a 2.0 checkpoint a SpanExtractor. Both are
+    nn.Module, so .to()/.eval() apply to either, and users pinning GLINER_MODEL
+    to a 2.0 checkpoint keep working.
+    """
+    global model, device
+
+    print(f"Loading GLiNER2 model: {MODEL_NAME}")
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+
+    model = AutoExtractor.from_pretrained(MODEL_NAME)
+    model = model.to(device)
+    model.eval()
+
+    print(f"Model loaded on {device} ({type(model).__name__})")
+    if torch.cuda.is_available():
+        gpu_name = torch.cuda.get_device_name(0)
+        gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1e9
+        print(f"GPU: {gpu_name} ({gpu_memory:.1f} GB)")
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health():
+    """Health check endpoint"""
+    gpu_name = torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+    return HealthResponse(
+        status="running",
+        model=MODEL_NAME,
+        device=device,
+        gpu_available=torch.cuda.is_available(),
+        gpu_name=gpu_name,
+    )
+
+
+@app.get("/", response_model=HealthResponse)
+async def root():
+    """Alias for the health check"""
+    return await health()
+
+
+@app.post("/extract", response_model=ExtractResponse)
+async def extract_entities(
+    request: ExtractRequest,
+    authorized: bool = Depends(verify_token),
+):
+    """Extract entities from text. Requires Bearer token authentication."""
+    try:
+        start_time = time.time()
+        result = model.extract_entities(
+            request.text,
+            request.labels,
+            threshold=request.threshold,
+        )
+        inference_time = time.time() - start_time
+
+        return ExtractResponse(
+            entities=result.get("entities", {}),
+            inference_time=inference_time,
+            device=device,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT, log_level="info")

--- a/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/README.md
+++ b/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/README.md
@@ -1,0 +1,53 @@
+# GLiNER2 QA template — zero-shot extraction smoke
+
+A disposable, private template for exercising a freshly-built `vastai/gliner` image
+on real hardware. It is **not** a user-facing template.
+
+## What it launches
+
+One supervisor service, `gliner`, running `server.py` (FastAPI + uvicorn) against
+`GLINER_MODEL`. The service waits for `/.provisioning` to clear, then downloads the
+checkpoint on first start — so the first boot is slower than subsequent ones by the
+size of the model, and the API is not reachable until that finishes.
+
+## The bind is deliberate
+
+`server.py` defaults to `0.0.0.0:8000` with **optional** auth — `GLINER_API_KEY`
+unset means every request is accepted. Published as-is that is an unauthenticated
+extraction endpoint on the open internet. This template pins `GLINER_HOST=127.0.0.1`
+and `GLINER_PORT=18000` so the only public path is through Caddy on `8000`, gated by
+`OPEN_BUTTON_TOKEN`. Set `GLINER_API_KEY` at launch if you intend to reach it another
+way; it is intentionally not committed here.
+
+`PORTAL_CONFIG` is load-bearing, not decoration: `gliner.sh` sources
+`exit_portal.sh "GLiNER API"`, which greps `/etc/portal.yaml` and, on no match,
+writes a skip marker and exits 0 — which supervisord treats as intentional, so the
+service never starts and the portal shows it as "not configured" rather than failed.
+Renaming that portal entry silently disables the app.
+
+## Smoke test
+
+```bash
+curl -s -X POST localhost:18000/extract \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Tim Cook announced the iPhone 15 in Cupertino for $999.",
+       "labels":["person","company","product","location","price"]}'
+```
+
+Every requested label comes back as a key; a label that matched nothing is an empty
+list, not a missing key. `threshold` (default `0.3`) trades recall for precision.
+
+## Coverage gap
+
+`INSTANCE_TEST_REQUIRE_PASS` names only the GPU trio, because this image ships no
+`gliner.d/` instance-test suite. The gate therefore asserts that the rented box has a
+working GPU and nothing about GLiNER itself. L072 does not fire — it is scoped to
+images that ship an own suite — but the gap is real, and writing that suite is the
+outstanding work before this template is worth wiring into `qa-gate.yml`.
+
+## Publishing
+
+```bash
+python tools/template_manager/create.py \
+  derivatives/pytorch/derivatives/gliner/templates/ --api-key "$VAST_API_KEY"
+```

--- a/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
+++ b/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
@@ -1,0 +1,88 @@
+# GLiNER2 QA template — zero-shot extraction smoke.
+#
+# Modelled on llama-cpp-qa, which is the closest shape in the tree: one supervisor
+# service fronting one HTTP API, no provisioning payload, no serverless backend.
+#
+# NOT wired into a live-GPU gate. `_gating_template_dirs()` defines "gating" as
+# "some workflow hands this dir to qa-gate.yml as template_dir:", and no workflow
+# does — there is no build-gliner.yml at all. So L057/L059/L072 do not apply here.
+# INSTANCE_TEST_REQUIRE_PASS is still declared below, so that wiring a gate later is
+# a workflow edit rather than a silently-uncovered promotion.
+name: "GLiNER2 QA — zero-shot extraction smoke"
+image: vastai/gliner
+tag: latest                       # override with the tag actually under test
+private: true                     # disposable QA template, never public
+readme_visible: false
+onstart: entrypoint.sh
+runtype: jupyter                  # production launch mode, as siblings use
+jup_direct: true
+ssh_direct: true
+use_ssh: true
+use_jupyter_lab: false
+ports:
+  - "1111:1111"                   # Instance Portal
+  - "8080:8080"                   # Jupyter
+  - "8000:8000"                   # GLiNER API (Caddy front; server binds 18000)
+  # Deliberately NO "3000:3000". L073 requires the serverless worker port only for a
+  # gate that sets SERVERLESS=true, and this image bakes no pyworker BACKEND — there
+  # is no OpenAI-compatible engine here for the worker to proxy to. Mapping it would
+  # publish a port nothing binds.
+env:
+  OPEN_BUTTON_PORT: "1111"
+  OPEN_BUTTON_TOKEN: "1"
+  JUPYTER_DIR: "/"
+  DATA_DIRECTORY: "/workspace/"
+  # LOAD-BEARING, in the same way llama.cpp's is. gliner.sh sources
+  #   . "${utils}/exit_portal.sh" "GLiNER API"
+  # which greps /etc/portal.yaml for that term and, on no match, writes a skip marker,
+  # sleeps 6 and exits 0 — and under `autorestart=unexpected` + `exitcodes=0`
+  # supervisord treats that as intentional, so the service is gone for the life of the
+  # instance and the portal renders it as "not configured" rather than failed. The
+  # entry name must therefore contain "GLiNER API" (the grep is case-insensitive).
+  #
+  # Path is /docs, not /: server.py mounts FastAPI's Swagger UI there, so the portal
+  # button lands on a page that actually renders. GET / returns a JSON health body.
+  PORTAL_CONFIG: "localhost:1111:11111:/:Instance Portal|localhost:8000:18000:/docs:GLiNER API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+  # Pin the bind explicitly rather than inheriting server.py's defaults, which are
+  # HOST=0.0.0.0 and PORT=8000 (`os.environ.get` in server.py). Both defaults are
+  # wrong for a published instance: 0.0.0.0:8000 would bind the API PUBLICLY, in
+  # front of Caddy instead of behind it, and GLINER_API_KEY is optional — an unset
+  # key disables auth entirely (`API_KEY = os.environ.get("GLINER_API_KEY")`). The
+  # combination is an unauthenticated extraction endpoint on the open internet.
+  # Loopback + Caddy is what makes OPEN_BUTTON_TOKEN the actual front door.
+  GLINER_HOST: "127.0.0.1"
+  GLINER_PORT: "18000"
+  # The 2.5 checkpoint this image was validated against. AutoExtractor dispatches on
+  # the checkpoint's config: 2.5 -> BoundaryExtractor, 2.0 -> SpanExtractor.
+  GLINER_MODEL: "fastino/gliner2.5-base-v1"
+  # Deliberately NOT set here: GLINER_API_KEY. A committed key is a published key,
+  # and this file is what a production template gets copied from. The loopback bind
+  # above means the only public path is through Caddy; set a real key at launch if
+  # the API is to be reached any other way.
+  #
+  # Only the GPU trio, which is all this image can honestly require: it ships no
+  # gliner.d/ suite, so there is no app-level assertion to name. That is exactly the
+  # hole L072 describes — a gate certifying that the rented box has a working GPU
+  # while asserting nothing about the app the image exists to ship — and L072 does
+  # not fire because it is scoped to images that DO ship an own suite. Writing a
+  # gliner.d/ suite is the outstanding work; this comment is the marker for it.
+  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries"
+extra_filters:
+  compute_cap:
+    gte: 750                      # sm_75, matching llama-cpp — deberta-v3 needs nothing newer
+  cuda_max_good:
+    gte: 12.9                     # matches the cuda-12.9 base this image is built on
+  # Generous relative to the measured cost: a gliner2.5-base forward pass measured
+  # 1.184 GB allocated on this box. The floor is headroom for the CUDA runtime and
+  # the encoder rather than the weights, and keeps the offer pool wide.
+  gpu_ram:
+    gte: 8192
+  reliability2:
+    gte: 0.95
+  inet_down:
+    gte: 500                      # Mbps — bounds the image pull inside the launch window
+  direct_port_count:
+    gte: 64                       # see templates/base-qa for the measurement
+  disk_space:
+    gte: 24                       # L058: must be >= recommended_disk_space or the rent fails late
+recommended_disk_space: 24.0


### PR DESCRIPTION
Adds GLiNER2 as a pytorch-nested derivative: zero-shot entity extraction served over FastAPI under Supervisor.

Supersedes #285 — that PR is a draft on a fork none of us can push to, so it could not be updated in place. This branch contains its commit unchanged (`d0ec66b`, same author) plus a second commit hardening the image. Close #285 in favour of this one.

### Why the server is vendored

Every sibling derivative clones an upstream application. GLiNER2 has none to clone: Fastino ships a pip library plus HuggingFace weights, and their serving story is a commercial hosted API. The FastAPI server therefore lives in-tree at `ROOT/opt/workspace-internal/gliner/server.py`.

### Hardening commit

- **Torch-drift guard widened.** It checked `torch.__version__` only, so a dependency that moved torchvision, torchaudio or torchcodec while leaving torch alone passed silently. Now snapshots all four before and after the install and diffs them on failure, matching whisper and voicebox and `docs/invariants.md` (present in 16/17 images).
- **gliner2 pinned.** Siblings pin the app they clone to a git ref; this one has nothing to clone, so the PyPI version is the equivalent pin. `ARG GLINER2_VERSION=2.0.0` — defaulted rather than required, because there is no build workflow to supply it and a bare ARG would make the directory unbuildable by hand. 2.0.0 is the version validated on hardware against the 2.5 checkpoints.
- **`ROOT/LICENSES.md` added.** 15/16 siblings ship one. It matters more here because the server is vendored rather than cloned, so there is no upstream LICENSE in the tree to point at. Covers PyTorch (BSD-3-Clause), GLiNER2 and Transformers (Apache-2.0), and notes that weights are fetched at runtime under their own per-repository licenses.
- **`ROOT/etc/vast_agents/gliner.md` added.** Also 15/16. Without it an agent meeting this image has no way to learn the API is not OpenAI-shaped and will reach for `/v1/...`. Names `POST /extract` and internal port 8000, and documents the zero-shot label contract.

### Validation

Run against `fastino/gliner2.5-base-v1`, `-small-v1`, `-multi-v1` and the 2.0 checkpoint on real hardware:

- `AutoExtractor` dispatches on checkpoint architecture — 2.5 loads as `BoundaryExtractor`, 2.0 as `SpanExtractor`. Both are `nn.Module`, so pinning `GLINER_MODEL` to a 2.0 checkpoint keeps working. Backward compatibility confirmed, not assumed.
- The label behaviour documented in the agent doc is measured: every requested label returns as a key, and one that matched nothing is an empty list rather than a missing key — so the correct test is `if not entities["price"]`. Verified with two labels that cannot match.
- `imagegen lint gliner`: **0 errors.** Two warnings, neither about this change — L030 (no `build-gliner.yml`; the rule is explicitly "not universal" and 3 other app images (`fooocus`, `kohya_ss`, `swarmui`) also lack one. Correcting an earlier claim in this PR: I previously wrote that `vastai/gliner` was already published. It is not — the Docker Hub repo exists but has **0 tags**, so this image has never been built. Wiring a build workflow is therefore still outstanding, and is left to Vast) and L041 (unset staging namespace, which CI supplies from a secret).

### Not addressed here

Two items in the vendored server look like judgment calls for whoever owns that code rather than image plumbing:

1. CORS is `allow_origins=["*"]` together with `allow_credentials=True`.
2. `GET /health` raises a 500 response-validation error when the model failed to load, because `device` is still unset — it reports a crash rather than reporting unhealthy. Documented as a known footgun in the agent doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
