### PR TITLE
Add GLiNER2 derivative image (zero-shot entity extraction)

### DIFF
--- a/.github/workflows/build-gliner.yml
+++ b/.github/workflows/build-gliner.yml
@@ -1,49 +1,40 @@
-# Build GLiNER2 image - works on main repo and forks (manual dispatch only).
+# Build GLiNER image - works on main repo (scheduled + manual) and forks (manual)
 # Required repository secrets:
 #   DOCKERHUB_USERNAME
 #   DOCKERHUB_TOKEN
 #   DOCKERHUB_NAMESPACE          - production namespace (final multi-arch index lives here)
 #   DOCKERHUB_NAMESPACE_STAGING  - staging namespace (per-arch build artifacts live here)
 # Optional: SLACK_WEBHOOK_URL
+# Note: Build matrix will need periodic updates as new Pytorch images become available
 #
-# NO RELEASE DETECTION, and no `schedule:`. Every sibling build workflow polls an
-# upstream git repo it clones -- build-whisper.yml watches jhj0517/Whisper-WebUI for
-# new release tags. GLiNER2 has no such repo to watch: Fastino publishes a pip
-# library and HuggingFace weights, no server and no Docker image, so the Dockerfile
-# clones nothing and the FastAPI server is vendored in ROOT/opt/workspace-internal/.
-# The PyPI version IS the pin, which is why the Dockerfile carries
-# `ARG GLINER2_VERSION=2.0.0` where its siblings carry a git ref. A cron here would
-# rebuild a byte-identical pinned version twice a day and notify Slack about it, so
-# the version is a dispatch input instead -- the human bumping the pin is the trigger.
+# Release detection: PyPI (gliner2), NOT a GitHub repository. Every sibling image
+# watches an upstream repo for release tags; GLiNER has none to watch. Fastino ships
+# the library to PyPI and the weights to HuggingFace, and publishes no server, no
+# Dockerfile and no image. So the version that identifies a build is the pip package
+# version, and check-pypi-release is the right resolver.
 #
-# Multi-arch strategy: each (base_image, arch) pair builds natively on the matching
-# runner (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64) and pushes an
-# arch-suffixed tag to the STAGING namespace. A per-base_image merge job then uses
-# crane to assemble the multi-arch index at the PRODUCTION tag. No QEMU emulation.
-# Verified 2026-09-10: the pinned base publishes both linux/amd64 and linux/arm64,
-# so neither matrix leg is building against a manifest that does not exist.
+# The MODEL is deliberately not part of the trigger. Weights are downloaded at first
+# boot and selected per-instance via GLINER_MODEL, so a new checkpoint on HuggingFace
+# does not change this image and must not rebuild it.
 #
-# NOT WIRED TO qa-gate.yml, deliberately, and this is the outstanding work on this
-# image rather than a settled decision. `_gating_template_dirs()` defines a gating
-# template as one some workflow hands to qa-gate.yml as `template_dir:` -- so adding
-# such a job here is what would make templates/gliner-qa/ gating and pull L057/L059/
-# L072 into force. The blocker is that this image ships no
-# ROOT/opt/instance-tools/tests/gliner.d/ suite, so the only tests a gate could
-# require are the GPU trio every image inherits from base. That is precisely the hole
-# L072 describes -- a gate certifying the RENTED BOX has a working GPU while
-# asserting nothing about the extraction API the image exists to ship. L072 does not
-# fire only because it is scoped to images that DO ship an own suite. Write gliner.d/
-# first; wiring the gate afterwards is a small edit to this file.
+# Multi-arch strategy: each (base_image, arch) pair builds natively on the
+# matching runner (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64) and
+# pushes an arch-suffixed tag to the STAGING namespace. A per-base_image
+# merge job then uses crane to assemble the multi-arch index at the
+# PRODUCTION tag. No QEMU emulation.
 
-name: Build GLiNER2 Image
+name: Build GLiNER Image
 
 on:
+  schedule:
+    # Run every 12 hours
+    - cron: '0 4,16 * * *'
+
   workflow_dispatch:
     inputs:
       GLINER2_VERSION:
-        description: "gliner2 PyPI version (installed as gliner2[local]==<version>)"
-        required: true
-        default: "2.0.0"
+        description: "gliner2 PyPI version - leave empty for latest"
+        required: false
       DOCKERHUB_REPO:
         description: "Push to namespace/<repo>"
         required: true
@@ -54,13 +45,15 @@ on:
 
 env:
   DEFAULT_DOCKERHUB_REPO: "gliner"
+  # 12 hours
+  RELEASE_AGE_THRESHOLD: 43200
 
 jobs:
   preflight:
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.decision.outputs.should-run }}
-      gliner2-version: ${{ steps.resolve-version.outputs.version }}
+      gliner2-version: ${{ steps.release-check.outputs.resolved-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,35 +74,28 @@ jobs:
             echo "::notice::Skipping - missing secrets: ${missing[*]}"
           fi
 
-      # Falls back to the Dockerfile's own ARG default rather than a second literal
-      # copy of the version, so the pin has exactly one home. A dispatch always
-      # supplies the input (it is `required: true`), so this is the belt to that
-      # braces -- it keeps a `gh workflow run` with an emptied field from building
-      # `gliner2[local]==` and failing deep inside the RUN layer.
-      - name: Resolve gliner2 version
-        id: resolve-version
-        run: |
-          VERSION="${{ inputs.GLINER2_VERSION }}"
-          if [ -z "$VERSION" ]; then
-            VERSION=$(sed -n 's/^ARG GLINER2_VERSION=\(.*\)$/\1/p' \
-              derivatives/pytorch/derivatives/gliner/Dockerfile)
-            echo "::notice::No version supplied; using Dockerfile default: $VERSION"
-          fi
-          if [ -z "$VERSION" ]; then
-            echo "::error::Could not resolve a gliner2 version"
-            exit 1
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building gliner2 $VERSION"
+      # version-pattern excludes pre-releases explicitly rather than relying on the
+      # default: gliner2 published 1.3.x betas alongside stable 1.2.x, so a resolver
+      # that admitted them could select a pre-release as "latest".
+      - name: Check PyPI release
+        id: release-check
+        uses: ./.github/actions/check-pypi-release
+        with:
+          package: gliner2
+          age-threshold-seconds: ${{ env.RELEASE_AGE_THRESHOLD }}
+          trigger: ${{ github.event_name }}
+          manual-version: ${{ inputs.GLINER2_VERSION }}
+          version-pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+          include-prereleases: "false"
 
-      - name: Build decision
+      - name: Determine if build should run
         id: decision
         run: |
-          if [[ "${{ steps.secrets.outputs.available }}" == "true" ]]; then
+          if [[ "${{ steps.secrets.outputs.available }}" == "true" && "${{ steps.release-check.outputs.new-release }}" == "true" ]]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "Building gliner2 ${{ steps.release-check.outputs.resolved-version }}"
           else
             echo "should-run=false" >> $GITHUB_OUTPUT
-            echo "::notice::Build skipped - required secrets are not configured"
           fi
 
   build:
@@ -125,6 +111,9 @@ jobs:
       matrix:
         base_image:
           - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+        # Both arches are built: every dependency this image adds on top of the base
+        # (transformers, tokenizers, sentencepiece, protobuf, peft, safetensors)
+        # publishes aarch64 wheels, and torch comes from the base rather than pip.
         arch:
           - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
           - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
@@ -149,24 +138,19 @@ jobs:
             exit 1
           fi
 
-          GLINER2_VERSION="${{ needs.preflight.outputs.gliner2-version }}"
-
           IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
           if [ -z "$IMAGE_TAG_BASE" ]; then
-            IMAGE_TAG_BASE="${GLINER2_VERSION}-cuda-${CUDA_VERSION}-${PYTHON_VERSION}"
+            IMAGE_TAG_BASE="${{ needs.preflight.outputs.gliner2-version }}"
           fi
 
           DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
-          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+          IMAGE_TAG="${IMAGE_TAG_BASE}-cuda-${CUDA_VERSION}-${PYTHON_VERSION}"
+          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG}"
 
           echo "STAGING_TAG_BASE=$STAGING_TAG_BASE" >> $GITHUB_ENV
 
           echo "Derived staging tag base: $STAGING_TAG_BASE (arch=${{ matrix.arch.suffix }})"
 
-      # PYTORCH_BASE is passed explicitly even though the Dockerfile defaults it to
-      # this same value: the matrix is the source of truth in CI, and leaving the
-      # Dockerfile default to apply would silently decouple the tag (which is derived
-      # from matrix.base_image above) from the layer actually built underneath it.
       - name: Build and push arch image to staging
         uses: ./.github/actions/build-arch-image
         with:
@@ -179,15 +163,40 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  # `workflow_dispatch` is the only trigger here, so unlike the sibling builds --
-  # where a scheduled run resolves this to '' and publishes unattended -- this
-  # expression always resolves to 'production'. That is the intent: nothing has ever
-  # been published under this repo name, so the first index to appear there should be
-  # one a human approved. On a fork with no such environment configured GitHub
-  # creates it with no reviewers and the job proceeds, so this does not block testing.
-  merge-manifests:
+  # Live-GPU QA gate (ADR 0005). A green `docker build` cannot see this image's
+  # primary failure modes: the weights are fetched at FIRST BOOT rather than baked, and
+  # the server falls back to CPU and still answers correctly when torch cannot see a
+  # device -- so both "the model never downloaded" and "it is serving on CPU" look
+  # identical to a successful build.
+  qa:
     needs: [preflight, build]
     if: needs.preflight.outputs.should-run == 'true'
+    uses: ./.github/workflows/qa-gate.yml
+    with:
+      repo: ${{ inputs.DOCKERHUB_REPO || 'gliner' }}
+      tag: ${{ inputs.CUSTOM_IMAGE_TAG || needs.preflight.outputs.gliner2-version }}-cuda-12.9-py312-amd64
+      template_dir: derivatives/pytorch/derivatives/gliner/templates/gliner-qa
+      label: base-image-qa-gliner
+      log_paths: "/var/log/portal/gliner.log"
+      require_tests: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries gliner.d/10-gliner-serving"
+      retries: 2
+    secrets:
+      VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+      DOCKERHUB_NAMESPACE_STAGING: ${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  merge-manifests:
+    # `qa` is in `needs` to ORDER it ahead of the production approval prompt. It is
+    # absent from the `if` so it cannot BLOCK yet -- ADR 0006's advisory ramp, matching
+    # how unsloth-studio introduced its gate. `!cancelled()` is what makes that true:
+    # a job named in `needs` blocks BY DEFAULT, so the result that MUST still block is
+    # named explicitly. Promote by adding `needs.qa.result == 'success'` to this `if`
+    # after two consecutive green runs.
+    needs: [preflight, build, qa]
+    if: >-
+      !cancelled()
+      && needs.preflight.outputs.should-run == 'true'
+      && needs.build.result == 'success'
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     strategy:
@@ -207,16 +216,15 @@ jobs:
           CUDA_VERSION=$(echo "$TAG" | sed -n 's/.*cuda-\([0-9.]*\).*/\1/p')
           PYTHON_VERSION=$(echo "$TAG" | sed -n 's/.*-py\([0-9]*\).*/py\1/p')
 
-          GLINER2_VERSION="${{ needs.preflight.outputs.gliner2-version }}"
-
           IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
           if [ -z "$IMAGE_TAG_BASE" ]; then
-            IMAGE_TAG_BASE="${GLINER2_VERSION}-cuda-${CUDA_VERSION}-${PYTHON_VERSION}"
+            IMAGE_TAG_BASE="${{ needs.preflight.outputs.gliner2-version }}"
           fi
 
           DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
-          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
-          PROD_TAG="${{ secrets.DOCKERHUB_NAMESPACE }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+          IMAGE_TAG="${IMAGE_TAG_BASE}-cuda-${CUDA_VERSION}-${PYTHON_VERSION}"
+          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG}"
+          PROD_TAG="${{ secrets.DOCKERHUB_NAMESPACE }}/${DOCKERHUB_REPO}:${IMAGE_TAG}"
 
           echo "STAGING_TAG_BASE=$STAGING_TAG_BASE" >> $GITHUB_ENV
           echo "PROD_TAG=$PROD_TAG" >> $GITHUB_ENV
@@ -229,6 +237,7 @@ jobs:
         with:
           target-tag: ${{ env.PROD_TAG }}
           source-tag-base: ${{ env.STAGING_TAG_BASE }}
+          arches: amd64,arm64
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -277,7 +286,7 @@ jobs:
     uses: ./.github/workflows/notify-slack.yml
     with:
       build-result: ${{ needs.merge-manifests.result }}
-      image-name: "GLiNER2"
+      image-name: "GLiNER"
       image-ref: ${{ needs.preflight.outputs.gliner2-version }}
       image-tags: ${{ needs.collect-tags.outputs.all-tags }}
       trigger: ${{ github.event_name }}

--- a/.github/workflows/build-gliner.yml
+++ b/.github/workflows/build-gliner.yml
@@ -1,0 +1,286 @@
+# Build GLiNER2 image - works on main repo and forks (manual dispatch only).
+# Required repository secrets:
+#   DOCKERHUB_USERNAME
+#   DOCKERHUB_TOKEN
+#   DOCKERHUB_NAMESPACE          - production namespace (final multi-arch index lives here)
+#   DOCKERHUB_NAMESPACE_STAGING  - staging namespace (per-arch build artifacts live here)
+# Optional: SLACK_WEBHOOK_URL
+#
+# NO RELEASE DETECTION, and no `schedule:`. Every sibling build workflow polls an
+# upstream git repo it clones -- build-whisper.yml watches jhj0517/Whisper-WebUI for
+# new release tags. GLiNER2 has no such repo to watch: Fastino publishes a pip
+# library and HuggingFace weights, no server and no Docker image, so the Dockerfile
+# clones nothing and the FastAPI server is vendored in ROOT/opt/workspace-internal/.
+# The PyPI version IS the pin, which is why the Dockerfile carries
+# `ARG GLINER2_VERSION=2.0.0` where its siblings carry a git ref. A cron here would
+# rebuild a byte-identical pinned version twice a day and notify Slack about it, so
+# the version is a dispatch input instead -- the human bumping the pin is the trigger.
+#
+# Multi-arch strategy: each (base_image, arch) pair builds natively on the matching
+# runner (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64) and pushes an
+# arch-suffixed tag to the STAGING namespace. A per-base_image merge job then uses
+# crane to assemble the multi-arch index at the PRODUCTION tag. No QEMU emulation.
+# Verified 2026-09-10: the pinned base publishes both linux/amd64 and linux/arm64,
+# so neither matrix leg is building against a manifest that does not exist.
+#
+# NOT WIRED TO qa-gate.yml, deliberately, and this is the outstanding work on this
+# image rather than a settled decision. `_gating_template_dirs()` defines a gating
+# template as one some workflow hands to qa-gate.yml as `template_dir:` -- so adding
+# such a job here is what would make templates/gliner-qa/ gating and pull L057/L059/
+# L072 into force. The blocker is that this image ships no
+# ROOT/opt/instance-tools/tests/gliner.d/ suite, so the only tests a gate could
+# require are the GPU trio every image inherits from base. That is precisely the hole
+# L072 describes -- a gate certifying the RENTED BOX has a working GPU while
+# asserting nothing about the extraction API the image exists to ship. L072 does not
+# fire only because it is scoped to images that DO ship an own suite. Write gliner.d/
+# first; wiring the gate afterwards is a small edit to this file.
+
+name: Build GLiNER2 Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      GLINER2_VERSION:
+        description: "gliner2 PyPI version (installed as gliner2[local]==<version>)"
+        required: true
+        default: "2.0.0"
+      DOCKERHUB_REPO:
+        description: "Push to namespace/<repo>"
+        required: true
+        default: "gliner"
+      CUSTOM_IMAGE_TAG:
+        description: "Custom tag (Auto default)"
+        required: false
+
+env:
+  DEFAULT_DOCKERHUB_REPO: "gliner"
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.decision.outputs.should-run }}
+      gliner2-version: ${{ steps.resolve-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for required secrets
+        id: secrets
+        run: |
+          missing=()
+          [[ -z "${{ secrets.DOCKERHUB_USERNAME }}" ]] && missing+=("DOCKERHUB_USERNAME")
+          [[ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]] && missing+=("DOCKERHUB_TOKEN")
+          [[ -z "${{ secrets.DOCKERHUB_NAMESPACE }}" ]] && missing+=("DOCKERHUB_NAMESPACE")
+          [[ -z "${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}" ]] && missing+=("DOCKERHUB_NAMESPACE_STAGING")
+          if [[ ${#missing[@]} -eq 0 ]]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+            echo "Required secrets configured"
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping - missing secrets: ${missing[*]}"
+          fi
+
+      # Falls back to the Dockerfile's own ARG default rather than a second literal
+      # copy of the version, so the pin has exactly one home. A dispatch always
+      # supplies the input (it is `required: true`), so this is the belt to that
+      # braces -- it keeps a `gh workflow run` with an emptied field from building
+      # `gliner2[local]==` and failing deep inside the RUN layer.
+      - name: Resolve gliner2 version
+        id: resolve-version
+        run: |
+          VERSION="${{ inputs.GLINER2_VERSION }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(sed -n 's/^ARG GLINER2_VERSION=\(.*\)$/\1/p' \
+              derivatives/pytorch/derivatives/gliner/Dockerfile)
+            echo "::notice::No version supplied; using Dockerfile default: $VERSION"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve a gliner2 version"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building gliner2 $VERSION"
+
+      - name: Build decision
+        id: decision
+        run: |
+          if [[ "${{ steps.secrets.outputs.available }}" == "true" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "::notice::Build skipped - required secrets are not configured"
+          fi
+
+  build:
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: ${{ matrix.arch.runs_on }}
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image:
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+        arch:
+          - { platform: linux/amd64, suffix: amd64, runs_on: ubuntu-latest }
+          - { platform: linux/arm64, suffix: arm64, runs_on: ubuntu-24.04-arm }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: ./.github/actions/maximize-build-space
+
+      - name: Derive staging tag
+        run: |
+          PYTORCH_BASE="${{ matrix.base_image }}"
+          TAG="${PYTORCH_BASE##*:}"
+
+          CUDA_VERSION=$(echo "$TAG" | sed -n 's/.*cuda-\([0-9.]*\).*/\1/p')
+          PYTHON_VERSION=$(echo "$TAG" | sed -n 's/.*-py\([0-9]*\).*/py\1/p')
+
+          if [ -z "$CUDA_VERSION" ] || [ -z "$PYTHON_VERSION" ]; then
+            echo "::error::Failed to parse base image: $PYTORCH_BASE"
+            exit 1
+          fi
+
+          GLINER2_VERSION="${{ needs.preflight.outputs.gliner2-version }}"
+
+          IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
+          if [ -z "$IMAGE_TAG_BASE" ]; then
+            IMAGE_TAG_BASE="${GLINER2_VERSION}-cuda-${CUDA_VERSION}-${PYTHON_VERSION}"
+          fi
+
+          DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
+          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+
+          echo "STAGING_TAG_BASE=$STAGING_TAG_BASE" >> $GITHUB_ENV
+
+          echo "Derived staging tag base: $STAGING_TAG_BASE (arch=${{ matrix.arch.suffix }})"
+
+      # PYTORCH_BASE is passed explicitly even though the Dockerfile defaults it to
+      # this same value: the matrix is the source of truth in CI, and leaving the
+      # Dockerfile default to apply would silently decouple the tag (which is derived
+      # from matrix.base_image above) from the layer actually built underneath it.
+      - name: Build and push arch image to staging
+        uses: ./.github/actions/build-arch-image
+        with:
+          context: derivatives/pytorch/derivatives/gliner
+          arch: ${{ matrix.arch.platform }}
+          tag-base: ${{ env.STAGING_TAG_BASE }}
+          build-args: |
+            PYTORCH_BASE=${{ matrix.base_image }}
+            GLINER2_VERSION=${{ needs.preflight.outputs.gliner2-version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  # `workflow_dispatch` is the only trigger here, so unlike the sibling builds --
+  # where a scheduled run resolves this to '' and publishes unattended -- this
+  # expression always resolves to 'production'. That is the intent: nothing has ever
+  # been published under this repo name, so the first index to appear there should be
+  # one a human approved. On a fork with no such environment configured GitHub
+  # creates it with no reviewers and the job proceeds, so this does not block testing.
+  merge-manifests:
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image:
+          - vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Derive image tags
+        run: |
+          PYTORCH_BASE="${{ matrix.base_image }}"
+          TAG="${PYTORCH_BASE##*:}"
+          CUDA_VERSION=$(echo "$TAG" | sed -n 's/.*cuda-\([0-9.]*\).*/\1/p')
+          PYTHON_VERSION=$(echo "$TAG" | sed -n 's/.*-py\([0-9]*\).*/py\1/p')
+
+          GLINER2_VERSION="${{ needs.preflight.outputs.gliner2-version }}"
+
+          IMAGE_TAG_BASE="${{ inputs.CUSTOM_IMAGE_TAG }}"
+          if [ -z "$IMAGE_TAG_BASE" ]; then
+            IMAGE_TAG_BASE="${GLINER2_VERSION}-cuda-${CUDA_VERSION}-${PYTHON_VERSION}"
+          fi
+
+          DOCKERHUB_REPO="${{ inputs.DOCKERHUB_REPO || env.DEFAULT_DOCKERHUB_REPO }}"
+          STAGING_TAG_BASE="${{ secrets.DOCKERHUB_NAMESPACE_STAGING }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+          PROD_TAG="${{ secrets.DOCKERHUB_NAMESPACE }}/${DOCKERHUB_REPO}:${IMAGE_TAG_BASE}"
+
+          echo "STAGING_TAG_BASE=$STAGING_TAG_BASE" >> $GITHUB_ENV
+          echo "PROD_TAG=$PROD_TAG" >> $GITHUB_ENV
+
+          MATRIX_ID=$(echo "$PYTORCH_BASE" | md5sum | cut -c1-8)
+          echo "MATRIX_ID=$MATRIX_ID" >> $GITHUB_ENV
+
+      - name: Assemble multi-arch index in production
+        uses: ./.github/actions/merge-arch-manifests
+        with:
+          target-tag: ${{ env.PROD_TAG }}
+          source-tag-base: ${{ env.STAGING_TAG_BASE }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Record merged manifest tag
+        run: |
+          mkdir -p built-tags
+          echo "${{ env.PROD_TAG }}" > built-tags/tag-${{ env.MATRIX_ID }}.txt
+
+      - name: Upload manifest tag
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-tag-${{ env.MATRIX_ID }}
+          path: built-tags/
+          retention-days: 1
+
+  collect-tags:
+    needs: [preflight, build, merge-manifests]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      all-tags: ${{ steps.collect.outputs.tags }}
+    steps:
+      - name: Download all tag artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: built-tag-*
+          path: all-tags/
+          merge-multiple: true
+
+      - name: Aggregate tags
+        id: collect
+        run: |
+          if [ -d all-tags ] && [ "$(ls -A all-tags 2>/dev/null)" ]; then
+            TAGS=$(cat all-tags/*.txt | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "Found tags: $TAGS"
+          else
+            echo "::warning::No tags found - build may have failed"
+            TAGS="[]"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+  notify:
+    needs: [preflight, build, merge-manifests, collect-tags]
+    if: always() && needs.preflight.outputs.should-run == 'true'
+    uses: ./.github/workflows/notify-slack.yml
+    with:
+      build-result: ${{ needs.merge-manifests.result }}
+      image-name: "GLiNER2"
+      image-ref: ${{ needs.preflight.outputs.gliner2-version }}
+      image-tags: ${{ needs.collect-tags.outputs.all-tags }}
+      trigger: ${{ github.event_name }}
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/derivatives/pytorch/derivatives/gliner/Dockerfile
+++ b/derivatives/pytorch/derivatives/gliner/Dockerfile
@@ -13,14 +13,15 @@ LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
 # Copy Supervisor configuration, startup scripts and the vendored server
 COPY ./ROOT /
 
-# Siblings pin the app to a git ref they clone; this one has nothing to clone, so
-# the PyPI version is the equivalent pin. Defaulted rather than required because
-# there is no build workflow to supply it -- a bare ARG would make the directory
-# unbuildable by hand. 2.0.0 is the version validated against the 2.5 checkpoints.
-ARG GLINER2_VERSION=2.0.0
+# Carries no default ON PURPOSE, the same reason ADR 0018 records for
+# LLAMA_CPP_VERSION: the image tag is DERIVED from this version, so an unpinned
+# install would publish a tag that does not describe its own contents.
+# build-gliner.yml always supplies it, resolving the latest gliner2 from PyPI.
+ARG GLINER2_VERSION
 
 RUN \
     set -euo pipefail && \
+    [[ -n "${GLINER2_VERSION}" ]] || { echo "Must specify GLINER2_VERSION" && exit 1; } && \
     . /venv/main/bin/activate && \
     # Snapshot the base's full torch ecosystem (torch + torchvision + torchaudio + torchcodec).
     torch_versions_pre="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
@@ -29,6 +30,12 @@ RUN \
     # -- the plain "gliner2" package moved those out of the default install in
     # 2.0.0. The base image is the source of truth for torch, so the assertion
     # below catches any attempt by the extra to move it.
+    #
+    # NOTE: this install DOWNGRADES huggingface-hub (1.30.0 -> 0.36.2 against the
+    # 2026-09-08 base), because transformers 4.57.6 caps it below 1.0. That is
+    # upstream's constraint, not a choice here, and the torch assertion does not
+    # cover it. GLiNER is the only consumer in this image, so nothing else depends
+    # on the newer hub API -- but it is stated rather than left to be discovered.
     uv pip install --no-cache-dir \
         "gliner2[local]==${GLINER2_VERSION}" \
         protobuf \

--- a/derivatives/pytorch/derivatives/gliner/Dockerfile
+++ b/derivatives/pytorch/derivatives/gliner/Dockerfile
@@ -13,27 +13,32 @@ LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
 # Copy Supervisor configuration, startup scripts and the vendored server
 COPY ./ROOT /
 
+# Siblings pin the app to a git ref they clone; this one has nothing to clone, so
+# the PyPI version is the equivalent pin. Defaulted rather than required because
+# there is no build workflow to supply it -- a bare ARG would make the directory
+# unbuildable by hand. 2.0.0 is the version validated against the 2.5 checkpoints.
+ARG GLINER2_VERSION=2.0.0
+
 RUN \
     set -euo pipefail && \
     . /venv/main/bin/activate && \
-    # Record pre-install PyTorch version
-    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # Snapshot the base's full torch ecosystem (torch + torchvision + torchaudio + torchcodec).
+    torch_versions_pre="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
     # gliner2's [local] extra carries torch, transformers, safetensors and peft.
     # Without it the library installs with no runtime at all and can load no model
     # -- the plain "gliner2" package moved those out of the default install in
     # 2.0.0. The base image is the source of truth for torch, so the assertion
     # below catches any attempt by the extra to move it.
     uv pip install --no-cache-dir \
-        'gliner2[local]>=2.0.0' \
+        "gliner2[local]==${GLINER2_VERSION}" \
         protobuf \
         sentencepiece \
         'fastapi>=0.100.0' \
         'uvicorn>=0.23.0' \
         'pydantic>=2.0.0' && \
-    # Verify PyTorch version unchanged
-    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
-    [[ $torch_version_pre = $torch_version_post ]] || \
-        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+    # Verify torch ecosystem unchanged.
+    torch_versions_post="$({ pip list --format=freeze 2>/dev/null | grep -E '^(torch|torchvision|torchaudio|torchcodec)==' || :; } | sort)" && \
+    [[ "$torch_versions_pre" = "$torch_versions_post" ]] || { echo "torch ecosystem version drift:"; diff <(echo "$torch_versions_pre") <(echo "$torch_versions_post"); exit 1; }
 
 # Defend against environment clashes when syncing to volume
 RUN \

--- a/derivatives/pytorch/derivatives/gliner/Dockerfile
+++ b/derivatives/pytorch/derivatives/gliner/Dockerfile
@@ -1,0 +1,41 @@
+# GLiNER2 is a pip library plus HuggingFace weights -- upstream (Fastino) publishes
+# no server and no Docker image, so unlike its siblings there is no repository to
+# clone. The FastAPI server is vendored in ROOT/opt/workspace-internal/gliner/.
+ARG PYTORCH_BASE=vastai/pytorch:2.10.0-cu128-cuda-12.9-mini-py312-2026-09-08
+
+FROM ${PYTORCH_BASE}
+
+# Maintainer details
+LABEL org.opencontainers.image.source="https://github.com/vastai/"
+LABEL org.opencontainers.image.description="GLiNER2 image (entity extraction API) suitable for Vast.ai."
+LABEL maintainer="Vast.ai Inc <contact@vast.ai>"
+
+# Copy Supervisor configuration, startup scripts and the vendored server
+COPY ./ROOT /
+
+RUN \
+    set -euo pipefail && \
+    . /venv/main/bin/activate && \
+    # Record pre-install PyTorch version
+    torch_version_pre="$(python -c 'import torch; print (torch.__version__)')" && \
+    # gliner2's [local] extra carries torch, transformers, safetensors and peft.
+    # Without it the library installs with no runtime at all and can load no model
+    # -- the plain "gliner2" package moved those out of the default install in
+    # 2.0.0. The base image is the source of truth for torch, so the assertion
+    # below catches any attempt by the extra to move it.
+    uv pip install --no-cache-dir \
+        'gliner2[local]>=2.0.0' \
+        protobuf \
+        sentencepiece \
+        'fastapi>=0.100.0' \
+        'uvicorn>=0.23.0' \
+        'pydantic>=2.0.0' && \
+    # Verify PyTorch version unchanged
+    torch_version_post="$(python -c 'import torch; print (torch.__version__)')" && \
+    [[ $torch_version_pre = $torch_version_post ]] || \
+        { echo "PyTorch version mismatch (wanted ${torch_version_pre} but got ${torch_version_post})"; exit 1; }
+
+# Defend against environment clashes when syncing to volume
+RUN \
+    set -euo pipefail && \
+    env-hash > /.env_hash

--- a/derivatives/pytorch/derivatives/gliner/README.md
+++ b/derivatives/pytorch/derivatives/gliner/README.md
@@ -40,10 +40,20 @@ The FastAPI server is therefore vendored in this directory at `ROOT/opt/workspac
 | `WORKSPACE` | `/workspace` | Directory the server is synced to |
 | `GLINER_MODEL` | `fastino/gliner2.5-base-v1` | HuggingFace checkpoint to serve |
 | `GLINER_API_KEY` | *(unset)* | Bearer token. **If unset the API is unauthenticated** |
-| `GLINER_HOST` | `0.0.0.0` | Bind address |
-| `GLINER_PORT` | `8000` | Bind port |
+| `GLINER_HOST` | `127.0.0.1` | Bind address. Loopback by default — Caddy fronts it |
+| `GLINER_PORT` | `18000` | Bind port. The portal maps external `8000` to it |
 
 Set `HF_TOKEN` if HuggingFace rate-limits anonymous weight downloads.
+
+The server binds loopback and is reached through Caddy on `8000`, like every other
+service in these images. Do not point `GLINER_HOST` at `0.0.0.0` — that publishes the
+extraction endpoint directly, bypassing the proxy, and the instance test asserts
+against it.
+
+### Weights
+
+Weights are **not baked into the image**; they are downloaded on first boot, so the
+first start is slower than a restart and needs working HuggingFace egress.
 
 ## API
 
@@ -88,6 +98,19 @@ curl -X POST http://<IP>:<PORT>/extract \
 }
 ```
 
+## QA
+
+`templates/gliner-qa/` is the live-GPU gate template, exercised by `build-gliner.yml`.
+`ROOT/opt/instance-tools/tests/gliner.d/10-gliner-serving.sh` asserts the service is
+up, `/health` reports a **GPU** (not a silent CPU fallback), `/extract` returns real
+entities, a wrong bearer token gets a 401, and the listener is on loopback.
+
 ## Notes
 
-The DeBERTa-v3 encoder has no SDPA implementation in transformers, so the model runs with eager attention. This is expected and logged at startup as a `RuntimeWarning`; it is not an error.
+The DeBERTa-v3 encoder has no SDPA implementation in transformers, so the model runs
+with eager attention. This is expected and logged at startup as a `RuntimeWarning`; it
+is not an error.
+
+The dependency install downgrades `huggingface-hub` from the base image's version,
+because `transformers` caps it below 1.0. GLiNER is the only consumer in this image.
+The Dockerfile's assertion covers the torch ecosystem, not this.

--- a/derivatives/pytorch/derivatives/gliner/README.md
+++ b/derivatives/pytorch/derivatives/gliner/README.md
@@ -1,0 +1,93 @@
+# GLiNER2 Image
+
+A [GLiNER2](https://github.com/fastino-ai/GLiNER2) image derived from the Vast.ai [PyTorch image](../../README.md). GLiNER2 performs zero-shot entity extraction: entity types are supplied per-request, so no retraining is needed to extract a new type.
+
+This image ships a FastAPI server exposing the model over HTTP, managed as a Supervisor service, along with all features from the Vast.ai base image.
+
+For detailed documentation on Instance Portal, Supervisor, environment variables, and other features, see the [base image README](../../../../README.md).
+
+## Why the server is vendored
+
+Every sibling derivative clones an upstream application repository. GLiNER2 has none to clone: Fastino ships it as a pip library plus HuggingFace weights, and their own serving story is a commercial hosted API. There is no upstream Docker image and no upstream server.
+
+The FastAPI server is therefore vendored in this directory at `ROOT/opt/workspace-internal/gliner/server.py`, rather than cloned during the build.
+
+## Models
+
+`AutoExtractor` dispatches on the checkpoint architecture, so `GLINER_MODEL` accepts both GLiNER 2.5 and GLiNER 2.0 checkpoints.
+
+| Model | Params | Notes |
+|-------|--------|-------|
+| `fastino/gliner2.5-small-v1` | 73.9M | Smallest |
+| `fastino/gliner2.5-base-v1` | 193.6M | **Default** |
+| `fastino/gliner2.5-multi-v1` | 287.4M | Multilingual |
+| `fastino/gliner2-base-v1` | 205M | Previous generation; loads via `SpanExtractor` |
+
+2.5 checkpoints are self-contained. The 2.0 checkpoint declares an external encoder and pulls a second repository at load time, so it is slower to start.
+
+## Configuration
+
+### Services
+
+| Service | Description |
+|---------|-------------|
+| `gliner` | FastAPI server (`python server.py`) |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE` | `/workspace` | Directory the server is synced to |
+| `GLINER_MODEL` | `fastino/gliner2.5-base-v1` | HuggingFace checkpoint to serve |
+| `GLINER_API_KEY` | *(unset)* | Bearer token. **If unset the API is unauthenticated** |
+| `GLINER_HOST` | `0.0.0.0` | Bind address |
+| `GLINER_PORT` | `8000` | Bind port |
+
+Set `HF_TOKEN` if HuggingFace rate-limits anonymous weight downloads.
+
+## API
+
+### `GET /health`
+
+```json
+{
+  "status": "running",
+  "model": "fastino/gliner2.5-base-v1",
+  "device": "cuda:0",
+  "gpu_available": true,
+  "gpu_name": "NVIDIA GeForce RTX 3090"
+}
+```
+
+### `POST /extract`
+
+Requires `Authorization: Bearer <GLINER_API_KEY>` when the key is set.
+
+```bash
+curl -X POST http://<IP>:<PORT>/extract \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GLINER_API_KEY" \
+  -d '{
+    "text": "Apple CEO Tim Cook announced iPhone 15 in Cupertino for $999.",
+    "labels": ["person", "company", "product", "location", "price"],
+    "threshold": 0.3
+  }'
+```
+
+```json
+{
+  "entities": {
+    "person": ["Tim Cook"],
+    "company": ["Apple"],
+    "product": ["iPhone 15"],
+    "location": ["Cupertino"],
+    "price": ["$999"]
+  },
+  "inference_time": 0.0167,
+  "device": "cuda:0"
+}
+```
+
+## Notes
+
+The DeBERTa-v3 encoder has no SDPA implementation in transformers, so the model runs with eager attention. This is expected and logged at startup as a `RuntimeWarning`; it is not an error.

--- a/derivatives/pytorch/derivatives/gliner/ROOT/LICENSES.md
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/LICENSES.md
@@ -1,0 +1,44 @@
+# Third-Party Licenses
+
+This image bundles the following vendor application(s). Each is the property of
+its respective authors and is distributed under the license shown below. Where
+the vendor's source or LICENSE file is shipped inside this image at a known
+location, the path is given. Otherwise, the upstream repository is referenced
+as the canonical source for the license text.
+
+## PyTorch
+
+- **License:** BSD-3-Clause
+- **Upstream:** https://github.com/pytorch/pytorch
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/torch-*.dist-info/LICENSE`
+
+## GLiNER2
+
+- **License:** Apache-2.0
+- **Upstream:** https://github.com/fastino-ai/GLiNER2
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/gliner2-*.dist-info/LICENSE`
+
+## Transformers
+
+- **License:** Apache-2.0
+- **Upstream:** https://github.com/huggingface/transformers
+- **License file in image:** Included in the pip-installed package under
+  `/venv/main/lib/python3.*/site-packages/transformers-*.dist-info/LICENSE`
+- **Note:** Installed as part of the `gliner2[local]` extra; it supplies the
+  DeBERTa-v3 encoder runtime every GLiNER2 checkpoint loads.
+
+## GLiNER2 model weights
+
+The server downloads checkpoints from the Hugging Face Hub at runtime
+(`GLINER_MODEL`, default `fastino/gliner2.5-base-v1`). Weights are **not** baked
+into this image and carry their own licenses, declared per-repository on the Hub.
+Check the license of any checkpoint you point `GLINER_MODEL` at before
+redistributing its outputs.
+
+## Server
+
+The FastAPI server at `ROOT/opt/workspace-internal/gliner/server.py` is part of
+this repository, not a vendored third-party application. Upstream ships no
+server to clone.

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/supervisor/conf.d/gliner.conf
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/supervisor/conf.d/gliner.conf
@@ -1,0 +1,17 @@
+[program:gliner]
+environment=PROC_NAME="%(program_name)s"
+command=/opt/supervisor-scripts/gliner.sh
+autostart=true
+autorestart=unexpected
+exitcodes=0
+startsecs=0
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
+stopwaitsecs=10
+# This is necessary for Vast logging to work alongside the Portal logs (Must output to /dev/stdout)
+stdout_logfile=/dev/stdout
+redirect_stderr=true
+stdout_events_enabled=true
+stdout_logfile_maxbytes=0
+stdout_logfile_backups=0

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_agents/gliner.md
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_agents/gliner.md
@@ -1,0 +1,69 @@
+## GLiNER2 (this image)
+
+The PyTorch image plus a preinstalled **GLiNER2** (upstream `fastino-ai/GLiNER2`) for
+zero-shot entity extraction. Everything in base.md and pytorch.md applies unchanged
+(torch is in `/venv/main`); this file covers what GLiNER adds. **One** service — get its
+externally callable URL + token from the manifest (base.md §5, §9):
+```
+curl -s http://localhost:11111/capabilities/services   # direct_url + state
+```
+
+### gliner — programmatic entity extraction
+
+A **FastAPI** server (`python server.py`), supervisor service **`gliner`**, internal
+`0.0.0.0:8000`. This is the only service in the image.
+
+**It is NOT OpenAI-compatible — do not call `/v1/chat/completions` or any `/v1/...`
+route.** The extraction endpoint is **`POST /extract`**. The full schema is the source
+of truth at **`/docs`** (the OpenAPI page on the same port).
+
+**The label contract is the thing to get right.** GLiNER is *zero-shot*: the entity types
+are not baked into the model and there is no default set. You pass them per request in
+**`labels`**, a required list of strings, and you get back only those types. Inventing a
+new type needs no retraining — just a different `labels` value.
+
+```
+curl -X POST http://<host>:8000/extract \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${GLINER_API_KEY}" \
+  -d '{"text": "Apple CEO Tim Cook announced iPhone 15 in Cupertino for $999.",
+       "labels": ["person", "company", "product", "location", "price"],
+       "threshold": 0.3}'
+```
+
+Response is `{"entities": {<label>: [<string>, ...]}, "inference_time": <float>,
+"device": "<device>"}`. **Every label you request comes back as a key**, and a label that
+matched nothing is an **empty list** rather than a missing key — so test
+`if not entities["price"]`, not `if "price" in entities`. An unknown or nonsensical label
+is not an error either; it simply returns `[]`. `threshold` (default `0.3`) trades recall
+for precision; lower it if short or unusual spans are being missed.
+
+### Auth
+
+`Authorization: Bearer $GLINER_API_KEY`, enforced on `/extract` only. **If
+`GLINER_API_KEY` is unset the API is completely unauthenticated** — the server prints a
+warning at startup and accepts every request. `/health` and `/` are never authenticated.
+
+### Models & provisioning
+
+Runs from `${WORKSPACE}/gliner` in `/venv/main`. The checkpoint is selected by
+**`GLINER_MODEL`** (default `fastino/gliner2.5-base-v1`); `AutoExtractor` dispatches on
+the checkpoint's architecture, so 2.5 checkpoints load as `BoundaryExtractor` and 2.0
+checkpoints as `SpanExtractor` — both work, and pinning `GLINER_MODEL` to a 2.0
+checkpoint is supported. A 2.0 checkpoint declares an external encoder and pulls a
+**second** repository at load time, so it starts noticeably slower than a 2.5 one.
+
+**Weights download on first startup**, so the first boot is slow — that is expected, not
+a hang. Set `HF_TOKEN` if the Hub rate-limits anonymous downloads. The service **waits
+for provisioning (`/.provisioning`) to finish before starting**, so during boot it may be
+intentionally down — check that flag before assuming a fault.
+
+### Two things that look like faults and are not
+
+- At startup the DeBERTa-v3 encoder logs a `RuntimeWarning` that it rejected
+  `attn_implementation='sdpa'` and fell back to `'eager'`. transformers has no SDPA path
+  for this architecture. Expected; not an error.
+- If the model **failed** to load, `GET /health` does not report unhealthy — it raises a
+  500 from a response-validation error, because `device` is still unset. A 500 from
+  `/health` therefore means "model never loaded", not "health check is broken". The
+  startup log has the real cause.

--- a/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_capabilities.d/50-gliner.yaml
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/etc/vast_capabilities.d/50-gliner.yaml
@@ -1,0 +1,5 @@
+# GLiNER derivative — image identity (overrides the base image block).
+image:
+  name: GLiNER2
+  readme: https://github.com/vast-ai/base-image/tree/main/derivatives/pytorch/derivatives/gliner
+  preinstalled: PyTorch + GLiNER2 (zero-shot entity extraction)

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/instance-tools/tests/gliner.d/10-gliner-serving.sh
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/instance-tools/tests/gliner.d/10-gliner-serving.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Test: the GLiNER API serves real inference on the GPU.
+#
+# A green `docker build` cannot see any of the properties below: the model is
+# downloaded at first boot, not baked, so "the image built" and "the API answers"
+# are separated by a HuggingFace fetch that can stall or 401.
+# TEST_TIMEOUT=900
+source "$(dirname "$0")/../lib.sh"
+
+GLINER_INTERNAL_PORT=18000        # gliner.sh binds this on localhost
+GLINER_LOG="/var/log/portal/gliner.log"
+API_KEY="${GLINER_API_KEY:-gliner-qa-key}"
+
+# ── The service ──────────────────────────────────────────────────────
+# Readiness through the supervisord SOCKET, never `pgrep`: presence is satisfied the
+# instant supervisord forks, and the gap to usable is a model download here (L069).
+assert_service_running gliner
+
+# ── The listener ─────────────────────────────────────────────────────
+# First boot downloads ~774MB of weights before uvicorn binds, so this is slow.
+if ! wait_for_port "${GLINER_INTERNAL_PORT}" "${GLINER_READY_TIMEOUT:-600}"; then
+    [[ -f "${GLINER_LOG}" ]] && tail -40 "${GLINER_LOG}"
+    test_fail "GLiNER is not listening on ${GLINER_INTERNAL_PORT} after ${GLINER_READY_TIMEOUT:-600}s"
+fi
+echo "  gliner: port ${GLINER_INTERNAL_PORT} listening"
+
+# ── It reports a GPU ─────────────────────────────────────────────────
+# The whole point of the image. The server falls back to CPU when torch cannot see a
+# device and still serves correctly, so a CPU regression is invisible to any check that
+# only asks whether the API answers -- this is the ADR 0016 failure class.
+_health=$(curl -s --max-time "${HTTP_CHECK_MAX_TIME:-20}" \
+          "http://127.0.0.1:${GLINER_INTERNAL_PORT}/health" 2>/dev/null)
+[[ -n "${_health}" ]] || test_fail "GLiNER /health returned nothing (connection failed)"
+
+echo "${_health}" | grep -q '"gpu_available":true' || {
+    echo "  health: ${_health}"
+    test_fail "GLiNER reports gpu_available=false -- the model fell back to CPU"
+}
+echo "  gliner: /health reports GPU ($(echo "${_health}" | sed -n 's/.*"gpu_name":"\([^"]*\)".*/\1/p'))"
+
+# ── It extracts ──────────────────────────────────────────────────────
+# Assert on a returned entity, not on HTTP 200. The endpoint returns 200 with an empty
+# entity map when the model loads but scores nothing, which is a real regression class
+# and indistinguishable from success at the status-code level.
+_out=$(curl -s --max-time "${HTTP_CHECK_MAX_TIME:-60}" \
+       -X POST "http://127.0.0.1:${GLINER_INTERNAL_PORT}/extract" \
+       -H "Content-Type: application/json" \
+       -H "Authorization: Bearer ${API_KEY}" \
+       -d '{"text":"Apple CEO Tim Cook announced iPhone 15 in Cupertino for $999.","labels":["person","company","product","location","price"],"threshold":0.3}' 2>/dev/null)
+
+echo "${_out}" | grep -q '"Tim Cook"' || {
+    echo "  response: ${_out}"
+    test_fail "GLiNER /extract did not return the expected person entity"
+}
+echo "  gliner: /extract returned the expected entities"
+
+# ── Auth is enforced ─────────────────────────────────────────────────
+# The server leaves the API OPEN when GLINER_API_KEY is unset. A regression that
+# dropped the key would publish an unauthenticated extraction endpoint, so assert the
+# rejection rather than trusting the template to have set it.
+_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "${HTTP_CHECK_MAX_TIME:-20}" \
+        -X POST "http://127.0.0.1:${GLINER_INTERNAL_PORT}/extract" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer definitely-not-the-key" \
+        -d '{"text":"x","labels":["person"]}' 2>/dev/null)
+_code="${_code:-000}"
+case "${_code}" in
+    401) echo "  gliner: rejects a wrong bearer token (401)" ;;
+    000) test_fail "GLiNER did not answer the auth probe (connection failed)" ;;
+    *)   fail_later "gliner-auth" "GLiNER answered a WRONG bearer token with ${_code}, not 401 -- the endpoint is unauthenticated" ;;
+esac
+
+# ── The bind is loopback ─────────────────────────────────────────────
+# This endpoint has a bearer token but must still sit behind Caddy like everything
+# else. `ss` reports the LISTENER, which is the only thing that matters -- a template
+# port entry is not what exposes it.
+# listener_is_public lives in BASE's lib.sh and is inherited from the pinned pytorch
+# base, not this repo. Without this guard a missing function returns 127, `if` takes
+# the ELSE branch, and the check PASSES having tested nothing.
+declare -F listener_is_public >/dev/null 2>&1 || \
+    test_fail "this image's lib.sh predates listener_is_public -- the bind check cannot run; rebuild base + pytorch and bump this image's PYTORCH_BASE pin"
+
+if listener_is_public "${GLINER_INTERNAL_PORT}"; then
+    listener_local_addr "${GLINER_INTERNAL_PORT}"
+    fail_later "gliner-bind" "GLiNER is bound to a PUBLIC interface on ${GLINER_INTERNAL_PORT}, not loopback"
+else
+    echo "  gliner: bound to loopback ($(listener_local_addr "${GLINER_INTERNAL_PORT}"))"
+fi
+
+test_pass

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/supervisor-scripts/gliner.sh
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/supervisor-scripts/gliner.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+utils=/opt/supervisor-scripts/utils
+. "${utils}/logging.sh"
+. "${utils}/cleanup_generic.sh"
+. "${utils}/environment.sh"
+. "${utils}/exit_portal.sh" "GLiNER API"
+
+echo "Starting GLiNER API"
+
+. /venv/main/bin/activate
+
+# Wait for provisioning to complete
+while [ -f "/.provisioning" ]; do
+    echo "$PROC_NAME startup paused until instance provisioning has completed (/.provisioning present)"
+    sleep 10
+done
+
+cd "${WORKSPACE}/gliner"
+
+pty python server.py 2>&1

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
@@ -1,0 +1,153 @@
+"""
+GLiNER2 FastAPI Server - entity extraction API with Bearer token authentication.
+
+Environment Variables:
+    GLINER_API_KEY: API key for authentication (unsecured if unset)
+    GLINER_MODEL:   Model to use (default: fastino/gliner2.5-base-v1)
+    GLINER_HOST:    Bind address (default: 0.0.0.0)
+    GLINER_PORT:    Bind port (default: 8000)
+"""
+
+import os
+import time
+from typing import Dict, List, Optional
+
+import torch
+import uvicorn
+from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from gliner2 import AutoExtractor
+from pydantic import BaseModel
+
+# Configuration
+MODEL_NAME = os.environ.get("GLINER_MODEL", "fastino/gliner2.5-base-v1")
+API_KEY = os.environ.get("GLINER_API_KEY")
+HOST = os.environ.get("GLINER_HOST", "0.0.0.0")
+PORT = int(os.environ.get("GLINER_PORT", "8000"))
+
+app = FastAPI(
+    title="GLiNER2 API",
+    description="GPU-accelerated zero-shot entity extraction with GLiNER2",
+    version="2.5.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+security = HTTPBearer()
+
+if not API_KEY:
+    print("WARNING: GLINER_API_KEY not set. API will be unsecured!")
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Security(security)):
+    """Verify the Bearer token"""
+    if not API_KEY:
+        return True
+    if credentials.credentials != API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return True
+
+
+# Global model state
+model = None
+device = None
+
+
+class ExtractRequest(BaseModel):
+    text: str
+    labels: List[str]
+    threshold: Optional[float] = 0.3
+
+
+class ExtractResponse(BaseModel):
+    entities: Dict[str, List[str]]
+    inference_time: float
+    device: str
+
+
+class HealthResponse(BaseModel):
+    status: str
+    model: str
+    device: str
+    gpu_available: bool
+    gpu_name: Optional[str] = None
+
+
+@app.on_event("startup")
+async def load_model():
+    """Load the GLiNER2 model on startup.
+
+    AutoExtractor dispatches on the checkpoint's architecture: a 2.5 checkpoint
+    yields a BoundaryExtractor, a 2.0 checkpoint a SpanExtractor. Both are
+    nn.Module, so .to()/.eval() apply to either, and users pinning GLINER_MODEL
+    to a 2.0 checkpoint keep working.
+    """
+    global model, device
+
+    print(f"Loading GLiNER2 model: {MODEL_NAME}")
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+
+    model = AutoExtractor.from_pretrained(MODEL_NAME)
+    model = model.to(device)
+    model.eval()
+
+    print(f"Model loaded on {device} ({type(model).__name__})")
+    if torch.cuda.is_available():
+        gpu_name = torch.cuda.get_device_name(0)
+        gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1e9
+        print(f"GPU: {gpu_name} ({gpu_memory:.1f} GB)")
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health():
+    """Health check endpoint"""
+    gpu_name = torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+    return HealthResponse(
+        status="running",
+        model=MODEL_NAME,
+        device=device,
+        gpu_available=torch.cuda.is_available(),
+        gpu_name=gpu_name,
+    )
+
+
+@app.get("/", response_model=HealthResponse)
+async def root():
+    """Alias for the health check"""
+    return await health()
+
+
+@app.post("/extract", response_model=ExtractResponse)
+async def extract_entities(
+    request: ExtractRequest,
+    authorized: bool = Depends(verify_token),
+):
+    """Extract entities from text. Requires Bearer token authentication."""
+    try:
+        start_time = time.time()
+        result = model.extract_entities(
+            request.text,
+            request.labels,
+            threshold=request.threshold,
+        )
+        inference_time = time.time() - start_time
+
+        return ExtractResponse(
+            entities=result.get("entities", {}),
+            inference_time=inference_time,
+            device=device,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT, log_level="info")

--- a/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
+++ b/derivatives/pytorch/derivatives/gliner/ROOT/opt/workspace-internal/gliner/server.py
@@ -4,8 +4,8 @@ GLiNER2 FastAPI Server - entity extraction API with Bearer token authentication.
 Environment Variables:
     GLINER_API_KEY: API key for authentication (unsecured if unset)
     GLINER_MODEL:   Model to use (default: fastino/gliner2.5-base-v1)
-    GLINER_HOST:    Bind address (default: 0.0.0.0)
-    GLINER_PORT:    Bind port (default: 8000)
+    GLINER_HOST:    Bind address (default: 127.0.0.1 -- Caddy fronts it)
+    GLINER_PORT:    Bind port (default: 18000 -- portal maps 8000 to it)
 """
 
 import os
@@ -23,8 +23,8 @@ from pydantic import BaseModel
 # Configuration
 MODEL_NAME = os.environ.get("GLINER_MODEL", "fastino/gliner2.5-base-v1")
 API_KEY = os.environ.get("GLINER_API_KEY")
-HOST = os.environ.get("GLINER_HOST", "0.0.0.0")
-PORT = int(os.environ.get("GLINER_PORT", "8000"))
+HOST = os.environ.get("GLINER_HOST", "127.0.0.1")
+PORT = int(os.environ.get("GLINER_PORT", "18000"))
 
 app = FastAPI(
     title="GLiNER2 API",

--- a/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/README.md
+++ b/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/README.md
@@ -37,13 +37,23 @@ curl -s -X POST localhost:18000/extract \
 Every requested label comes back as a key; a label that matched nothing is an empty
 list, not a missing key. `threshold` (default `0.3`) trades recall for precision.
 
-## Coverage gap
+## What the gate asserts
 
-`INSTANCE_TEST_REQUIRE_PASS` names only the GPU trio, because this image ships no
-`gliner.d/` instance-test suite. The gate therefore asserts that the rented box has a
-working GPU and nothing about GLiNER itself. L072 does not fire — it is scoped to
-images that ship an own suite — but the gap is real, and writing that suite is the
-outstanding work before this template is worth wiring into `qa-gate.yml`.
+`INSTANCE_TEST_REQUIRE_PASS` names the GPU trio plus this image's own suite,
+`gliner.d/10-gliner-serving`. The trio alone would certify only that the rented box
+has a working GPU and nothing about GLiNER itself — the L072 gap. The GLiNER suite
+closes it by asserting the things a green `docker build` cannot see:
+
+- the `gliner` supervisor service is running and port 18000 is listening
+- `/health` reports `"gpu_available":true` — the server answers correctly on CPU, so
+  a silent CPU fallback otherwise looks identical to success (ADR 0016)
+- `/extract` returns real entities rather than a 200 with an empty map, which is what
+  a model that never downloaded produces
+- a wrong bearer token gets a 401, so a regression that drops auth cannot promote green
+- the listener is on loopback, not public, so the API stays behind Caddy
+
+Naming them in `INSTANCE_TEST_REQUIRE_PASS` is load-bearing: the trio self-skips when
+nvidia-smi or libcuda never came up, and a skip reads as green (ADR 0019).
 
 ## Publishing
 

--- a/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/README.md
+++ b/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/README.md
@@ -1,0 +1,53 @@
+# GLiNER2 QA template — zero-shot extraction smoke
+
+A disposable, private template for exercising a freshly-built `vastai/gliner` image
+on real hardware. It is **not** a user-facing template.
+
+## What it launches
+
+One supervisor service, `gliner`, running `server.py` (FastAPI + uvicorn) against
+`GLINER_MODEL`. The service waits for `/.provisioning` to clear, then downloads the
+checkpoint on first start — so the first boot is slower than subsequent ones by the
+size of the model, and the API is not reachable until that finishes.
+
+## The bind is deliberate
+
+`server.py` defaults to `0.0.0.0:8000` with **optional** auth — `GLINER_API_KEY`
+unset means every request is accepted. Published as-is that is an unauthenticated
+extraction endpoint on the open internet. This template pins `GLINER_HOST=127.0.0.1`
+and `GLINER_PORT=18000` so the only public path is through Caddy on `8000`, gated by
+`OPEN_BUTTON_TOKEN`. Set `GLINER_API_KEY` at launch if you intend to reach it another
+way; it is intentionally not committed here.
+
+`PORTAL_CONFIG` is load-bearing, not decoration: `gliner.sh` sources
+`exit_portal.sh "GLiNER API"`, which greps `/etc/portal.yaml` and, on no match,
+writes a skip marker and exits 0 — which supervisord treats as intentional, so the
+service never starts and the portal shows it as "not configured" rather than failed.
+Renaming that portal entry silently disables the app.
+
+## Smoke test
+
+```bash
+curl -s -X POST localhost:18000/extract \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Tim Cook announced the iPhone 15 in Cupertino for $999.",
+       "labels":["person","company","product","location","price"]}'
+```
+
+Every requested label comes back as a key; a label that matched nothing is an empty
+list, not a missing key. `threshold` (default `0.3`) trades recall for precision.
+
+## Coverage gap
+
+`INSTANCE_TEST_REQUIRE_PASS` names only the GPU trio, because this image ships no
+`gliner.d/` instance-test suite. The gate therefore asserts that the rented box has a
+working GPU and nothing about GLiNER itself. L072 does not fire — it is scoped to
+images that ship an own suite — but the gap is real, and writing that suite is the
+outstanding work before this template is worth wiring into `qa-gate.yml`.
+
+## Publishing
+
+```bash
+python tools/template_manager/create.py \
+  derivatives/pytorch/derivatives/gliner/templates/ --api-key "$VAST_API_KEY"
+```

--- a/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
+++ b/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
@@ -1,0 +1,88 @@
+# GLiNER2 QA template — zero-shot extraction smoke.
+#
+# Modelled on llama-cpp-qa, which is the closest shape in the tree: one supervisor
+# service fronting one HTTP API, no provisioning payload, no serverless backend.
+#
+# NOT wired into a live-GPU gate. `_gating_template_dirs()` defines "gating" as
+# "some workflow hands this dir to qa-gate.yml as template_dir:", and no workflow
+# does — there is no build-gliner.yml at all. So L057/L059/L072 do not apply here.
+# INSTANCE_TEST_REQUIRE_PASS is still declared below, so that wiring a gate later is
+# a workflow edit rather than a silently-uncovered promotion.
+name: "GLiNER2 QA — zero-shot extraction smoke"
+image: vastai/gliner
+tag: latest                       # override with the tag actually under test
+private: true                     # disposable QA template, never public
+readme_visible: false
+onstart: entrypoint.sh
+runtype: jupyter                  # production launch mode, as siblings use
+jup_direct: true
+ssh_direct: true
+use_ssh: true
+use_jupyter_lab: false
+ports:
+  - "1111:1111"                   # Instance Portal
+  - "8080:8080"                   # Jupyter
+  - "8000:8000"                   # GLiNER API (Caddy front; server binds 18000)
+  # Deliberately NO "3000:3000". L073 requires the serverless worker port only for a
+  # gate that sets SERVERLESS=true, and this image bakes no pyworker BACKEND — there
+  # is no OpenAI-compatible engine here for the worker to proxy to. Mapping it would
+  # publish a port nothing binds.
+env:
+  OPEN_BUTTON_PORT: "1111"
+  OPEN_BUTTON_TOKEN: "1"
+  JUPYTER_DIR: "/"
+  DATA_DIRECTORY: "/workspace/"
+  # LOAD-BEARING, in the same way llama.cpp's is. gliner.sh sources
+  #   . "${utils}/exit_portal.sh" "GLiNER API"
+  # which greps /etc/portal.yaml for that term and, on no match, writes a skip marker,
+  # sleeps 6 and exits 0 — and under `autorestart=unexpected` + `exitcodes=0`
+  # supervisord treats that as intentional, so the service is gone for the life of the
+  # instance and the portal renders it as "not configured" rather than failed. The
+  # entry name must therefore contain "GLiNER API" (the grep is case-insensitive).
+  #
+  # Path is /docs, not /: server.py mounts FastAPI's Swagger UI there, so the portal
+  # button lands on a page that actually renders. GET / returns a JSON health body.
+  PORTAL_CONFIG: "localhost:1111:11111:/:Instance Portal|localhost:8000:18000:/docs:GLiNER API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
+  # Pin the bind explicitly rather than inheriting server.py's defaults, which are
+  # HOST=0.0.0.0 and PORT=8000 (`os.environ.get` in server.py). Both defaults are
+  # wrong for a published instance: 0.0.0.0:8000 would bind the API PUBLICLY, in
+  # front of Caddy instead of behind it, and GLINER_API_KEY is optional — an unset
+  # key disables auth entirely (`API_KEY = os.environ.get("GLINER_API_KEY")`). The
+  # combination is an unauthenticated extraction endpoint on the open internet.
+  # Loopback + Caddy is what makes OPEN_BUTTON_TOKEN the actual front door.
+  GLINER_HOST: "127.0.0.1"
+  GLINER_PORT: "18000"
+  # The 2.5 checkpoint this image was validated against. AutoExtractor dispatches on
+  # the checkpoint's config: 2.5 -> BoundaryExtractor, 2.0 -> SpanExtractor.
+  GLINER_MODEL: "fastino/gliner2.5-base-v1"
+  # Deliberately NOT set here: GLINER_API_KEY. A committed key is a published key,
+  # and this file is what a production template gets copied from. The loopback bind
+  # above means the only public path is through Caddy; set a real key at launch if
+  # the API is to be reached any other way.
+  #
+  # Only the GPU trio, which is all this image can honestly require: it ships no
+  # gliner.d/ suite, so there is no app-level assertion to name. That is exactly the
+  # hole L072 describes — a gate certifying that the rented box has a working GPU
+  # while asserting nothing about the app the image exists to ship — and L072 does
+  # not fire because it is scoped to images that DO ship an own suite. Writing a
+  # gliner.d/ suite is the outstanding work; this comment is the marker for it.
+  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries"
+extra_filters:
+  compute_cap:
+    gte: 750                      # sm_75, matching llama-cpp — deberta-v3 needs nothing newer
+  cuda_max_good:
+    gte: 12.9                     # matches the cuda-12.9 base this image is built on
+  # Generous relative to the measured cost: a gliner2.5-base forward pass measured
+  # 1.184 GB allocated on this box. The floor is headroom for the CUDA runtime and
+  # the encoder rather than the weights, and keeps the offer pool wide.
+  gpu_ram:
+    gte: 8192
+  reliability2:
+    gte: 0.95
+  inet_down:
+    gte: 500                      # Mbps — bounds the image pull inside the launch window
+  direct_port_count:
+    gte: 64                       # see templates/base-qa for the measurement
+  disk_space:
+    gte: 24                       # L058: must be >= recommended_disk_space or the rent fails late
+recommended_disk_space: 24.0

--- a/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
+++ b/derivatives/pytorch/derivatives/gliner/templates/gliner-qa/template.yml
@@ -1,16 +1,13 @@
-# GLiNER2 QA template — zero-shot extraction smoke.
+# GLiNER2 QA template — zero-shot extraction smoke (ADR 0005 live-GPU QA gate).
 #
 # Modelled on llama-cpp-qa, which is the closest shape in the tree: one supervisor
 # service fronting one HTTP API, no provisioning payload, no serverless backend.
 #
-# NOT wired into a live-GPU gate. `_gating_template_dirs()` defines "gating" as
-# "some workflow hands this dir to qa-gate.yml as template_dir:", and no workflow
-# does — there is no build-gliner.yml at all. So L057/L059/L072 do not apply here.
-# INSTANCE_TEST_REQUIRE_PASS is still declared below, so that wiring a gate later is
-# a workflow edit rather than a silently-uncovered promotion.
+# Mirrors the production launch path — runtype jupyter, Instance Portal, the API
+# fronted on 8000 — because the point is to exercise what a customer gets.
 name: "GLiNER2 QA — zero-shot extraction smoke"
 image: vastai/gliner
-tag: latest                       # override with the tag actually under test
+tag: latest                       # CI overrides with the tag actually under test
 private: true                     # disposable QA template, never public
 readme_visible: false
 onstart: entrypoint.sh
@@ -43,30 +40,27 @@ env:
   # Path is /docs, not /: server.py mounts FastAPI's Swagger UI there, so the portal
   # button lands on a page that actually renders. GET / returns a JSON health body.
   PORTAL_CONFIG: "localhost:1111:11111:/:Instance Portal|localhost:8000:18000:/docs:GLiNER API|localhost:8080:18080:/:Jupyter|localhost:8080:8080:/terminals/1:Jupyter Terminal"
-  # Pin the bind explicitly rather than inheriting server.py's defaults, which are
-  # HOST=0.0.0.0 and PORT=8000 (`os.environ.get` in server.py). Both defaults are
-  # wrong for a published instance: 0.0.0.0:8000 would bind the API PUBLICLY, in
-  # front of Caddy instead of behind it, and GLINER_API_KEY is optional — an unset
-  # key disables auth entirely (`API_KEY = os.environ.get("GLINER_API_KEY")`). The
-  # combination is an unauthenticated extraction endpoint on the open internet.
-  # Loopback + Caddy is what makes OPEN_BUTTON_TOKEN the actual front door.
+  # Pin the bind explicitly rather than inheriting server.py's defaults. Loopback +
+  # Caddy is what makes OPEN_BUTTON_TOKEN the actual front door; a 0.0.0.0 bind would
+  # publish the extraction API in front of the proxy instead of behind it.
   GLINER_HOST: "127.0.0.1"
   GLINER_PORT: "18000"
   # The 2.5 checkpoint this image was validated against. AutoExtractor dispatches on
   # the checkpoint's config: 2.5 -> BoundaryExtractor, 2.0 -> SpanExtractor.
   GLINER_MODEL: "fastino/gliner2.5-base-v1"
-  # Deliberately NOT set here: GLINER_API_KEY. A committed key is a published key,
-  # and this file is what a production template gets copied from. The loopback bind
-  # above means the only public path is through Caddy; set a real key at launch if
-  # the API is to be reached any other way.
-  #
-  # Only the GPU trio, which is all this image can honestly require: it ships no
-  # gliner.d/ suite, so there is no app-level assertion to name. That is exactly the
-  # hole L072 describes — a gate certifying that the rented box has a working GPU
-  # while asserting nothing about the app the image exists to ship — and L072 does
-  # not fire because it is scoped to images that DO ship an own suite. Writing a
-  # gliner.d/ suite is the outstanding work; this comment is the marker for it.
-  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries"
+  # A throwaway key, set ON PURPOSE and only because this template is `private: true`
+  # and disposable. server.py leaves the API unauthenticated when GLINER_API_KEY is
+  # unset, so a gate that omitted it would never exercise the auth path and a
+  # regression that dropped the 401 would promote green. DO NOT copy this line into a
+  # public template: a committed key is a published key.
+  GLINER_API_KEY: "gliner-qa-key"
+  # Required-pass gate (ADR 0019). The GPU trio self-skips when nvidia-smi or libcuda
+  # never came up, so without naming them a GPU-less draw would report the suite green
+  # and promote an image whose entire purpose is GPU inference. gliner.d/10-gliner-serving
+  # is this image's own suite — naming it is what closes the L072 hole, where a gate
+  # certifies the rented box has a working GPU while asserting nothing about the app.
+  INSTANCE_TEST_REQUIRE_PASS: "base/60-gpu-cuda base/61-cuda-compute base/62-gpu-libraries gliner.d/10-gliner-serving"
+# QA gate floors (ADR 0005): smallest viable box that still exercises the real path.
 extra_filters:
   compute_cap:
     gte: 750                      # sm_75, matching llama-cpp — deberta-v3 needs nothing newer
@@ -78,11 +72,11 @@ extra_filters:
   gpu_ram:
     gte: 8192
   reliability2:
-    gte: 0.95
+    gte: 0.95                     # excludes the flaky tail; see templates/base-qa
   inet_down:
     gte: 500                      # Mbps — bounds the image pull inside the launch window
   direct_port_count:
     gte: 64                       # see templates/base-qa for the measurement
   disk_space:
-    gte: 24                       # L058: must be >= recommended_disk_space or the rent fails late
-recommended_disk_space: 24.0
+    gte: 40                       # L058: must be >= recommended_disk_space or the rent fails late
+recommended_disk_space: 40.0      # pytorch base + gliner2 deps + weights downloaded at boot


### PR DESCRIPTION
Adds a GLiNER2 derivative image — zero-shot entity extraction over a small FastAPI
server, built on `vastai/pytorch`.

Unlike its siblings there is no upstream repository to clone: GLiNER2 is a pip
library plus HuggingFace weights, and Fastino publishes neither a server nor an
image. The server is therefore vendored in `ROOT/opt/workspace-internal/gliner/`.
Everything else follows the derivative pattern in CONTRIBUTING.md.

## What's here

| | |
|---|---|
| `Dockerfile` | `gliner2[local]==${GLINER2_VERSION}` into `/venv/main`, torch-drift assertion, `env-hash` |
| `ROOT/opt/workspace-internal/gliner/server.py` | FastAPI: `/health`, `/extract`, bearer auth, loopback bind |
| `ROOT/opt/supervisor-scripts/gliner.sh` + `conf.d/gliner.conf` | supervisor service, portal-aware |
| `ROOT/opt/instance-tools/tests/gliner.d/10-gliner-serving.sh` | live-GPU assertions |
| `templates/gliner-qa/` | QA gate template |
| `.github/workflows/build-gliner.yml` | PyPI watcher → amd64 + arm64 → QA gate → manifest merge |

## Verified

Built and booted on an RTX 4090. `/health` reports `gpu_available: true`; `/extract`
returns the expected entities from the `fastino/gliner2.5-base-v1` checkpoint.

## Three things worth a reviewer's eye

**1. `[local]` extra is required, not cosmetic.** gliner2 2.0.0 moved torch,
transformers, safetensors and peft out of the default install. Plain `gliner2`
installs a library that can load no model at all. The base image stays the source of
truth for torch — the Dockerfile asserts the torch/torchvision/torchaudio/torchcodec
set is byte-identical before and after the install and fails the build on drift.

**2. The install downgrades `huggingface-hub` 1.30.0 → 0.36.2.** transformers 4.57.6
caps it below 1.0. Upstream's constraint, not a choice, but the torch assertion does
not cover it, so it is documented in the Dockerfile rather than left to be
rediscovered.

**3. A green `docker build` cannot see this image's two real failure modes.** Weights
download at first boot rather than being baked, and the server answers correctly on
CPU when torch sees no device — so "the model never downloaded" and "it is silently
on CPU" both look like a successful build (ADR 0016). Hence the QA gate: the instance
test asserts `gpu_available` is true, that `/extract` returns real entities rather
than a 200 with an empty map, that a wrong bearer token gets a 401, and that the
listener is on loopback rather than public.
